### PR TITLE
Feature structuredformatstring

### DIFF
--- a/samples/SampleApp/Program.cs
+++ b/samples/SampleApp/Program.cs
@@ -38,8 +38,8 @@ namespace SampleApp
                 .WriteTo.Sink(new RollingFileSink("file-{Date}.json", new JsonFormatter(), null, null))
                 .WriteTo.Sink(new FileSink("dump.txt", new RawFormatter(), null)));
 #endif
-            //factory.AddConsole();
-            //factory.AddConsole((category, logLevel) => logLevel >= LogLevel.Critical && category.Equals(typeof(Program).FullName));
+            factory.AddConsole();
+            factory.AddConsole((category, logLevel) => logLevel >= LogLevel.Critical && category.Equals(typeof(Program).FullName));
         }
 
         public void Main(string[] args)
@@ -77,8 +77,8 @@ namespace SampleApp
             _logger.WriteInformation("Stopping");
 
             _logger.WriteInformation(Environment.NewLine);
-            _logger.WriteInformation("{2,-10}{0,15}{1,15}{3,15}", "RESULT", "START TIME", "END TIME", "DURATION(ms)");
-            _logger.WriteInformation("{2,-10}{0,15}{1,15}{3,15}", "------", "----- ----", "--- ----", "------------");
+            _logger.WriteInformation("{Result,-10}{StartTime,15}{EndTime,15}{Duration,15}", "RESULT", "START TIME", "END TIME", "DURATION(ms)");
+            _logger.WriteInformation("{Result,-10}{StartTime,15}{EndTime,15}{Duration,15}", "------", "----- ----", "--- ----", "------------");
             _logger.WriteInformation("{Result,-10}{StartTime,15:mm:s tt}{EndTime,15:mm:s tt}{Duration,15}", "SUCCESS", startTime, endTime, (endTime - startTime).TotalMilliseconds);
         }
     }

--- a/samples/SampleApp/Program.cs
+++ b/samples/SampleApp/Program.cs
@@ -41,12 +41,13 @@ namespace SampleApp
             //factory.AddConsole();
             //factory.AddConsole((category, logLevel) => logLevel >= LogLevel.Critical && category.Equals(typeof(Program).FullName));
         }
-        
+
         public void Main(string[] args)
         {
             _logger.WriteInformation("Starting");
 
-            _logger.WriteInformation(1, "Started at '{StartTime}' and 0x{Hello:X} is hex of 42", DateTimeOffset.UtcNow, 42);
+            var startTime = DateTimeOffset.UtcNow;
+            _logger.WriteInformation(1, "Started at '{StartTime}' and 0x{Hello:X} is hex of 42", startTime, 42);
 
             try
             {
@@ -70,10 +71,15 @@ namespace SampleApp
                 Console.ReadLine();
             }
 
-            _logger.WriteInformation(2, "Stopping at '{StopTime}'", DateTimeOffset.UtcNow);
+            var endTime = DateTimeOffset.UtcNow;
+            _logger.WriteInformation(2, "Stopping at '{StopTime}'", endTime);
 
             _logger.WriteInformation("Stopping");
 
+            _logger.WriteInformation(Environment.NewLine);
+            _logger.WriteInformation("{2,-10}{0,15}{1,15}{3,15}", "RESULT", "START TIME", "END TIME", "DURATION(ms)");
+            _logger.WriteInformation("{2,-10}{0,15}{1,15}{3,15}", "------", "----- ----", "--- ----", "------------");
+            _logger.WriteInformation("{Result,-10}{StartTime,15:mm:s tt}{EndTime,15:mm:s tt}{Duration,15}", "SUCCESS", startTime, endTime, (endTime - startTime).TotalMilliseconds);
         }
     }
 }

