### PR TITLE
added net45 framework target for NLog implementation

### DIFF
--- a/src/Microsoft.Framework.Logging.NLog/project.json
+++ b/src/Microsoft.Framework.Logging.NLog/project.json
@@ -1,11 +1,16 @@
 {
     "dependencies": {
-        "Microsoft.Framework.Logging.Interfaces": { "version": "1.0.0-*", "type": "build" },
         "NLog": "3.1.0"
     },
-    "frameworks" : {
-        "aspnet50" : { 
+    "frameworks": {
+        "net45": { 
             "dependencies": {
+                "Microsoft.Framework.Logging.Interfaces": "1.0.0-*"
+            }
+        },
+        "aspnet50": {
+            "dependencies": {
+                "Microsoft.Framework.Logging.Interfaces": { "version": "1.0.0-*", "type": "build" }
             }
         }
     }


### PR DESCRIPTION
I believe that NLog implementation should target net45 instead of aspnet50. As it's a tiny change, I wanted to raise the issue with a pull request.
