### PR TITLE
Improve compatibility with Serilog

### DIFF
--- a/src/Microsoft.Framework.Logging.Serilog/SerilogLogger.cs
+++ b/src/Microsoft.Framework.Logging.Serilog/SerilogLogger.cs
@@ -88,9 +88,10 @@ namespace Microsoft.Framework.Logging.Serilog
                 case LogLevel.Information:
                     return LogEventLevel.Information;
                 case LogLevel.Verbose:
-                    return LogEventLevel.Verbose;
+                    return LogEventLevel.Debug;
+                case LogLevel.Debug:
                 default:
-                    throw new NotSupportedException();
+                    return LogEventLevel.Verbose;
             }
         }
 

--- a/src/Microsoft.Framework.Logging.Serilog/SerilogLogger.cs
+++ b/src/Microsoft.Framework.Logging.Serilog/SerilogLogger.cs
@@ -44,35 +44,38 @@ namespace Microsoft.Framework.Logging.Serilog
             }
 
             var logger = _logger;
+            string messageTemplate = null;
 
-            var message = string.Empty;
-            if (formatter != null)
+            var structure = state as ILogValues;
+            if (structure != null)
             {
-                message = formatter(state, exception);
+                foreach (var property in structure.GetValues())
+                {
+                    if (property.Key == "{OriginalFormat}" && property.Value is string)
+                    {
+                        messageTemplate = (string)property.Value;
+                    }
+
+                    logger = logger.ForContext(property.Key, property.Value);
+                }
             }
-            else
+
+            if (messageTemplate == null && state != null)
             {
-                message = LogFormatter.Formatter(state, exception);
+                messageTemplate = LogFormatter.Formatter(state, null);
             }
-            if (string.IsNullOrEmpty(message))
+
+            if (string.IsNullOrEmpty(messageTemplate))
             {
                 return;
             }
+
             if (eventId != 0)
             {
                 logger = logger.ForContext("EventId", eventId, false);
             }
-            var structure = state as ILogValues;
-            if (structure != null)
-            {
-                logger = logger.ForContext(new[] { new StructureEnricher(structure) });
-            }
-            if (exception != null)
-            {
-                logger = logger.ForContext(new[] { new ExceptionEnricher(exception) });
-            }
 
-            logger.Write(level, "{Message:l}", message);
+            logger.Write(level, exception, messageTemplate);
         }
 
         private LogEventLevel ConvertLevel(LogLevel logLevel)
@@ -92,51 +95,6 @@ namespace Microsoft.Framework.Logging.Serilog
                 case LogLevel.Debug:
                 default:
                     return LogEventLevel.Verbose;
-            }
-        }
-
-        private class StructureEnricher : ILogEventEnricher
-        {
-            private readonly ILogValues _structure;
-
-            public StructureEnricher(ILogValues structure)
-            {
-                _structure = structure;
-            }
-
-            public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
-            {
-                foreach (var value in _structure.GetValues())
-                {
-                    logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
-                        value.Key,
-                        value.Value));
-                }
-            }
-        }
-
-        private sealed class ExceptionEnricher : ILogEventEnricher
-        {
-            private readonly Exception _exception;
-
-            public ExceptionEnricher(Exception exception)
-            {
-                _exception = exception;
-            }
-
-            public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
-            {
-                logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
-                    "Exception",
-                    _exception.ToString()));
-
-                logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
-                    "ExceptionType",
-                    _exception.GetType().FullName));
-
-                logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
-                    "ExceptionMessage",
-                    _exception.Message));
             }
         }
     }