--- a/samples/SampleApp/project.json
+++ b/samples/SampleApp/project.json
@@ -6,7 +6,8 @@
     "frameworks": {
         "aspnet50": {
             "dependencies": {
-                "Microsoft.Framework.Logging.NLog": "1.0.0-*"
+                "Microsoft.Framework.Logging.NLog": "1.0.0-*",
+                "Microsoft.Framework.Logging.Serilog": "1.0.0-*"
             }
         },
         "aspnetcore50": {

--- a/src/Microsoft.Framework.Logging.Console/ConsoleLogger.cs
+++ b/src/Microsoft.Framework.Logging.Console/ConsoleLogger.cs
@@ -32,7 +32,11 @@ namespace Microsoft.Framework.Logging.Console
             }
             var message = string.Empty;
             var structure = state as ILoggerStructure;
-            if (structure != null)
+            if (formatter != null)
+            {
+                message = formatter(state, exception);
+            }
+            else if (structure != null)
             {
                 var builder = new StringBuilder();
                 FormatLoggerStructure(
@@ -45,10 +49,6 @@ namespace Microsoft.Framework.Logging.Console
                 {
                     message += Environment.NewLine + exception;
                 }
-            }
-            else if (formatter != null)
-            {
-                message = formatter(state, exception);
             }
             else
             {

--- a/src/Microsoft.Framework.Logging.Serilog/SerilogLogger.cs
+++ b/src/Microsoft.Framework.Logging.Serilog/SerilogLogger.cs
@@ -59,6 +59,10 @@ namespace Microsoft.Framework.Logging.Serilog
             {
                 return;
             }
+            if (eventId != 0)
+            {
+                logger = logger.ForContext("EventId", eventId, false);
+            }
             var structure = state as ILoggerStructure;
             if (structure != null)
             {

--- a/src/Microsoft.Framework.Logging/LoggerExtensions.cs
+++ b/src/Microsoft.Framework.Logging/LoggerExtensions.cs
@@ -50,8 +50,7 @@ namespace Microsoft.Framework.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void WriteVerbose([NotNull] this ILogger logger, string format, params object[] args)
         {
-            logger.Write(LogLevel.Verbose, 0,
-                string.Format(CultureInfo.InvariantCulture, format, args), null, TheMessage);
+            logger.Write(LogLevel.Verbose, 0, new LoggerStructureFormat(format, args), null, _loggerStructureFormatter);
         }
 
         /// <summary>
@@ -63,8 +62,7 @@ namespace Microsoft.Framework.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void WriteVerbose([NotNull] this ILogger logger, int eventId, string format, params object[] args)
         {
-            logger.Write(LogLevel.Verbose, eventId,
-                string.Format(CultureInfo.InvariantCulture, format, args), null, TheMessage);
+            logger.Write(LogLevel.Verbose, eventId, new LoggerStructureFormat(format, args), null, _loggerStructureFormatter);
         }
 
         /// <summary>
@@ -128,8 +126,7 @@ namespace Microsoft.Framework.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void WriteInformation([NotNull] this ILogger logger, string format, params object[] args)
         {
-            logger.Write(LogLevel.Information, 0,
-                string.Format(CultureInfo.InvariantCulture, format, args), null, TheMessage);
+            logger.Write(LogLevel.Information, 0, new LoggerStructureFormat(format, args), null, _loggerStructureFormatter);
         }
 
         /// <summary>
@@ -205,8 +202,7 @@ namespace Microsoft.Framework.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void WriteWarning([NotNull] this ILogger logger, string format, params object[] args)
         {
-            logger.Write(LogLevel.Warning, 0,
-                string.Format(CultureInfo.InvariantCulture, format, args), null, TheMessage);
+            logger.Write(LogLevel.Warning, 0, new LoggerStructureFormat(format, args), null, _loggerStructureFormatter);
         }
 
         /// <summary>
@@ -218,8 +214,7 @@ namespace Microsoft.Framework.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void WriteWarning([NotNull] this ILogger logger, int eventId, string format, params object[] args)
         {
-            logger.Write(LogLevel.Warning, eventId,
-                string.Format(CultureInfo.InvariantCulture, format, args), null, TheMessage);
+            logger.Write(LogLevel.Warning, eventId, new LoggerStructureFormat(format, args), null, _loggerStructureFormatter);
         }
 
         /// <summary>
@@ -306,8 +301,7 @@ namespace Microsoft.Framework.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void WriteError([NotNull] this ILogger logger, string format, params object[] args)
         {
-            logger.Write(LogLevel.Error, 0,
-                string.Format(CultureInfo.InvariantCulture, format, args), null, TheMessage);
+            logger.Write(LogLevel.Error, 0, new LoggerStructureFormat(format, args), null, _loggerStructureFormatter);
         }
 
         /// <summary>
@@ -319,8 +313,7 @@ namespace Microsoft.Framework.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void WriteError([NotNull] this ILogger logger, int eventId, string format, params object[] args)
         {
-            logger.Write(LogLevel.Error, eventId,
-                string.Format(CultureInfo.InvariantCulture, format, args), null, TheMessage);
+            logger.Write(LogLevel.Error, eventId, new LoggerStructureFormat(format, args), null, _loggerStructureFormatter);
         }
 
         /// <summary>
@@ -407,8 +400,7 @@ namespace Microsoft.Framework.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void WriteCritical([NotNull] this ILogger logger, string format, params object[] args)
         {
-            logger.Write(LogLevel.Critical, 0,
-                string.Format(CultureInfo.InvariantCulture, format, args), null, TheMessage);
+            logger.Write(LogLevel.Critical, 0, new LoggerStructureFormat(format, args), null, _loggerStructureFormatter);
         }
 
         /// <summary>
@@ -420,8 +412,7 @@ namespace Microsoft.Framework.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void WriteCritical([NotNull] this ILogger logger, int eventId, string format, params object[] args)
         {
-            logger.Write(LogLevel.Critical, eventId,
-                string.Format(CultureInfo.InvariantCulture, format, args), null, TheMessage);
+            logger.Write(LogLevel.Critical, eventId, new LoggerStructureFormat(format, args), null, _loggerStructureFormatter);
         }
 
         /// <summary>
@@ -504,6 +495,7 @@ namespace Microsoft.Framework.Logging
             {
                 return state.Format();
             }
+
             return state.Format() + Environment.NewLine + exception;
         }
     }

--- a/src/Microsoft.Framework.Logging/LoggerExtensions.cs
+++ b/src/Microsoft.Framework.Logging/LoggerExtensions.cs
@@ -141,8 +141,7 @@ namespace Microsoft.Framework.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void WriteInformation([NotNull] this ILogger logger, int eventId, string format, params object[] args)
         {
-            logger.Write(LogLevel.Information, eventId,
-                string.Format(CultureInfo.InvariantCulture, format, args), null, TheMessage);
+            logger.Write(LogLevel.Information, eventId, new LoggerStructureFormat(format, args), null, _loggerStructureFormatter);
         }
 
         /// <summary>
@@ -501,6 +500,10 @@ namespace Microsoft.Framework.Logging
 
         private static string LoggerStructureFormatter(ILoggerStructure state, Exception exception)
         {
+            if (exception == null)
+            {
+                return state.Format();
+            }
             return state.Format() + Environment.NewLine + exception;
         }
     }

--- a/src/Microsoft.Framework.Logging/LoggerStructureFormat.cs
+++ b/src/Microsoft.Framework.Logging/LoggerStructureFormat.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
@@ -7,23 +10,17 @@ namespace Microsoft.Framework.Logging
 {
     public class LoggerStructureFormat : ILoggerStructure
     {
-        static Dictionary<string, Formatter> _formatters = new Dictionary<string, Formatter>();
-        static object _formattersLock = new Object();
+        private static ConcurrentDictionary<string, Formatter> _formatters = new ConcurrentDictionary<string, Formatter>();
         private readonly Formatter _formatter;
         private readonly object[] _values;
 
         public LoggerStructureFormat(string format, params object[] values)
         {
-            lock (_formattersLock)
+            if (!_formatters.TryGetValue(format, out _formatter))
             {
-                // TODO: ConcurrentDictionary not available in portable profile?
-                // _formatter = _formatters.GetOrAdd(format, ParseFormatter);
-                if (!_formatters.TryGetValue(format, out _formatter))
-                {
-                    _formatter = ParseFormatter(format);
-                    _formatters[format] = _formatter;
-                }
+                _formatter = _formatters.GetOrAdd(format, ParseFormatter(format));
             }
+
             _values = values;
         }
 

--- a/src/Microsoft.Framework.Logging/LoggerStructureFormat.cs
+++ b/src/Microsoft.Framework.Logging/LoggerStructureFormat.cs
@@ -8,6 +8,10 @@ using System.Text;
 
 namespace Microsoft.Framework.Logging
 {
+    /// <summary>
+    /// LoggerStructure to enable formatting options supported by <see cref="string.Format"/>. 
+    /// This also enables using {NamedformatItem} in the format string.
+    /// </summary>
     public class LoggerStructureFormat : ILoggerStructure
     {
         private static ConcurrentDictionary<string, Formatter> _formatters = new ConcurrentDictionary<string, Formatter>();

--- a/src/Microsoft.Framework.Logging/LoggerStructureFormat.cs
+++ b/src/Microsoft.Framework.Logging/LoggerStructureFormat.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Microsoft.Framework.Logging
+{
+    public class LoggerStructureFormat : ILoggerStructure
+    {
+        static Dictionary<string, Formatter> _formatters = new Dictionary<string, Formatter>();
+        static object _formattersLock = new Object();
+        private readonly Formatter _formatter;
+        private readonly object[] _values;
+
+        public LoggerStructureFormat(string format, params object[] values)
+        {
+            lock (_formattersLock)
+            {
+                // TODO: ConcurrentDictionary not available in portable profile?
+                // _formatter = _formatters.GetOrAdd(format, ParseFormatter);
+                if (!_formatters.TryGetValue(format, out _formatter))
+                {
+                    _formatter = ParseFormatter(format);
+                    _formatters[format] = _formatter;
+                }
+            }
+            _values = values;
+        }
+
+        public string Message { get { return null; } }
+
+        public string Format()
+        {
+            return _formatter.Format(_values);
+        }
+
+        public IEnumerable<KeyValuePair<string, object>> GetValues()
+        {
+            return _formatter.GetValues(_values);
+        }
+
+        private Formatter ParseFormatter(string format)
+        {
+            return new Formatter(format);
+        }
+
+        class Formatter
+        {
+            private readonly string _format;
+            private readonly List<string> _valueNames = new List<string>();
+
+            public Formatter(string format)
+            {
+                var sb = new StringBuilder();
+                var endIndex = format.Length;
+                for (var scanIndex = 0; scanIndex != endIndex; )
+                {
+                    var openBraceIndex = FindIndexOf(format, '{', scanIndex, endIndex);
+                    var closeBraceIndex = FindIndexOf(format, '}', openBraceIndex, endIndex);
+                    var formatDelimiterIndex = FindIndexOf(format, ':', openBraceIndex, closeBraceIndex);
+
+                    if (closeBraceIndex == endIndex)
+                    {
+                        sb.Append(format, scanIndex, endIndex - scanIndex);
+                        scanIndex = endIndex;
+                    }
+                    else
+                    {
+                        sb.Append(format, scanIndex, openBraceIndex - scanIndex + 1);
+                        sb.Append(_valueNames.Count.ToString(CultureInfo.InvariantCulture));
+                        _valueNames.Add(format.Substring(openBraceIndex + 1, formatDelimiterIndex - openBraceIndex - 1));
+                        sb.Append(format, formatDelimiterIndex, closeBraceIndex - formatDelimiterIndex + 1);
+
+                        scanIndex = closeBraceIndex + 1;
+                    }
+                }
+                _format = sb.ToString();
+            }
+
+            int FindIndexOf(string format, char ch, int startIndex, int endIndex)
+            {
+                var findIndex = format.IndexOf(ch, startIndex, endIndex - startIndex);
+                return findIndex == -1 ? endIndex : findIndex;
+            }
+
+            internal string Format(object[] values)
+            {
+                return string.Format(CultureInfo.InvariantCulture, _format, values);
+            }
+
+            internal IEnumerable<KeyValuePair<string, object>> GetValues(object[] values)
+            {
+                var valueArray = new KeyValuePair<string, object>[values.Length];
+                for (var index = 0; index != values.Length; ++index)
+                {
+                    valueArray[index] = new KeyValuePair<string, object>(_valueNames[index], values[index]);
+                }
+                return valueArray;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Framework.Logging/LoggerStructureFormat.cs
+++ b/src/Microsoft.Framework.Logging/LoggerStructureFormat.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Text;
 
 namespace Microsoft.Framework.Logging
 {
@@ -14,13 +12,13 @@ namespace Microsoft.Framework.Logging
     /// </summary>
     public class LoggerStructureFormat : ILoggerStructure
     {
-        private static ConcurrentDictionary<string, Formatter> _formatters = new ConcurrentDictionary<string, Formatter>();
-        private readonly Formatter _formatter;
+        private static ConcurrentDictionary<string, LoggerStructureFormatter> _formatters = new ConcurrentDictionary<string, LoggerStructureFormatter>();
+        private readonly LoggerStructureFormatter _formatter;
         private readonly object[] _values;
 
-        public LoggerStructureFormat(string format, object[] values)
+        public LoggerStructureFormat(string format, params object[] values)
         {
-            _formatter = _formatters.GetOrAdd(format, f => new Formatter(f));
+            _formatter = _formatters.GetOrAdd(format, f => new LoggerStructureFormatter(f));
             _values = values;
         }
 
@@ -34,70 +32,6 @@ namespace Microsoft.Framework.Logging
         public IEnumerable<KeyValuePair<string, object>> GetValues()
         {
             return _formatter.GetValues(_values);
-        }
-
-        private class Formatter
-        {
-            private readonly string _format;
-            private readonly List<string> _valueNames = new List<string>();
-
-            public Formatter(string format)
-            {
-                var sb = new StringBuilder();
-                var scanIndex = 0;
-                var endIndex = format.Length;
-
-                while (scanIndex < endIndex)
-                {
-                    var openBraceIndex = FindIndexOf(format, '{', scanIndex, endIndex);
-                    var closeBraceIndex = FindIndexOf(format, '}', openBraceIndex, endIndex);
-
-                    // Format item syntax : { index[,alignment][ :formatString] }.
-                    var formatDelimiterIndex = FindIndexOf(format, ',', openBraceIndex, closeBraceIndex);
-                    if (formatDelimiterIndex == closeBraceIndex)
-                    {
-                        formatDelimiterIndex = FindIndexOf(format, ':', openBraceIndex, closeBraceIndex);
-                    }
-
-                    if (closeBraceIndex == endIndex)
-                    {
-                        sb.Append(format, scanIndex, endIndex - scanIndex);
-                        scanIndex = endIndex;
-                    }
-                    else
-                    {
-                        sb.Append(format, scanIndex, openBraceIndex - scanIndex + 1);
-                        sb.Append(_valueNames.Count.ToString(CultureInfo.InvariantCulture));
-                        _valueNames.Add(format.Substring(openBraceIndex + 1, formatDelimiterIndex - openBraceIndex - 1));
-                        sb.Append(format, formatDelimiterIndex, closeBraceIndex - formatDelimiterIndex + 1);
-
-                        scanIndex = closeBraceIndex + 1;
-                    }
-                }
-
-                _format = sb.ToString();
-            }
-
-            private static int FindIndexOf(string format, char ch, int startIndex, int endIndex)
-            {
-                var findIndex = format.IndexOf(ch, startIndex, endIndex - startIndex);
-                return findIndex == -1 ? endIndex : findIndex;
-            }
-
-            public string Format(object[] values)
-            {
-                return string.Format(CultureInfo.InvariantCulture, _format, values);
-            }
-
-            public IEnumerable<KeyValuePair<string, object>> GetValues(object[] values)
-            {
-                var valueArray = new KeyValuePair<string, object>[values.Length];
-                for (var index = 0; index != values.Length; ++index)
-                {
-                    valueArray[index] = new KeyValuePair<string, object>(_valueNames[index], values[index]);
-                }
-                return valueArray;
-            }
         }
     }
 }

--- a/src/Microsoft.Framework.Logging/LoggerStructureFormat.cs
+++ b/src/Microsoft.Framework.Logging/LoggerStructureFormat.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Framework.Logging
 
         public LoggerStructureFormat(string format, object[] values)
         {
-            _formatter = _formatters.GetOrAdd(format, _ => new Formatter(format));
+            _formatter = _formatters.GetOrAdd(format, f => new Formatter(f));
             _values = values;
         }
 
@@ -74,7 +74,7 @@ namespace Microsoft.Framework.Logging
                 _format = sb.ToString();
             }
 
-            private int FindIndexOf(string format, char ch, int startIndex, int endIndex)
+            private static int FindIndexOf(string format, char ch, int startIndex, int endIndex)
             {
                 var findIndex = format.IndexOf(ch, startIndex, endIndex - startIndex);
                 return findIndex == -1 ? endIndex : findIndex;

--- a/src/Microsoft.Framework.Logging/LoggerStructureFormat.cs
+++ b/src/Microsoft.Framework.Logging/LoggerStructureFormat.cs
@@ -53,11 +53,17 @@ namespace Microsoft.Framework.Logging
             {
                 var sb = new StringBuilder();
                 var endIndex = format.Length;
-                for (var scanIndex = 0; scanIndex != endIndex; )
+                for (var scanIndex = 0; scanIndex != endIndex;)
                 {
                     var openBraceIndex = FindIndexOf(format, '{', scanIndex, endIndex);
                     var closeBraceIndex = FindIndexOf(format, '}', openBraceIndex, endIndex);
-                    var formatDelimiterIndex = FindIndexOf(format, ':', openBraceIndex, closeBraceIndex);
+
+                    // Format item syntax : { index[,alignment][ :formatString] }.
+                    var formatDelimiterIndex = FindIndexOf(format, ',', openBraceIndex, closeBraceIndex);
+                    if (formatDelimiterIndex == closeBraceIndex)
+                    {
+                        formatDelimiterIndex = FindIndexOf(format, ':', openBraceIndex, closeBraceIndex);
+                    }
 
                     if (closeBraceIndex == endIndex)
                     {

--- a/src/Microsoft.Framework.Logging/LoggerStructureFormatter.cs
+++ b/src/Microsoft.Framework.Logging/LoggerStructureFormatter.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Framework.Logging
 
             while (scanIndex < endIndex)
             {
-                var openBraceIndex = FindBrace(format, '{', scanIndex, endIndex);
-                var closeBraceIndex = FindBrace(format, '}', openBraceIndex, endIndex);
+                var openBraceIndex = FindBraceIndex(format, '{', scanIndex, endIndex);
+                var closeBraceIndex = FindBraceIndex(format, '}', openBraceIndex, endIndex);
 
                 // Format item syntax : { index[,alignment][ :formatString] }.
                 var formatDelimiterIndex = FindIndexOf(format, ',', openBraceIndex, closeBraceIndex);
@@ -55,7 +55,7 @@ namespace Microsoft.Framework.Logging
             _format = sb.ToString();
         }
 
-        private static int FindBrace(string format, char braceCharacter, int startIndex, int endIndex)
+        private static int FindBraceIndex(string format, char brace, int startIndex, int endIndex)
         {
             // Example: {{prefix{{{Argument}}}suffix}}.
             var braceIndex = endIndex;
@@ -64,7 +64,7 @@ namespace Microsoft.Framework.Logging
 
             while (scanIndex < endIndex)
             {
-                if (braceOccurenceCount > 0 && format[scanIndex] != braceCharacter)
+                if (braceOccurenceCount > 0 && format[scanIndex] != brace)
                 {
                     if (braceOccurenceCount % 2 == 0)
                     {
@@ -78,9 +78,9 @@ namespace Microsoft.Framework.Logging
                         break;
                     }
                 }
-                else if (format[scanIndex] == braceCharacter)
+                else if (format[scanIndex] == brace)
                 {
-                    if (braceCharacter == '}')
+                    if (brace == '}')
                     {
                         if (braceOccurenceCount == 0)
                         {

--- a/src/Microsoft.Framework.Logging/LoggerStructureFormatter.cs
+++ b/src/Microsoft.Framework.Logging/LoggerStructureFormatter.cs
@@ -13,12 +13,13 @@ namespace Microsoft.Framework.Logging
     public class LoggerStructureFormatter
     {
         private readonly string _format;
-        private readonly string _originalFormat;
         private readonly List<string> _valueNames = new List<string>();
+
+        public string OriginalFormat { get; private set; }
 
         public LoggerStructureFormatter(string format)
         {
-            _originalFormat = format;
+            OriginalFormat = format;
 
             var sb = new StringBuilder();
             var scanIndex = 0;
@@ -122,7 +123,7 @@ namespace Microsoft.Framework.Logging
                 valueArray[index] = new KeyValuePair<string, object>(_valueNames[index], values[index]);
             }
 
-            valueArray[valueArray.Length - 1] = new KeyValuePair<string, object>("__OriginalFormat", _originalFormat);
+            valueArray[valueArray.Length - 1] = new KeyValuePair<string, object>("__OriginalFormat", OriginalFormat);
             return valueArray;
         }
     }

--- a/src/Microsoft.Framework.Logging/LoggerStructureFormatter.cs
+++ b/src/Microsoft.Framework.Logging/LoggerStructureFormatter.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Microsoft.Framework.Logging
+{
+    /// <summary>
+    /// Formatter to convert the named format items like {NamedformatItem} to <see cref="string.Format"/> format.
+    /// </summary>
+    public class LoggerStructureFormatter
+    {
+        private readonly string _format;
+        private readonly string _originalFormat;
+        private readonly List<string> _valueNames = new List<string>();
+
+        public LoggerStructureFormatter(string format)
+        {
+            _originalFormat = format;
+
+            var sb = new StringBuilder();
+            var scanIndex = 0;
+            var endIndex = format.Length;
+
+            while (scanIndex < endIndex)
+            {
+                var openBraceIndex = FindBrace(format, '{', scanIndex, endIndex);
+                var closeBraceIndex = FindBrace(format, '}', openBraceIndex, endIndex);
+
+                // Format item syntax : { index[,alignment][ :formatString] }.
+                var formatDelimiterIndex = FindIndexOf(format, ',', openBraceIndex, closeBraceIndex);
+                if (formatDelimiterIndex == closeBraceIndex)
+                {
+                    formatDelimiterIndex = FindIndexOf(format, ':', openBraceIndex, closeBraceIndex);
+                }
+
+                if (closeBraceIndex == endIndex)
+                {
+                    sb.Append(format, scanIndex, endIndex - scanIndex);
+                    scanIndex = endIndex;
+                }
+                else
+                {
+                    sb.Append(format, scanIndex, openBraceIndex - scanIndex + 1);
+                    sb.Append(_valueNames.Count.ToString(CultureInfo.InvariantCulture));
+                    _valueNames.Add(format.Substring(openBraceIndex + 1, formatDelimiterIndex - openBraceIndex - 1));
+                    sb.Append(format, formatDelimiterIndex, closeBraceIndex - formatDelimiterIndex + 1);
+
+                    scanIndex = closeBraceIndex + 1;
+                }
+            }
+
+            _format = sb.ToString();
+        }
+
+        private static int FindBrace(string format, char braceCharacter, int startIndex, int endIndex)
+        {
+            // Example: {{prefix{{{Argument}}}suffix}}.
+            var braceIndex = endIndex;
+            var scanIndex = startIndex;
+            var braceOccurenceCount = 0;
+
+            while (scanIndex < endIndex)
+            {
+                if (braceOccurenceCount > 0 && format[scanIndex] != braceCharacter)
+                {
+                    if (braceOccurenceCount % 2 == 0)
+                    {
+                        // Even number of '{' or '}' found. Proceed search with next occurence of '{' or '}'.
+                        braceOccurenceCount = 0;
+                        braceIndex = endIndex;
+                    }
+                    else
+                    {
+                        // An unescaped '{' or '}' found.
+                        break;
+                    }
+                }
+                else if (format[scanIndex] == braceCharacter)
+                {
+                    if (braceCharacter == '}')
+                    {
+                        if (braceOccurenceCount == 0)
+                        {
+                            // For '}' pick the first occurence.
+                            braceIndex = scanIndex;
+                        }
+                    }
+                    else
+                    {
+                        // For '{' pick the last occurence.
+                        braceIndex = scanIndex;
+                    }
+
+                    braceOccurenceCount++;
+                }
+
+                scanIndex++;
+            }
+
+            return braceIndex;
+        }
+
+        private static int FindIndexOf(string format, char ch, int startIndex, int endIndex)
+        {
+            var findIndex = format.IndexOf(ch, startIndex, endIndex - startIndex);
+            return findIndex == -1 ? endIndex : findIndex;
+        }
+
+        public string Format(object[] values)
+        {
+            return string.Format(CultureInfo.InvariantCulture, _format, values);
+        }
+
+        public IEnumerable<KeyValuePair<string, object>> GetValues(object[] values)
+        {
+            var valueArray = new KeyValuePair<string, object>[values.Length + 1];
+            for (var index = 0; index != _valueNames.Count; ++index)
+            {
+                valueArray[index] = new KeyValuePair<string, object>(_valueNames[index], values[index]);
+            }
+
+            valueArray[valueArray.Length - 1] = new KeyValuePair<string, object>("__OriginalFormat", _originalFormat);
+            return valueArray;
+        }
+    }
+}

--- a/src/Microsoft.Framework.Logging/LoggerStructureFormatter.cs
+++ b/src/Microsoft.Framework.Logging/LoggerStructureFormatter.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Framework.Logging
                 valueArray[index] = new KeyValuePair<string, object>(_valueNames[index], values[index]);
             }
 
-            valueArray[valueArray.Length - 1] = new KeyValuePair<string, object>("__OriginalFormat", OriginalFormat);
+            valueArray[valueArray.Length - 1] = new KeyValuePair<string, object>("{OriginalFormat}", OriginalFormat);
             return valueArray;
         }
     }

--- a/src/Microsoft.Framework.Logging/project.json
+++ b/src/Microsoft.Framework.Logging/project.json
@@ -2,24 +2,30 @@
     "version": "1.0.0-*",
     "description": "Logging infrastructure.",
     "compilationOptions": {
-        "define": [ "TRACE" ]
-    },
-    "dependencies": {
-        "System.Collections.Concurrent": "4.0.10-beta-*"
+        "define": [
+            "TRACE"
+        ]
     },
     "frameworks": {
         "net45": {
             "dependencies": {
                 "Microsoft.Framework.Logging.Interfaces": "1.0.0-*"
+            },
+            "frameworkAssemblies": {
+                "System.Collections.Concurrent": ""
             }
         },
         "aspnet50": {
             "dependencies": {
                 "Microsoft.Framework.Logging.Interfaces": { "version": "1.0.0-*", "type": "build" }
+            },
+            "frameworkAssemblies": {
+                "System.Collections.Concurrent": ""
             }
         },
         "aspnetcore50": {
             "dependencies": {
+                "System.Collections.Concurrent": "4.0.10-beta-*",
                 "System.Diagnostics.TraceSource": "4.0.0-beta-*",
                 "System.Globalization": "4.0.10-beta-*",
                 "System.Linq": "4.0.0-beta-*",
@@ -33,6 +39,7 @@
             },
             "frameworkAssemblies": {
                 "System.Collections": "",
+                "System.Collections.Concurrent": "",
                 "System.Reflection": "",
                 "System.Runtime.Extensions": "",
                 "System.Linq": "",

--- a/src/Microsoft.Framework.Logging/project.json
+++ b/src/Microsoft.Framework.Logging/project.json
@@ -4,6 +4,9 @@
     "compilationOptions": {
         "define": [ "TRACE" ]
     },
+    "dependencies": {
+        "System.Collections.Concurrent": "4.0.10-beta-*"
+    },
     "frameworks": {
         "net45": {
             "dependencies": {
@@ -17,7 +20,6 @@
         },
         "aspnetcore50": {
             "dependencies": {
-                "System.Collections.Concurrent": "4.0.10-beta-*",
                 "System.Diagnostics.TraceSource": "4.0.0-beta-*",
                 "System.Globalization": "4.0.10-beta-*",
                 "System.Linq": "4.0.0-beta-*",
@@ -31,7 +33,7 @@
             },
             "frameworkAssemblies": {
                 "System.Collections": "",
-                "System.Reflection":  "",
+                "System.Reflection": "",
                 "System.Runtime.Extensions": "",
                 "System.Linq": "",
                 "System.Threading": ""

--- a/test/Microsoft.Framework.Logging.Test/LoggerExtensionsTest.cs
+++ b/test/Microsoft.Framework.Logging.Test/LoggerExtensionsTest.cs
@@ -87,31 +87,31 @@ namespace Microsoft.Framework.Logging.Test
 
             var verbose = sink.Writes[0];
             Assert.Equal(LogLevel.Verbose, verbose.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), verbose.State);
+            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILoggerStructure)verbose.State).Format());
             Assert.Equal(0, verbose.EventId);
             Assert.Equal(null, verbose.Exception);
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), information.State);
+            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILoggerStructure)information.State).Format());
             Assert.Equal(0, information.EventId);
             Assert.Equal(null, information.Exception);
 
             var warning = sink.Writes[2];
             Assert.Equal(LogLevel.Warning, warning.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), warning.State);
+            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILoggerStructure)warning.State).Format());
             Assert.Equal(0, warning.EventId);
             Assert.Equal(null, warning.Exception);
 
             var error = sink.Writes[3];
             Assert.Equal(LogLevel.Error, error.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), error.State);
+            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILoggerStructure)error.State).Format());
             Assert.Equal(0, error.EventId);
             Assert.Equal(null, error.Exception);
 
             var critical = sink.Writes[4];
             Assert.Equal(LogLevel.Critical, critical.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), critical.State);
+            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILoggerStructure)critical.State).Format());
             Assert.Equal(0, critical.EventId);
             Assert.Equal(null, critical.Exception);
         }
