### PR TITLE
Added the ILogger<T> to enable resolution of named ILogger from DI

### DIFF
--- a/src/Microsoft.Framework.Logging.Interfaces/ILogger `T.cs
+++ b/src/Microsoft.Framework.Logging.Interfaces/ILogger `T.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Framework.Logging
+{
+    /// <summary>
+    /// A generic interface for logging where the category name is taken from the specified T.
+    /// </summary>
+#if ASPNET50 || ASPNETCORE50
+    [Runtime.AssemblyNeutral]
+#endif
+    public interface ILogger<T> : ILogger
+    {
+        
+    }
+}

--- a/src/Microsoft.Framework.Logging/Logger`T.cs
+++ b/src/Microsoft.Framework.Logging/Logger`T.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 
 namespace Microsoft.Framework.Logging
 {

--- a/src/Microsoft.Framework.Logging/Logger`T.cs
+++ b/src/Microsoft.Framework.Logging/Logger`T.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.Framework.Logging
+{
+	/// <summary>
+    /// Delegates to a new <see cref="ILogger"/> instance using the full name of the given type, created by the
+    /// provided <see cref="ILoggerFactory"/>.
+    /// </summary>
+    /// <typeparam name="T">The type.</typeparam>
+    public class Logger<T> : ILogger<T>
+    {
+        private readonly ILogger _logger;
+        
+        /// <summary>
+        /// Creates a new <see cref="Logger{T}"/>.
+        /// </summary>
+        /// <param name="factory">The factory.</param>
+        public Logger(ILoggerFactory factory)
+        {
+            _logger = factory.Create<T>();
+        }
+
+        IDisposable ILogger.BeginScope(object state)
+        {
+            return _logger.BeginScope(state);
+        }
+
+        bool ILogger.IsEnabled(LogLevel logLevel)
+        {
+            return _logger.IsEnabled(logLevel);
+        }
+
+        void ILogger.Write(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
+        {
+            _logger.Write(logLevel, eventId, state, exception, formatter);
+        }
+    }
+}


### PR DESCRIPTION
Enables resolving an `ILogger` with the name of a given type (`T`) directly from DI, without having to use `ILoggerFactory`.

Corresponding change in Hosting to add it as a default service is at https://github.com/aspnet/Hosting/pull/147