### PR TITLE
Handle enumerable value when formatting log values

### DIFF
--- a/src/Microsoft.Framework.Logging.Interfaces/Internal/LogValuesFormatter.cs
+++ b/src/Microsoft.Framework.Logging.Interfaces/Internal/LogValuesFormatter.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Globalization;
 using System.Text;
 
@@ -112,6 +114,32 @@ namespace Microsoft.Framework.Logging.Internal
 
         public string Format(object[] values)
         {
+            if (values != null)
+            {
+                for (int i = 0; i < values.Length; i++)
+                {
+                    var value = values[i];
+
+                    if (value == null)
+                    {
+                        continue;
+                    }
+
+                    // since 'string' implements IEnumerable, special case it
+                    if (value is string)
+                    {
+                        continue;
+                    }
+
+                    // if the value implements IEnumerable, build a comma separated string.
+                    var enumerable = value as IEnumerable;
+                    if (enumerable != null)
+                    {
+                        values[i] = string.Join(", ", enumerable.Cast<object>().Where(obj => obj != null));
+                    }
+                }
+            }
+
             return string.Format(CultureInfo.InvariantCulture, _format, values);
         }
 

--- a/test/Microsoft.Framework.Logging.Test/project.json
+++ b/test/Microsoft.Framework.Logging.Test/project.json
@@ -1,9 +1,10 @@
 {
     "dependencies": {
+        "Microsoft.AspNet.Http.Extensions": "1.0.0-*",
         "Microsoft.Framework.Logging": "1.0.0-*",
         "Microsoft.Framework.Logging.Console": "1.0.0-*",
-        "Microsoft.Framework.Logging.TraceSource": "1.0.0-*",
         "Microsoft.Framework.Logging.Serilog": "1.0.0-*",
+        "Microsoft.Framework.Logging.TraceSource": "1.0.0-*",
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
     },
     "commands": {
@@ -11,7 +12,7 @@
         "test": "xunit.runner.aspnet"
     },
     "frameworks": {
-        "dnx451": { 
+        "dnx451": {
             "dependencies": {
                 "Moq": "4.2.1312.1622"
             }


### PR DESCRIPTION
@rynowak @lodejard @Eilon 

Text loggers like Console use the `Format` method to get the string representation of the log values. The current logic causes `ToString()` to be called on values which implement IEnumerable. This PR handles one level depth of flattening this values for showing in text loggers.

Example scenario(in case when an MVC view is not found, we would like to provide a list of locations that the view was searched for):
```c#
var viewEngineResult = viewEngine.FindView(context, viewName);
if(!viewEngineResult.Success)
{
    logger.LogError(
        "The view '{ViewName}' was not found. Searched locations: {SearchedViewLocations}", 
        viewName,
        viewEngineResult.SearchedLocations);
}
```