### PR TITLE
Replace portable target with netcore451

### DIFF
--- a/src/Microsoft.Framework.Logging.Interfaces/project.json
+++ b/src/Microsoft.Framework.Logging.Interfaces/project.json
@@ -19,7 +19,7 @@
                 "System.Runtime.InteropServices": "4.0.20-beta-*"
             }
         },
-        ".NETPortable,Version=v4.6,Profile=Profile151": {
+        "netcore451": {
             "frameworkAssemblies": {
                 "System.Collections": "",
                 "System.Collections.Concurrent": "",

--- a/src/Microsoft.Framework.Logging/project.json
+++ b/src/Microsoft.Framework.Logging/project.json
@@ -31,7 +31,7 @@
                 "System.Threading": "4.0.10-beta-*"
             }
         },
-        ".NETPortable,Version=v4.6,Profile=Profile151": {
+        "netcore451": {
             "frameworkAssemblies": {
                 "System.Collections": "",
                 "System.Collections.Concurrent": "",


### PR DESCRIPTION
(This will collapse into `core50` when DNX and the Tools for Windows 10 support it.)