@@ -183,31 +183,31 @@ namespace Microsoft.Framework.Logging.Test
 
             var verbose = sink.Writes[0];
             Assert.Equal(LogLevel.Verbose, verbose.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), verbose.State);
+            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILoggerStructure)verbose.State).Format());
             Assert.Equal(1, verbose.EventId);
             Assert.Equal(null, verbose.Exception);
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), information.State);
+            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILoggerStructure)information.State).Format());
             Assert.Equal(2, information.EventId);
             Assert.Equal(null, information.Exception);
 
             var warning = sink.Writes[2];
             Assert.Equal(LogLevel.Warning, warning.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), warning.State);
+            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILoggerStructure)warning.State).Format());
             Assert.Equal(3, warning.EventId);
             Assert.Equal(null, warning.Exception);
 
             var error = sink.Writes[3];
             Assert.Equal(LogLevel.Error, error.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), error.State);
+            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILoggerStructure)error.State).Format());
             Assert.Equal(4, error.EventId);
             Assert.Equal(null, error.Exception);
 
             var critical = sink.Writes[4];
             Assert.Equal(LogLevel.Critical, critical.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), critical.State);
+            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILoggerStructure)critical.State).Format());
             Assert.Equal(5, critical.EventId);
             Assert.Equal(null, critical.Exception);
         }
