### PR TITLE
[Feedback] Adding IConfiguration overload for console logger

### DIFF
--- a/samples/SampleApp/LocalConfig.json
+++ b/samples/SampleApp/LocalConfig.json
@@ -1,0 +1,5 @@
+﻿{
+    "ConsoleLogger": {
+        "SampleApp.Program": "Information"
+    }
+}

--- a/samples/SampleApp/Program.cs
+++ b/samples/SampleApp/Program.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Framework.ConfigurationModel;
+using System;
 using System.Collections.Generic;
 using Microsoft.Framework.Logging;
 using Microsoft.Framework.Logging.Console;
@@ -38,8 +39,9 @@ namespace SampleApp
                 .WriteTo.Sink(new RollingFileSink("file-{Date}.json", new JsonFormatter(), null, null))
                 .WriteTo.Sink(new FileSink("dump.txt", new RawFormatter(), null)));
 #endif
-            factory.AddConsole();
+            // factory.AddConsole();
             factory.AddConsole((category, logLevel) => logLevel >= LogLevel.Critical && category.Equals(typeof(Program).FullName));
+            factory.AddConsole(new Configuration().AddJsonFile("LocalConfig.json"));
         }
 
         public void Main(string[] args)

--- a/samples/SampleApp/project.json
+++ b/samples/SampleApp/project.json
@@ -1,7 +1,8 @@
 {
     "dependencies": {
         "Microsoft.Framework.Logging": "1.0.0-*",
-        "Microsoft.Framework.Logging.Console": "1.0.0-*"
+        "Microsoft.Framework.Logging.Console": "1.0.0-*",
+        "Microsoft.Framework.ConfigurationModel.Json":"1.0.0-*" 
     },
     "frameworks": {
         "aspnet50": {

--- a/src/Microsoft.Framework.Logging.Console/ConsoleLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Framework.Logging.Console/ConsoleLoggerFactoryExtensions.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel;
+using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.Logging.Console;
 
 namespace Microsoft.Framework.Logging
@@ -33,6 +35,24 @@ namespace Microsoft.Framework.Logging
         public static ILoggerFactory AddConsole(this ILoggerFactory factory, LogLevel minLevel)
         {
             factory.AddProvider(new ConsoleLoggerProvider((category, logLevel) => logLevel >= minLevel));
+            return factory;
+        }
+
+        /// <summary>
+        ///     Adds a console logger that is enabled as defined by the IConfiguration object
+        /// </summary>
+        /// <param name="configuration">IConfiguration object with filter attributes</param>
+        /// <returns></returns>
+        public static ILoggerFactory AddConsole(this ILoggerFactory factory, IConfiguration configuration)
+        {
+            factory.AddProvider(new ConsoleLoggerProvider((category, logLevel) =>
+            {
+                LogLevel minLevel;
+
+                return Enum.TryParse(configuration?.GetSubKey("ConsoleLogger")?.Get(category), out minLevel) &&
+                       logLevel >= minLevel;
+            }));
+
             return factory;
         }
     }

--- a/src/Microsoft.Framework.Logging.Console/project.json
+++ b/src/Microsoft.Framework.Logging.Console/project.json
@@ -2,7 +2,8 @@
     "version": "1.0.0-*",
     "description": "Console logger implementation.",
     "dependencies": {
-        "Microsoft.Framework.Logging.Interfaces": "1.0.0-*"
+        "Microsoft.Framework.Logging.Interfaces": "1.0.0-*",
+        "Microsoft.Framework.ConfigurationModel": "1.0.0-*"
     },
     "frameworks": {
         "net45": { },


### PR DESCRIPTION
@lodejard @glennc 

This a feedback PR so you can refrain from nitpick. The final PR will have unit tests as well

Some clarifications needed
- Is the subconfig name `ConsoleLogger` fine or should we rename it.
- Also should the key value pairs be `"category":"logLevel"` or should it be `"category":{"category1","category2"}`. I am trying to keep it simple to went with the first approach
- Should the loglevel allowed be >= loglevel or == level 
