### PR TITLE
Logger extension to create scope based on format string

### DIFF
--- a/src/Microsoft.Framework.Logging.Interfaces/LoggerExtensions.cs
+++ b/src/Microsoft.Framework.Logging.Interfaces/LoggerExtensions.cs
@@ -546,6 +546,23 @@ namespace Microsoft.Framework.Logging
             logger.LogWithEvent(LogLevel.Critical, eventId, state, error);
         }
 
+        //------------------------------------------Scope------------------------------------------//
+
+        /// <summary>
+        /// Formats the message and creates a scope.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to create the scope in.</param>
+        /// <param name="messageFormat">Format string of the scope message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        /// <returns>A disposable scope object. Can be null.</returns>
+        public static IDisposable BeginScope(
+            [NotNull] this ILogger logger,
+            [NotNull] string messageFormat,
+            params object[] args)
+        {
+            return logger.BeginScope(new FormattedLogValues(messageFormat, args));
+        }
+
         //------------------------------------------HELPERS------------------------------------------//
 
         private static void Log(

--- a/src/Microsoft.Framework.Logging.NLog/NLogLoggerProvider.cs
+++ b/src/Microsoft.Framework.Logging.NLog/NLogLoggerProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Framework.Internal;
 using NLog;
 
 namespace Microsoft.Framework.Logging.NLog
@@ -72,9 +73,20 @@ namespace Microsoft.Framework.Logging.NLog
                 return global::NLog.LogLevel.Debug;
             }
 
-            public IDisposable BeginScope(object state)
+            public IDisposable BeginScope([NotNull] object state)
             {
-                return NestedDiagnosticsContext.Push(state.ToString());
+                string scopeMessage;
+                var logValues = state as ILogValues;
+                if (logValues != null)
+                {
+                    scopeMessage = logValues.Format();
+                }
+                else
+                {
+                    scopeMessage = state.ToString();
+                }
+
+                return NestedDiagnosticsContext.Push(scopeMessage);
             }
         }
     }

--- a/src/Microsoft.Framework.Logging.NLog/project.json
+++ b/src/Microsoft.Framework.Logging.NLog/project.json
@@ -2,6 +2,7 @@
     "version": "1.0.0-*",
     "dependencies": {
         "Microsoft.Framework.Logging.Interfaces": "1.0.0-*",
+        "Microsoft.Framework.NotNullAttribute.Internal": { "type": "build", "version": "1.0.0-*" },
         "NLog": "3.1.0"
     },
     "frameworks": {


### PR DESCRIPTION
@rynowak @loudej @suhasj 

FYI:
- I have verified that this change works successfully in ConsoleLogger(where its noop), SerilogLogger writing to ElasticSearch
- I had to make some changes in ElmLogger where it does not handle the case where the state is `ILogValues`...will send out a separate PR for it in diagnostics repo.