@@ -307,35 +307,35 @@ namespace Microsoft.Framework.Logging.Test
             Assert.Equal(testStructure, verbose.State);
             Assert.Equal(0, verbose.EventId);
             Assert.Equal(null, verbose.Exception);
-            Assert.Equal("Test 1" + Environment.NewLine, verbose.Formatter(verbose.State, verbose.Exception));
+            Assert.Equal("Test 1", verbose.Formatter(verbose.State, verbose.Exception));
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
             Assert.Equal(testStructure, information.State);
             Assert.Equal(0, information.EventId);
             Assert.Equal(null, information.Exception);
-            Assert.Equal("Test 1" + Environment.NewLine, information.Formatter(information.State, information.Exception));
+            Assert.Equal("Test 1", information.Formatter(information.State, information.Exception));
 
             var warning = sink.Writes[2];
             Assert.Equal(LogLevel.Warning, warning.LogLevel);
             Assert.Equal(testStructure, warning.State);
             Assert.Equal(0, warning.EventId);
             Assert.Equal(null, warning.Exception);
-            Assert.Equal("Test 1" + Environment.NewLine, warning.Formatter(warning.State, warning.Exception));
+            Assert.Equal("Test 1", warning.Formatter(warning.State, warning.Exception));
 
             var error = sink.Writes[3];
             Assert.Equal(LogLevel.Error, error.LogLevel);
             Assert.Equal(testStructure, error.State);
             Assert.Equal(0, error.EventId);
             Assert.Equal(null, error.Exception);