--- a/src/Microsoft.Framework.Logging.Serilog/project.json
+++ b/src/Microsoft.Framework.Logging.Serilog/project.json
@@ -3,7 +3,7 @@
     "dependencies": {
         "Microsoft.Framework.Logging.Abstractions": "1.0.0-*",
         "Microsoft.Framework.NotNullAttribute.Sources": { "type": "build", "version": "1.0.0-*" },
-        "Serilog": "1.4.14"
+        "Serilog": "1.5.5"
     },
     "frameworks": {
         "dnx451": {

--- a/test/Microsoft.Framework.Logging.Test/SerilogLoggerTest.cs
+++ b/test/Microsoft.Framework.Logging.Test/SerilogLoggerTest.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Framework.Logging.Test
         public void LogsCorrectLevel()
         {
             // Arrange
-            var t = SetUp(LogLevel.Verbose);
+            var t = SetUp(LogLevel.Debug);
             var logger = t.Item1;
             var sink = t.Item2;
 

--- a/test/Microsoft.Framework.Logging.Test/SerilogLoggerTest.cs
+++ b/test/Microsoft.Framework.Logging.Test/SerilogLoggerTest.cs
@@ -37,8 +37,10 @@ namespace Microsoft.Framework.Logging.Test
         {
             switch (logLevel)
             {
-                case LogLevel.Verbose:
+                case LogLevel.Debug:
                     return serilog.MinimumLevel.Verbose();
+                case LogLevel.Verbose:
+                    return serilog.MinimumLevel.Debug();
                 case LogLevel.Information:
                     return serilog.MinimumLevel.Information();
                 case LogLevel.Warning:

--- a/test/Microsoft.Framework.Logging.Test/SerilogLoggerTest.cs
+++ b/test/Microsoft.Framework.Logging.Test/SerilogLoggerTest.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Framework.Logging.Test
             var sink = t.Item2;
 
             // Act
+            logger.Log(LogLevel.Debug, 0, _state, null, null);
             logger.Log(LogLevel.Verbose, 0, _state, null, null);
             logger.Log(LogLevel.Information, 0, _state, null, null);
             logger.Log(LogLevel.Warning, 0, _state, null, null);
@@ -85,12 +86,13 @@ namespace Microsoft.Framework.Logging.Test
             logger.Log(LogLevel.Critical, 0, _state, null, null);
 
             // Assert
-            Assert.Equal(5, sink.Writes.Count);
+            Assert.Equal(6, sink.Writes.Count);
             Assert.Equal(LogEventLevel.Verbose, sink.Writes[0].Level);
-            Assert.Equal(LogEventLevel.Information, sink.Writes[1].Level);
-            Assert.Equal(LogEventLevel.Warning, sink.Writes[2].Level);
-            Assert.Equal(LogEventLevel.Error, sink.Writes[3].Level);
-            Assert.Equal(LogEventLevel.Fatal, sink.Writes[4].Level);
+            Assert.Equal(LogEventLevel.Debug, sink.Writes[1].Level);
+            Assert.Equal(LogEventLevel.Information, sink.Writes[2].Level);
+            Assert.Equal(LogEventLevel.Warning, sink.Writes[3].Level);
+            Assert.Equal(LogEventLevel.Error, sink.Writes[4].Level);
+            Assert.Equal(LogEventLevel.Fatal, sink.Writes[5].Level);
         }
 
         [Theory]
@@ -147,14 +149,10 @@ namespace Microsoft.Framework.Logging.Test
             // Act
             logger.Log(LogLevel.Information, 0, null, null, null);
             logger.Log(LogLevel.Information, 0, _state, null, null);
-            logger.Log(LogLevel.Information, 0, _state, exception, null);
-            logger.Log(LogLevel.Information, 0, _state, exception, TheMessageAndError);
 
             // Assert
-            Assert.Equal(3, sink.Writes.Count);
+            Assert.Equal(1, sink.Writes.Count);
             Assert.Equal(_state, sink.Writes[0].RenderMessage());
-            Assert.Equal(_state + Environment.NewLine + exception, sink.Writes[1].RenderMessage());
-            Assert.Equal(TheMessageAndError(_state, exception), sink.Writes[2].RenderMessage());
         }
 
         [Fact]


### PR DESCRIPTION
This PR improves support for Serilog as a logging target. The changes are in the `Microsoft.Framework.Logging.Serilog` adapter only.

There are a few changes rolled up here; I'm happy to split/squash/etc. as needed but thought I'd get the ball rolling and some feedback first.

The PR:

 1. Fixes support for the ASP.NET `Debug` level and avoids a `NotSupportedException`
 2. Uses the Serilog pipeline for message template formatting
 3. Uses the Serilog pipeline for exception processing
 4. Updates the Serilog package dependency to 1.5 (latest)

Of these, 1 & 4 are fairly self-explanatory - details of 2 & 3 below.

### Message template formatting

ASP.NET Logging supports `"Serilog-style {Message} templates"` but uses its own formatting infrastructure to process these. In console/file output the difference is pretty much indistinguishable, but elsewhere this makes for a second-class Serilog experience.

Here's a "before" shot of the sample app, using the [Literate Console](https://github.com/serilog/serilog-sinks-literate) sink which colors output via type information:

![image](https://cloud.githubusercontent.com/assets/342712/7586104/bfa2f220-f8ec-11e4-8260-e59d0d7d6c84.png)

All of the messages show in blue because they're just strings; the "after" shot shows the difference, especially in the second message:

![image](https://cloud.githubusercontent.com/assets/342712/7586144/0e77351e-f8ed-11e4-9e2f-7d38baed79b0.png)

The example shows a cosmetic difference - it's nice to have a guide to what parts of a log event are going to be easily queryable later on - but other impacts are more fundamental to Serilog's usability.

For example, it's intended a Serilog user can silence an unwanted event with code like:

```csharp
    .Filter.ByExcluding(le => {
        return le.MessageTemplate.Text == "Very {Noisy} Event";
    })
```

In effect:

> _the message template is Serilog's internal representation of the event type_

The unmodified integration does not support this because all events use the same `"{Message:l}"` template.

The change made here to fix this does so by ignoring ASP.NET's built-in formatting; good compatibility with Serilog seems like a reasonable trade-off here.

(Sinks that are bandwidth-constrained will also benefit from removing the duplicated copy of each element of the message.)

### Exception processing

Serilog has its own processing pipeline that allows users to serialize/interrogate exceptions for their own purposes, and many sinks have special handling for exceptions attached to log events. (You can see a trivial case again in the screenshots above.)

The unmodified integration formats the exception into the message text, and adds some helper properties to get back some of the structured exception data. This bloats the log event payload, and will also create headaches for log searches when some of an application's exceptions are logged via the standard property, and some use the ones introduced by ASP.NET.

The PR removes this and passes the exception through as-is, an approach enabled by the move away from built-in formatting discussed above.

### Caveats

The change to property enrichment filters out the` "{OriginalFormat}"` property while stacking `ForContext()` calls; I don't think this will perform measurably worse than the eariler enricher-based version, but if optimization has been done here I can take it back in the custom-enricher direction

Anyone already dependent on the `"Exception`", `"ExceptionMessage"` and `"ExceptionType"` properties can get them back by adding the enricher below:

```csharp
class AspNetStyleExceptionEnricher : ILogEventEnricher
{
    public void Enrich(ILogEvent logEvent, ILogEventPropertyFactory propertyFactory)
    {
        if (logEvent.Exception == null)
        {
            return;
        }

        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
                    "Exception",
                    exception.ToString()));

        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
                    "ExceptionType",
                    exception.GetType().FullName));

        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
                    "ExceptionMessage",
                    exception.Message));
    }
}
```

