### PR TITLE
Add Serilog provider link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ Travis:   [![Travis](https://travis-ci.org/aspnet/Logging.svg?branch=dev)](https
 Contains common logging abstractions for ASP.NET 5. Refer to the [wiki](https://github.com/aspnet/Logging/wiki) for more information
 
 This project is part of ASP.NET 5. You can find samples, documentation and getting started instructions for ASP.NET 5 at the [Home](https://github.com/aspnet/home) repo.
+
+### Providers
+
+Community projects adapt _Microsoft.Framework.Logging_ for use with different back-ends.
+
+ * [Serilog](https://github.com/serilog/serilog-framework-logging) - provider for the Serilog library


### PR DESCRIPTION
Adds a link to the Serilog provider based on the original _Microsoft.Framework.Logging.Serilog_ sample.