-            Assert.Equal("Test 1" + Environment.NewLine, error.Formatter(error.State, error.Exception));
+            Assert.Equal("Test 1", error.Formatter(error.State, error.Exception));
 
             var critical = sink.Writes[4];
             Assert.Equal(LogLevel.Critical, critical.LogLevel);
             Assert.Equal(testStructure, critical.State);
             Assert.Equal(0, critical.EventId);
             Assert.Equal(null, critical.Exception);
-            Assert.Equal("Test 1" + Environment.NewLine, critical.Formatter(critical.State, critical.Exception));
+            Assert.Equal("Test 1", critical.Formatter(critical.State, critical.Exception));
         }
 
         [Fact]
@@ -365,35 +365,35 @@ namespace Microsoft.Framework.Logging.Test
             Assert.Equal(testStructure, verbose.State);
             Assert.Equal(1, verbose.EventId);
             Assert.Equal(null, verbose.Exception);
-            Assert.Equal("Test 1" + Environment.NewLine, verbose.Formatter(verbose.State, verbose.Exception));
+            Assert.Equal("Test 1", verbose.Formatter(verbose.State, verbose.Exception));
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
             Assert.Equal(testStructure, information.State);
             Assert.Equal(2, information.EventId);
             Assert.Equal(null, information.Exception);
