### PR TITLE
Using 'nameof' operator instead of magic strings

### DIFF
--- a/src/Microsoft.Framework.Logging.Abstractions/LoggerFactoryExtensions.cs
+++ b/src/Microsoft.Framework.Logging.Abstractions/LoggerFactoryExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Framework.Logging
         {
             if (factory == null)
             {
-                throw new ArgumentNullException("factory");
+                throw new ArgumentNullException(nameof(factory));
             }
 
             return factory.CreateLogger(TypeNameHelper.GetTypeDisplayName(typeof(T), fullName: true));


### PR DESCRIPTION
Using the "nameof" operator instead of magic string will help us if the variable change in the future for whatever the reason