### PR TITLE
Make FormatMessage protected virtual

### DIFF
--- a/src/Microsoft.Framework.Logging.Console/ConsoleLogger.cs
+++ b/src/Microsoft.Framework.Logging.Console/ConsoleLogger.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Framework.Logging.Console
                 SetConsoleColor(logLevel);
                 try
                 {
-                    Console.WriteLine(FormatMessage(logLevel, message));
+                    Console.WriteLine(FormatMessage(logLevel, _name, message));
                 }
                 finally
                 {
@@ -73,10 +73,10 @@ namespace Microsoft.Framework.Logging.Console
             }
         }
 
-        private string FormatMessage(LogLevel logLevel, string message)
+        public virtual string FormatMessage(LogLevel logLevel, string logName, string message)
         {
             var logLevelString = GetRightPaddedLogLevelString(logLevel);
-            return $"{logLevelString}: [{_name}] {message}";
+            return $"{logLevelString}: [{logName}] {message}";
         }
 
         public bool IsEnabled(LogLevel logLevel)


### PR DESCRIPTION
Make `FormatMessage` method protected so that subclasses can override it for adding other useful info like time, and custom prefixes or suffixes without writing another console logger from scratch.

Also abstracted out `GetLogLevelString` as a protected virtual method.