### PR TITLE
NLogLogger: added Debug LogLevel, mapped Verbose to Trace

### DIFF
--- a/src/Microsoft.Framework.Logging.NLog/NLogLoggerProvider.cs
+++ b/src/Microsoft.Framework.Logging.NLog/NLogLoggerProvider.cs
@@ -64,7 +64,8 @@ namespace Microsoft.Framework.Logging.NLog
             {
                 switch (logLevel)
                 {
-                    case LogLevel.Verbose: return global::NLog.LogLevel.Debug;
+                    case LogLevel.Verbose: return global::NLog.LogLevel.Trace;
+                    case LogLevel.Debug: return global::NLog.LogLevel.Debug;
                     case LogLevel.Information: return global::NLog.LogLevel.Info;
                     case LogLevel.Warning: return global::NLog.LogLevel.Warn;
                     case LogLevel.Error: return global::NLog.LogLevel.Error;


### PR DESCRIPTION
Right now any Debug messages (ILogger.LogDebug) are ignored by NLogLogger. But all Verbose messages marked as Debug.