### PR TITLE
Removed Format() method from ILogValues interface

### DIFF
--- a/src/Microsoft.Framework.Logging.Interfaces/ILogValues.cs
+++ b/src/Microsoft.Framework.Logging.Interfaces/ILogValues.cs
@@ -11,10 +11,5 @@ namespace Microsoft.Framework.Logging
         /// Returns an enumerable of key value pairs mapping the name of the structured data to the data.
         /// </summary>
         IEnumerable<KeyValuePair<string, object>> GetValues();
-
-        /// <summary>
-        /// Returns a human-readable string of the structured data.
-        /// </summary>
-        string Format();
     }
 }

--- a/src/Microsoft.Framework.Logging.Interfaces/Internal/FormattedLogValues.cs
+++ b/src/Microsoft.Framework.Logging.Interfaces/Internal/FormattedLogValues.cs
@@ -22,14 +22,14 @@ namespace Microsoft.Framework.Logging.Internal
             _values = values;
         }
 
-        public string Format()
-        {
-            return _formatter.Format(_values);
-        }
-
         public IEnumerable<KeyValuePair<string, object>> GetValues()
         {
             return _formatter.GetValues(_values);
+        }
+
+        public override string ToString()
+        {
+            return _formatter.Format(_values);
         }
     }
 }

--- a/src/Microsoft.Framework.Logging.Interfaces/LoggerExtensions.cs
+++ b/src/Microsoft.Framework.Logging.Interfaces/LoggerExtensions.cs
@@ -588,10 +588,10 @@ namespace Microsoft.Framework.Logging
         {
             if (exception == null)
             {
-                return state.Format();
+                return state?.ToString();
             }
 
-            return state.Format() + Environment.NewLine + exception;
+            return state?.ToString() + Environment.NewLine + exception;
         }
     }
 }

--- a/src/Microsoft.Framework.Logging.NLog/NLogLoggerProvider.cs
+++ b/src/Microsoft.Framework.Logging.NLog/NLogLoggerProvider.cs
@@ -75,18 +75,7 @@ namespace Microsoft.Framework.Logging.NLog
 
             public IDisposable BeginScope([NotNull] object state)
             {
-                string scopeMessage;
-                var logValues = state as ILogValues;
-                if (logValues != null)
-                {
-                    scopeMessage = logValues.Format();
-                }
-                else
-                {
-                    scopeMessage = state.ToString();
-                }
-
-                return NestedDiagnosticsContext.Push(scopeMessage);
+                return NestedDiagnosticsContext.Push(state.ToString());
             }
         }
     }

--- a/src/Microsoft.Framework.Logging/ReflectionBasedLogValues.cs
+++ b/src/Microsoft.Framework.Logging/ReflectionBasedLogValues.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace Microsoft.Framework.Logging
 {
-    public abstract class ReflectionBasedLogValues : ILogValues
+    public class ReflectionBasedLogValues : ILogValues
     {
         public virtual IEnumerable<KeyValuePair<string, object>> GetValues()
         {
@@ -17,7 +17,5 @@ namespace Microsoft.Framework.Logging
             }
             return values;
         }
-
-        public abstract string Format();
     }
 }

--- a/test/Microsoft.Framework.Logging.Test/FormattedLogValuesTest.cs
+++ b/test/Microsoft.Framework.Logging.Test/FormattedLogValuesTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Framework.Logging.Test
         public void LogValues_With_Basic_Types(string expected, string format, object[] args)
         {
             var logValues = new FormattedLogValues(format, args);
-            Assert.Equal(expected, logValues.Format());
+            Assert.Equal(expected, logValues.ToString());
 
             // Original format is expected to be returned from GetValues.
             Assert.Equal(format, logValues.GetValues().First(v => v.Key == "{OriginalFormat}").Value);
@@ -33,7 +33,7 @@ namespace Microsoft.Framework.Logging.Test
         {
             var dateTime = new DateTime(2015, 1, 1, 1, 1, 1);
             var logValues = new FormattedLogValues(format, new object[] { dateTime, dateTime });
-            Assert.Equal(expected, logValues.Format());
+            Assert.Equal(expected, logValues.ToString());
 
             // Original format is expected to be returned from GetValues.
             Assert.Equal(format, logValues.GetValues().First(v => v.Key == "{OriginalFormat}").Value);
@@ -53,7 +53,7 @@ namespace Microsoft.Framework.Logging.Test
                 new FormattedLogValues(format) :
                 new FormattedLogValues(format, args);
 
-            Assert.Equal(expected, logValues.Format());
+            Assert.Equal(expected, logValues.ToString());
 
             // Original format is expected to be returned from GetValues.
             Assert.Equal(format, logValues.GetValues().First(v => v.Key == "{OriginalFormat}").Value);
@@ -68,7 +68,7 @@ namespace Microsoft.Framework.Logging.Test
             Assert.Throws<FormatException>(() =>
             {
                 var logValues = new FormattedLogValues(format);
-                logValues.Format();
+                logValues.ToString();
             });
         }
     }

--- a/test/Microsoft.Framework.Logging.Test/LoggerExtensionsTest.cs
+++ b/test/Microsoft.Framework.Logging.Test/LoggerExtensionsTest.cs
@@ -97,37 +97,37 @@ namespace Microsoft.Framework.Logging.Test
 
             var verbose = sink.Writes[0];
             Assert.Equal(LogLevel.Verbose, verbose.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILogValues)verbose.State).Format());