-            Assert.Equal("Test 1" + Environment.NewLine, information.Formatter(information.State, information.Exception));
+            Assert.Equal("Test 1", information.Formatter(information.State, information.Exception));
 
             var warning = sink.Writes[2];
             Assert.Equal(LogLevel.Warning, warning.LogLevel);
             Assert.Equal(testStructure, warning.State);
             Assert.Equal(3, warning.EventId);
             Assert.Equal(null, warning.Exception);
-            Assert.Equal("Test 1" + Environment.NewLine, warning.Formatter(warning.State, warning.Exception));
+            Assert.Equal("Test 1", warning.Formatter(warning.State, warning.Exception));
 
             var error = sink.Writes[3];
             Assert.Equal(LogLevel.Error, error.LogLevel);
             Assert.Equal(testStructure, error.State);
             Assert.Equal(4, error.EventId);
             Assert.Equal(null, error.Exception);
-            Assert.Equal("Test 1" + Environment.NewLine, error.Formatter(error.State, error.Exception));
+            Assert.Equal("Test 1", error.Formatter(error.State, error.Exception));
 
             var critical = sink.Writes[4];
             Assert.Equal(LogLevel.Critical, critical.LogLevel);
             Assert.Equal(testStructure, critical.State);
             Assert.Equal(5, critical.EventId);
             Assert.Equal(null, critical.Exception);
