### PR TITLE
Override ToString() in FormattedLogValues

### DIFF
--- a/src/Microsoft.Framework.Logging.Interfaces/Internal/FormattedLogValues.cs
+++ b/src/Microsoft.Framework.Logging.Interfaces/Internal/FormattedLogValues.cs
@@ -31,5 +31,10 @@ namespace Microsoft.Framework.Logging.Internal
         {
             return _formatter.GetValues(_values);
         }
+
+        public override string ToString()
+        {
+            return Format();
+        }
     }
 }


### PR DESCRIPTION
@rynowak @loudej @Eilon 
Instead of earlier discussion of removing the `Format()` method from the `ILogValues` interface, I think we could just override the `ToString()` implementation of `FormattedLogValues`. I feel `Format()` contract is more explicit and clear.
