### PR TITLE
Beautifying generic types

### DIFF
--- a/samples/SampleApp/project.json
+++ b/samples/SampleApp/project.json
@@ -15,5 +15,8 @@
                 "System.Console": "4.0.0-beta-*"
             }
         }
+    },
+    "commands": {
+        "run": "run"
     }
 }

--- a/src/Microsoft.Framework.Logging/LoggerFactoryExtensions.cs
+++ b/src/Microsoft.Framework.Logging/LoggerFactoryExtensions.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Framework.Logging
                 throw new ArgumentNullException("factory");
             }
 
-            return factory.Create(typeof(T).FullName);
+            return factory.Create(TypeNameHelper.GetTypeDisplayFullName(typeof(T)));
         }
     }
+        
 }

--- a/src/Microsoft.Framework.Logging/Utils/TypeNameHelper.cs
+++ b/src/Microsoft.Framework.Logging/Utils/TypeNameHelper.cs
@@ -72,11 +72,7 @@ namespace Microsoft.Framework.Logging
                 text = t.Name;
             }
             var num = text.IndexOf('`');
-            if (num != -1)
-            {
-                return text.Substring(0, num);
-            }
-            return text;
+            return num != -1 ? text.Substring(0, num) : text;
         }
     }
 }

--- a/src/Microsoft.Framework.Logging/Utils/TypeNameHelper.cs
+++ b/src/Microsoft.Framework.Logging/Utils/TypeNameHelper.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using System.Text;
+
+namespace Microsoft.Framework.Logging
+{
+    public static class TypeNameHelper
+    {
+        public static string GetTypeDisplayFullName(Type type)
+        {
+            var sb = new StringBuilder(64);
+            ProcessTypeName(type, sb);
+            return sb.ToString();
+        }
+
+        private static void AppendGenericArguments(Type[] args, StringBuilder sb)
+        {
+            if (args.Length > 0)
+            {
+                sb.Append("<");
+                for (int i = 0; i < args.Length; i++)
+                {
+                    ProcessTypeName(args[i], sb);
+                    if (i + 1 < args.Length)
+                    {
+                        sb.Append(", ");
+                    }
+                }
+                sb.Append(">");
+            }
+        }
+
+        private static Type GetMostGenericTypeDefinition(Type t)
+        {
+            while (t.GetTypeInfo().IsGenericType)
+            {
+                var genericTypeDefinition = t.GetGenericTypeDefinition();
+                if (genericTypeDefinition == null || t == genericTypeDefinition)
+                {
+                    return t;
+                }
+                t = genericTypeDefinition;
+            }
+            return t;
+        }
+
+        private static void ProcessTypeName(Type t, StringBuilder sb)
+        {
+            if (t.IsGenericParameter)
+            {
+                sb.Append(t.GetTypeInfo().Name);
+                return;
+            }
+            if (t.GetTypeInfo().IsGenericType)
+            {
+                var mostGenericTypeDefinition = GetMostGenericTypeDefinition(t);
+                sb.Append(GetSimpleGenericTypeName(mostGenericTypeDefinition));
+                AppendGenericArguments(t.GetTypeInfo().GenericTypeArguments, sb);
+                return;
+            }
+            sb.Append(GetSimpleGenericTypeName(t));
+        }
+
+        private static string GetSimpleGenericTypeName(Type t)
+        {
+            var text = t.FullName;
+            if (text == null)
+            {
+                text = t.Name;
+            }
+            var num = text.IndexOf('`');
+            if (num != -1)
+            {
+                return text.Substring(0, num);
+            }
+            return text;
+        }
+    }
+}

--- a/src/Microsoft.Framework.Logging/project.json
+++ b/src/Microsoft.Framework.Logging/project.json
@@ -17,7 +17,8 @@
         },
         "aspnet50": {
             "frameworkAssemblies": {
-                "System.Collections.Concurrent": ""
+                "System.Collections.Concurrent": "",
+                "System.Reflection": ""
             }
         },
         "aspnetcore50": {
@@ -27,6 +28,7 @@
                 "System.Diagnostics.TraceSource": "4.0.0-beta-*",
                 "System.Globalization": "4.0.10-beta-*",
                 "System.Linq": "4.0.0-beta-*",
+		"System.Reflection": "4.0.10-beta-*",
                 "System.Threading": "4.0.10-beta-*"
             }
         },

--- a/test/Microsoft.Framework.Logging.Test/LoggerFactoryExtensionsTest.cs
+++ b/test/Microsoft.Framework.Logging.Test/LoggerFactoryExtensionsTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Framework.Logging.Test
     public class LoggerFactoryExtensionsTest
     {
 #if ASPNET50
-        [Fact] 
+        [Fact]
         public void LoggerFactoryCreateOfT_CallsCreateWithCorrectName()
         {
             // Arrange
@@ -28,11 +28,56 @@ namespace Microsoft.Framework.Logging.Test
             // Assert
             factory.Verify(f => f.Create(expected));
         }
-#endif
 
-        private class TestType
+        [Fact]
+        public void LoggerFactoryCreateOfT_SingleGeneric_CallsCreateWithCorrectName()
         {
-            // intentionally holds nothing
+            // Arrange
+            var factory = new Mock<ILoggerFactory>();
+            factory.Setup(f => f.Create(It.Is<string>(
+                x => x.Equals("Microsoft.Framework.Logging.Test.GenericClass<Microsoft.Framework.Logging.Test.TestType>"))))
+            .Returns(new Mock<ILogger>().Object);
+
+            var logger = factory.Object.Create<GenericClass<TestType>>();
+
+            // Assert
+            Assert.NotNull(logger);
         }
+
+        [Fact]
+        public void LoggerFactoryCreateOfT_TwoGenerics_CallsCreateWithCorrectName()
+        {
+            // Arrange
+            var factory = new Mock<ILoggerFactory>();
+            factory.Setup(f => f.Create(It.Is<string>(
+                x => x.Equals("Microsoft.Framework.Logging.Test.GenericClass<Microsoft.Framework.Logging.Test.TestType, Microsoft.Framework.Logging.Test.SecondTestType>"))))
+            .Returns(new Mock<ILogger>().Object);
+
+            var logger = factory.Object.Create<GenericClass<TestType,SecondTestType>>();
+
+            // Assert
+            Assert.NotNull(logger);
+        }
+#endif
+    }
+
+    internal class TestType
+    {
+        // intentionally holds nothing
+    }
+
+    internal class SecondTestType
+    {
+        // intentionally holds nothing
+    }
+
+    internal class GenericClass<X, Y> where X : class where Y : class
+    {
+        // intentionally holds nothing
+    }
+
+    internal class GenericClass<X> where X : class
+    {
+        // intentionally holds nothing
     }
 }


### PR DESCRIPTION
@Eilon @davidfowl 

Problem: The current experience of logging generics is that the name for the logger is type.fullname which in this case would be `namespace.classname[classname, assemblyinformation]` which is not friendly. It gets worse if the arity is 2

Fix: @Eilon provided a helper class that provides a beautified generic class name in the format `namespace.class<namespace.class>`. This should not affect the behavior of non generic classes

Sample output can be seen in the unit tests