-            Assert.Equal("Test 1" + Environment.NewLine, critical.Formatter(critical.State, critical.Exception));
+            Assert.Equal("Test 1", critical.Formatter(critical.State, critical.Exception));
         }
 
         [Fact]
@@ -424,7 +424,7 @@ namespace Microsoft.Framework.Logging.Test
             Assert.Equal(0, verbose.EventId);
             Assert.Equal(_exception, verbose.Exception);
             Assert.Equal(
-                "Test 1" + Environment.NewLine + _exception, 
+                "Test 1" + Environment.NewLine + _exception,
                 verbose.Formatter(verbose.State, verbose.Exception));
 
             var information = sink.Writes[1];
@@ -433,7 +433,7 @@ namespace Microsoft.Framework.Logging.Test
             Assert.Equal(0, information.EventId);
             Assert.Equal(_exception, information.Exception);
             Assert.Equal(
-                "Test 1" + Environment.NewLine + _exception, 
+                "Test 1" + Environment.NewLine + _exception,
                 information.Formatter(information.State, information.Exception));
 
             var warning = sink.Writes[2];
@@ -442,7 +442,7 @@ namespace Microsoft.Framework.Logging.Test
             Assert.Equal(0, warning.EventId);
             Assert.Equal(_exception, warning.Exception);
             Assert.Equal(
-                "Test 1" + Environment.NewLine + _exception, 
+                "Test 1" + Environment.NewLine + _exception,
                 warning.Formatter(warning.State, warning.Exception));
 
             var error = sink.Writes[3];
@@ -451,7 +451,7 @@ namespace Microsoft.Framework.Logging.Test
             Assert.Equal(0, error.EventId);
             Assert.Equal(_exception, error.Exception);
             Assert.Equal(
-                "Test 1" + Environment.NewLine + _exception, 
+                "Test 1" + Environment.NewLine + _exception,
                 error.Formatter(error.State, error.Exception));
 
             var critical = sink.Writes[4];
@@ -460,7 +460,7 @@ namespace Microsoft.Framework.Logging.Test
             Assert.Equal(0, critical.EventId);
             Assert.Equal(_exception, critical.Exception);
             Assert.Equal(
-                "Test 1" + Environment.NewLine + _exception, 
+                "Test 1" + Environment.NewLine + _exception,
                 critical.Formatter(critical.State, critical.Exception));
         }
 

