### PR TITLE
Adding WriteStart and WriteStop to LoggerExtensions.

### DIFF
--- a/Logging.sln
+++ b/Logging.sln
@@ -1,9 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.21628.1
+VisualStudioVersion = 14.0.21730.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.Logging", "src\Microsoft.Framework.Logging\Microsoft.Framework.Logging.kproj", "{19D1B6C5-8A62-4387-8816-C54874D1DF5F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{09920C51-6220-4D8D-94DC-E70C13446187}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.Logging.Test", "test\Microsoft.Framework.Logging.Test\Microsoft.Framework.Logging.Test.kproj", "{96B1D6A8-7E40-43C7-813F-898DC8192DDE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,18 +19,31 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Debug|Mixed Platforms.Build.0 = Debug|x86
-		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Debug|x86.ActiveCfg = Debug|x86
-		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Debug|x86.Build.0 = Debug|x86
-		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Release|Any CPU.ActiveCfg = Release|x86
-		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Release|Mixed Platforms.ActiveCfg = Release|x86
-		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Release|Mixed Platforms.Build.0 = Release|x86
-		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Release|x86.ActiveCfg = Release|x86
-		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Release|x86.Build.0 = Release|x86
+		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{19D1B6C5-8A62-4387-8816-C54874D1DF5F}.Release|x86.ActiveCfg = Release|Any CPU
+		{96B1D6A8-7E40-43C7-813F-898DC8192DDE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{96B1D6A8-7E40-43C7-813F-898DC8192DDE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{96B1D6A8-7E40-43C7-813F-898DC8192DDE}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{96B1D6A8-7E40-43C7-813F-898DC8192DDE}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{96B1D6A8-7E40-43C7-813F-898DC8192DDE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{96B1D6A8-7E40-43C7-813F-898DC8192DDE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{96B1D6A8-7E40-43C7-813F-898DC8192DDE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{96B1D6A8-7E40-43C7-813F-898DC8192DDE}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{96B1D6A8-7E40-43C7-813F-898DC8192DDE}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{96B1D6A8-7E40-43C7-813F-898DC8192DDE}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{96B1D6A8-7E40-43C7-813F-898DC8192DDE} = {09920C51-6220-4D8D-94DC-E70C13446187}
 	EndGlobalSection
 EndGlobal

--- a/global.json
+++ b/global.json
@@ -1,0 +1,3 @@
+{
+    "sources": ["src", "test"]
+}

--- a/src/Microsoft.Framework.Logging/LoggerExtensions.cs
+++ b/src/Microsoft.Framework.Logging/LoggerExtensions.cs
@@ -32,6 +32,44 @@ namespace Microsoft.Framework.Logging
         }
 
         /// <summary>
+        /// Writes a begin log message
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="eventType">The event type.</param>
+        /// <param name="message">The message to be written.</param>
+        /// <returns>
+        /// Returns an IDisposable that calls <see cref="WriteEnd(ILogger, TraceType, string)"/>.
+        /// </returns>
+        public static IDisposable WriteStart(this ILogger logger, TraceType eventType, string message)
+        {
+            if (logger == null)
+            {
+                throw new ArgumentNullException("logger"); 
+            }
+
+            logger.WriteCore(eventType | TraceType.Start, 0, message, null, TheMessage);
+
+            return new LogicalOperation(logger, eventType, message);
+        }
+
+        /// <summary>
+        /// Writes an end log message
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        /// <param name="eventType">The event type.</param>
+        /// <param name="message">The message to be written.</param>
+        /// <returns></returns>
+        public static void WriteStop(this ILogger logger, TraceType eventType, string message)
+        {
+            if (logger == null)
+            {
+                throw new ArgumentNullException("logger");
+            }
+
+            logger.WriteCore(eventType | TraceType.Stop, 0, message, null, TheMessage);
+        }
+
+        /// <summary>
         /// Writes a verbose log message.
         /// </summary>
         /// <param name="logger"></param>

--- a/src/Microsoft.Framework.Logging/LogicalOperation.cs
+++ b/src/Microsoft.Framework.Logging/LogicalOperation.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Framework.Logging
+{
+    public class LogicalOperation : IDisposable
+    {
+        private bool _disposedValue; // To detect redundant calls
+
+        public LogicalOperation(ILogger logger, TraceType eventType, string message)
+        {
+            Logger = logger;
+            EventType = eventType;
+            Message = message;
+        }
+
+        public ILogger Logger { get; private set; }
+
+        public TraceType EventType { get; private set; }
+
+        public string Message { get; private set; }
+
+        public void Dispose()
+        {
+            if (!_disposedValue)
+            {
+                Logger.WriteEnd(EventType, Message);
+                _disposedValue = true;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Framework.Logging/Microsoft.Framework.Logging.kproj
+++ b/src/Microsoft.Framework.Logging/Microsoft.Framework.Logging.kproj
@@ -25,6 +25,7 @@
     <Compile Include="ILogger.cs" />
     <Compile Include="ILoggerFactory.cs" />
     <Compile Include="LoggerExtensions.cs" />
+    <Compile Include="LogicalOperation.cs" />
     <Compile Include="TraceType.cs" />
   </ItemGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/src/Microsoft.Framework.Logging/TraceType.cs
+++ b/src/Microsoft.Framework.Logging/TraceType.cs
@@ -10,5 +10,7 @@ namespace Microsoft.Framework.Logging
         Warning = 4,
         Information = 8,
         Verbose = 16,
+        Start = 256,
+        Stop = 512,
     }
 }

--- a/test/Microsoft.Framework.Logging.Test/LoggerExtensionsTests.cs
+++ b/test/Microsoft.Framework.Logging.Test/LoggerExtensionsTests.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Framework.Logging.Test
+{
+    public class LoggerExtensionsTests
+    {
+        [Fact]
+        public void WriteStartDisposable_Calls_WriteStop()
+        {
+            // Arrange
+            var eventType = TraceType.Information;
+            var message = "test message";
+
+            var mockLogger = new Mock<ILogger>();
+
+            mockLogger
+                .Setup(m => m.WriteCore(
+                    eventType | TraceType.Start,
+                    0,
+                    message,
+                    null,
+                    It.IsAny<Func<object, Exception, string>>()))
+                .Returns(true)
+                .Verifiable();
+
+            mockLogger
+                .Setup(m => m.WriteCore(
+                    eventType | TraceType.Stop,
+                    0,
+                    message,
+                    null,
+                    It.IsAny<Func<object, Exception, string>>()))
+                .Returns(true)
+                .Verifiable();
+
+            var logger = mockLogger.Object;
+
+            // Act
+            var disposable = Assert.IsType<LogicalOperation>(logger.WriteStart(eventType, message));
+            disposable.Dispose();
+
+            // Assert
+            mockLogger.VerifyAll();
+        }
+    }
+}

--- a/test/Microsoft.Framework.Logging.Test/Microsoft.Framework.Logging.Test.kproj
+++ b/test/Microsoft.Framework.Logging.Test/Microsoft.Framework.Logging.Test.kproj
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>96b1d6a8-7e40-43c7-813f-898dc8192dde</ProjectGuid>
+    <OutputType>Web</OutputType>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(OutputType) == 'Console'">
+    <DebuggerFlavor>ConsoleDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(OutputType) == 'Web'">
+    <DebuggerFlavor>WebDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" Label="Configuration">
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DevelopmentServerPort>58658</DevelopmentServerPort>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="LoggerExtensionsTests.cs" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/Microsoft.Framework.Logging.Test/project.json
+++ b/test/Microsoft.Framework.Logging.Test/project.json
@@ -1,0 +1,16 @@
+﻿{
+  "compilationOptions": {
+    "warningsAsErrors": true
+  },
+  "dependencies": {
+    "Microsoft.Framework.Logging": "",
+    "Moq": "4.2.1312.1622",
+    "Xunit.KRunner": "1.0.0-*"
+  },
+  "commands": {
+    "test": "Xunit.KRunner"
+  },
+  "configurations": {
+    "net45": { }
+  }
+}


### PR DESCRIPTION
It gives the ability to write structured logs. Added start and stop to TraceType, WriteStart and WriteStop, and corresponding tests.
