### PR TITLE
changed the default verbosity from warning to information

### DIFF
--- a/src/Microsoft.Framework.Logging.Console/ConsoleLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Framework.Logging.Console/ConsoleLoggerFactoryExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Framework.Logging.Console
         /// </summary>
         public static ILoggerFactory AddConsole(this ILoggerFactory factory)
         {
-            factory.AddProvider(new ConsoleLoggerProvider((category, traceType) => traceType >= TraceType.Warning));
+            factory.AddProvider(new ConsoleLoggerProvider((category, traceType) => traceType >= TraceType.Information));
             return factory;
         }
 


### PR DESCRIPTION
@rustd changing the default to log Information and above, so no need to pass a custom filter in the template