--- a/test/Microsoft.Framework.Logging.Test/LoggerStructureFormatTest.cs
+++ b/test/Microsoft.Framework.Logging.Test/LoggerStructureFormatTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.Framework.Logging.Test
@@ -9,6 +10,7 @@ namespace Microsoft.Framework.Logging.Test
     public class LoggerStructureFormatTest
     {
         [Theory]
+        [InlineData("", "", new object[] { })]
         [InlineData("arg1 arg2", "{0} {1}", new object[] { "arg1", "arg2" })]
         [InlineData("arg1 arg2", "{Start} {End}", new object[] { "arg1", "arg2" })]
         [InlineData("arg1     arg2", "{Start,-6} {End,6}", new object[] { "arg1", "arg2" })]
@@ -17,16 +19,43 @@ namespace Microsoft.Framework.Logging.Test
         {
             var loggerStructure = new LoggerStructureFormat(format, args);
             Assert.Equal(expected, loggerStructure.Format());
+
+            // Original format is expected to be returned from GetValues.
+            Assert.Equal(format, loggerStructure.GetValues().First(v => v.Key == "__OriginalFormat").Value);
         }
 
         [Theory]
         [InlineData("1 2015", "{Year,6:d yyyy}")]
         [InlineData("1:01:2015 AM,:        01", "{Year,-10:d:MM:yyyy tt},:{second,10:ss}")]
+        [InlineData("{prefix{1 2015}suffix}", "{{prefix{{{Year,6:d yyyy}}}suffix}}")]
         public void LoggerStructure_With_DateTime(string expected, string format)
         {
             var dateTime = new DateTime(2015, 1, 1, 1, 1, 1);
             var loggerStructure = new LoggerStructureFormat(format, new object[] { dateTime, dateTime });
             Assert.Equal(expected, loggerStructure.Format());
+
+            // Original format is expected to be returned from GetValues.
+            Assert.Equal(format, loggerStructure.GetValues().First(v => v.Key == "__OriginalFormat").Value);
+        }
+
+        [Theory]
+        [InlineData("{", "{{", null)]
+        [InlineData("'{'", "'{{'", null)]
+        [InlineData("'{}'", "'{{}}'", null)]
+        [InlineData("arg1 arg2 '{}'  '{' '{:}' '{,:}' {,}- test string",
+            "{0} {1} '{{}}'  '{{' '{{:}}' '{{,:}}' {{,}}- test string",
+            new object[] { "arg1", "arg2" })]
+        [InlineData("{prefix{arg1}suffix}", "{{prefix{{{Argument}}}suffix}}", new object[] { "arg1" })]
+        public void LoggerStructure_With_Escaped_Braces(string expected, string format, object[] args)
+        {
+            var loggerStructure = args == null ?
+                new LoggerStructureFormat(format) :
+                new LoggerStructureFormat(format, args);
+
+            Assert.Equal(expected, loggerStructure.Format());
+
+            // Original format is expected to be returned from GetValues.
+            Assert.Equal(format, loggerStructure.GetValues().First(v => v.Key == "__OriginalFormat").Value);
         }
     }
 }

--- a/test/Microsoft.Framework.Logging.Test/LoggerStructureFormatTest.cs
+++ b/test/Microsoft.Framework.Logging.Test/LoggerStructureFormatTest.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Framework.Logging.Test
+{
+    public class LoggerStructureFormatTest
+    {
+        [Theory]
+        [InlineData("arg1 arg2", "{0} {1}", new object[] { "arg1", "arg2" })]
+        [InlineData("arg1 arg2", "{Start} {End}", new object[] { "arg1", "arg2" })]
+        [InlineData("arg1     arg2", "{Start,-6} {End,6}", new object[] { "arg1", "arg2" })]
+        [InlineData("0064", "{Hex:X4}", new object[] { 100 })]
+        public void LoggerStructure_With_Basic_Types(string expected, string format, object[] args)
+        {
+            var loggerStructure = new LoggerStructureFormat(format, args);
+            Assert.Equal(expected, loggerStructure.Format());
+        }
+
+        [Theory]
+        [InlineData("1 2015", "{Year,6:d yyyy}")]
+        [InlineData("1:01:2015 AM,:        01", "{Year,-10:d:MM:yyyy tt},:{second,10:ss}")]
+        public void LoggerStructure_With_DateTime(string expected, string format)
+        {
+            var dateTime = new DateTime(2015, 1, 1, 1, 1, 1);
+            var loggerStructure = new LoggerStructureFormat(format, new object[] { dateTime, dateTime });
+            Assert.Equal(expected, loggerStructure.Format());
+        }
+    }
+}

--- a/test/Microsoft.Framework.Logging.Test/LoggerStructureFormatTest.cs
+++ b/test/Microsoft.Framework.Logging.Test/LoggerStructureFormatTest.cs
@@ -57,5 +57,18 @@ namespace Microsoft.Framework.Logging.Test
             // Original format is expected to be returned from GetValues.
             Assert.Equal(format, loggerStructure.GetValues().First(v => v.Key == "__OriginalFormat").Value);
         }
+
+        [Theory]
+        [InlineData("{foo")]
+        [InlineData("bar}")]
+        [InlineData("{foo bar}")]
+        public void LoggerStructure_With_UnbalancedBraces(string format)
+        {
+            Assert.Throws<FormatException>(() =>
+            {
+                var loggerStructure = new LoggerStructureFormat(format);
+                loggerStructure.Format();
+            });
+        }
     }
 }

--- a/test/Microsoft.Framework.Logging.Test/LoggerStructureFormatTest.cs
+++ b/test/Microsoft.Framework.Logging.Test/LoggerStructureFormatTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Framework.Logging.Test
             Assert.Equal(expected, loggerStructure.Format());
 
             // Original format is expected to be returned from GetValues.
-            Assert.Equal(format, loggerStructure.GetValues().First(v => v.Key == "__OriginalFormat").Value);
+            Assert.Equal(format, loggerStructure.GetValues().First(v => v.Key == "{OriginalFormat}").Value);
         }
 
         [Theory]
@@ -35,7 +35,7 @@ namespace Microsoft.Framework.Logging.Test
             Assert.Equal(expected, loggerStructure.Format());
 
             // Original format is expected to be returned from GetValues.
-            Assert.Equal(format, loggerStructure.GetValues().First(v => v.Key == "__OriginalFormat").Value);
+            Assert.Equal(format, loggerStructure.GetValues().First(v => v.Key == "{OriginalFormat}").Value);
         }
 
         [Theory]
@@ -55,7 +55,7 @@ namespace Microsoft.Framework.Logging.Test
             Assert.Equal(expected, loggerStructure.Format());
 
             // Original format is expected to be returned from GetValues.
-            Assert.Equal(format, loggerStructure.GetValues().First(v => v.Key == "__OriginalFormat").Value);
+            Assert.Equal(format, loggerStructure.GetValues().First(v => v.Key == "{OriginalFormat}").Value);
         }
 
         [Theory]


### PR DESCRIPTION
This adds ability to specify named placeholders while writing logs. 

For example: 
`logger.WriteInformation("Tests started at '{StartTime}'", DateTime.Now)` (instead of `'{0}'` => `'{StartTime}'`). 

@lodejard 