### PR TITLE
Update `ILoggerStructure` to support `IReadOnlyDictionary` instead of `IEnumerable`

### DIFF
--- a/src/Microsoft.Framework.Logging.Interfaces/ILoggerStructure.cs
+++ b/src/Microsoft.Framework.Logging.Interfaces/ILoggerStructure.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Framework.Logging
 #endif
     public interface ILoggerStructure
     {
-        IEnumerable<KeyValuePair<string, object>> GetValues();
+        IReadOnlyDictionary<string, object> GetValues();
 
         /// <summary>
         /// Returns a human-readable string of the structured data


### PR DESCRIPTION
I've been reviewing a decent amount of the logging code and I'm really not getting why `ILoggerStructure` wants:
```
IEnumerable<KeyValuePair<string, object>> GetValues()

// vs.

IReadOnlyDictionary<string, object> GetValues()
```

Using `IEnumerable` is so painful and takes away any advantage of performing key look on the data it contains. For people who need to look up keys, they are probably going to be forced to trying to cast the result of `GetValues` as they will have seen that all the implementations are `Dictionary` anyway. Being forced to loop over the dataset and not having access to a simple list of keys, etc feels really limiting. \

Additionally, in reality, I don't think anyone is going to use anything other than a type that implements that implements `IReadOnlyDictionary` already... in fact I would make a bet that 99.999% of people will be returning a `Dictionary` and the other 0.001% probably should be using an existing data structure that dose already implement `IReadOnlyDictionary`. Can we be semi pragmatic on this one?

Note, I'm not expecting the PR to be pulled in as is, but didn't want to do more work before discussing it.