+            Assert.Equal(string.Format(_format, "test1", "test2"), verbose.State?.ToString());
             Assert.Equal(0, verbose.EventId);
             Assert.Equal(null, verbose.Exception);
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILogValues)information.State).Format());
+            Assert.Equal(string.Format(_format, "test1", "test2"), information.State?.ToString());
             Assert.Equal(0, information.EventId);
             Assert.Equal(null, information.Exception);
 
             var warning = sink.Writes[2];
             Assert.Equal(LogLevel.Warning, warning.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILogValues)warning.State).Format());
+            Assert.Equal(string.Format(_format, "test1", "test2"), warning.State?.ToString());
             Assert.Equal(0, warning.EventId);
             Assert.Equal(null, warning.Exception);
 
             var error = sink.Writes[3];
             Assert.Equal(LogLevel.Error, error.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILogValues)error.State).Format());
+            Assert.Equal(string.Format(_format, "test1", "test2"), error.State?.ToString());
             Assert.Equal(0, error.EventId);
             Assert.Equal(null, error.Exception);
 
             var critical = sink.Writes[4];
             Assert.Equal(LogLevel.Critical, critical.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILogValues)critical.State).Format());
+            Assert.Equal(string.Format(_format, "test1", "test2"), critical.State?.ToString());
             Assert.Equal(0, critical.EventId);
             Assert.Equal(null, critical.Exception);
 
             var debug = sink.Writes[5];
             Assert.Equal(LogLevel.Debug, debug.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILogValues)debug.State).Format());
+            Assert.Equal(string.Format(_format, "test1", "test2"), debug.State?.ToString());
             Assert.Equal(0, debug.EventId);
             Assert.Equal(null, debug.Exception);
         }
@@ -207,37 +207,37 @@ namespace Microsoft.Framework.Logging.Test
 
             var verbose = sink.Writes[0];
             Assert.Equal(LogLevel.Verbose, verbose.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILogValues)verbose.State).Format());
+            Assert.Equal(string.Format(_format, "test1", "test2"), verbose.State?.ToString());
             Assert.Equal(1, verbose.EventId);
             Assert.Equal(null, verbose.Exception);
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILogValues)information.State).Format());
+            Assert.Equal(string.Format(_format, "test1", "test2"), information.State?.ToString());
             Assert.Equal(2, information.EventId);
             Assert.Equal(null, information.Exception);
 
             var warning = sink.Writes[2];
             Assert.Equal(LogLevel.Warning, warning.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILogValues)warning.State).Format());
+            Assert.Equal(string.Format(_format, "test1", "test2"), warning.State?.ToString());
             Assert.Equal(3, warning.EventId);
             Assert.Equal(null, warning.Exception);
 
             var error = sink.Writes[3];
             Assert.Equal(LogLevel.Error, error.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILogValues)error.State).Format());
+            Assert.Equal(string.Format(_format, "test1", "test2"), error.State?.ToString());
             Assert.Equal(4, error.EventId);
             Assert.Equal(null, error.Exception);
 
             var critical = sink.Writes[4];
             Assert.Equal(LogLevel.Critical, critical.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILogValues)critical.State).Format());
+            Assert.Equal(string.Format(_format, "test1", "test2"), critical.State?.ToString());
             Assert.Equal(5, critical.EventId);
             Assert.Equal(null, critical.Exception);
 
             var debug = sink.Writes[5];
             Assert.Equal(LogLevel.Debug, debug.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), ((ILogValues)debug.State).Format());
+            Assert.Equal(string.Format(_format, "test1", "test2"), debug.State?.ToString());
             Assert.Equal(6, debug.EventId);
             Assert.Equal(null, debug.Exception);
         }
@@ -611,7 +611,7 @@ namespace Microsoft.Framework.Logging.Test
             Assert.Equal(1, testSink.Scopes.Count);
             Assert.IsType<FormattedLogValues>(testSink.Scopes[0].Scope);
             var scopeState = (FormattedLogValues)testSink.Scopes[0].Scope;
-            Assert.Equal(expectedStringMessage, scopeState.Format());
+            Assert.Equal(expectedStringMessage, scopeState.ToString());
             var scopeProperties = scopeState.GetValues();
             Assert.NotNull(scopeProperties);
             Assert.Contains(scopeProperties, (kvp) =>
@@ -624,7 +624,7 @@ namespace Microsoft.Framework.Logging.Test
         {
             public int Value { get; set; }
 
-            public override string Format()
+            public override string ToString()
             {
                 return "Test " + Value;
             }

--- a/test/Microsoft.Framework.Logging.Test/SerilogLoggerTest.cs
+++ b/test/Microsoft.Framework.Logging.Test/SerilogLoggerTest.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Framework.Logging.Test
 
             public string Name { get { return _name; } }
 
-            public override string Format()
+            public override string ToString()
             {
                 return string.Format("Scope {0}", Name);
             }
@@ -252,7 +252,7 @@ namespace Microsoft.Framework.Logging.Test
 
             public int LuckyNumber { get { return _luckyNumber; } }
 
-            public override string Format()
+            public override string ToString()
             {
                 return string.Format("Scope {0}", LuckyNumber);
             }


### PR DESCRIPTION
@rynowak @lodejard @Eilon 

Based on the following comment:
https://github.com/aspnet/Diagnostics/pull/113/files#r27738942