### PR TITLE
Move TraceSourceLoggerProvider to Microsoft.Framework.Logging.TraceSource

### DIFF
--- a/src/Microsoft.Framework.Logging.TraceSource/Internal/TraceSourceScope.cs
+++ b/src/Microsoft.Framework.Logging.TraceSource/Internal/TraceSourceScope.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Diagnostics;
 
-namespace Microsoft.Framework.Logging.Internal
+namespace Microsoft.Framework.Logging.TraceSource.Internal
 {
     /// <summary>
     /// Provides an IDisposable that represents a logical operation scope based on System.Diagnostics LogicalOperationStack

--- a/src/Microsoft.Framework.Logging.TraceSource/TraceSourceFactoryExtensions.cs
+++ b/src/Microsoft.Framework.Logging.TraceSource/TraceSourceFactoryExtensions.cs
@@ -1,9 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Diagnostics;
 using Microsoft.Framework.Internal;
+using Microsoft.Framework.Logging.TraceSource;
 
 namespace Microsoft.Framework.Logging
 {

--- a/src/Microsoft.Framework.Logging.TraceSource/TraceSourceLogger.cs
+++ b/src/Microsoft.Framework.Logging.TraceSource/TraceSourceLogger.cs
@@ -3,15 +3,16 @@
 
 using System;
 using System.Diagnostics;
-using Microsoft.Framework.Logging.Internal;
+using Microsoft.Framework.Logging.TraceSource.Internal;
+using DiagnosticsTraceSource = System.Diagnostics.TraceSource;
 
-namespace Microsoft.Framework.Logging
+namespace Microsoft.Framework.Logging.TraceSource
 {
     internal class TraceSourceLogger : ILogger
     {
-        private readonly TraceSource _traceSource;
+        private readonly DiagnosticsTraceSource _traceSource;
 
-        public TraceSourceLogger(TraceSource traceSource)
+        public TraceSourceLogger(DiagnosticsTraceSource traceSource)
         {
             _traceSource = traceSource;
         }

--- a/test/Microsoft.Framework.Logging.Test/TraceSourceScopeTest.cs
+++ b/test/Microsoft.Framework.Logging.Test/TraceSourceScopeTest.cs
@@ -6,7 +6,7 @@ using Xunit;
 #if DNX451
 using Moq;
 #endif
-using Microsoft.Framework.Logging.Internal;
+using Microsoft.Framework.Logging.TraceSource.Internal;
 
 namespace Microsoft.Framework.Logging.Test
 {


### PR DESCRIPTION
For consistency with the other loggers' namespaces.

Fixes #192