### PR TITLE
Make TraceSourceScope internal

### DIFF
--- a/src/Microsoft.Framework.Logging.TraceSource/TraceSourceLogger.cs
+++ b/src/Microsoft.Framework.Logging.TraceSource/TraceSourceLogger.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using Microsoft.Framework.Logging.TraceSource.Internal;
 using DiagnosticsTraceSource = System.Diagnostics.TraceSource;
 
 namespace Microsoft.Framework.Logging.TraceSource

--- a/src/Microsoft.Framework.Logging.TraceSource/TraceSourceScope.cs
+++ b/src/Microsoft.Framework.Logging.TraceSource/TraceSourceScope.cs
@@ -4,12 +4,12 @@
 using System;
 using System.Diagnostics;
 
-namespace Microsoft.Framework.Logging.TraceSource.Internal
+namespace Microsoft.Framework.Logging.TraceSource
 {
     /// <summary>
     /// Provides an IDisposable that represents a logical operation scope based on System.Diagnostics LogicalOperationStack
     /// </summary>
-    public class TraceSourceScope : IDisposable
+    internal class TraceSourceScope : IDisposable
     {
         // To detect redundant calls
         private bool _isDisposed;

--- a/test/Microsoft.Framework.Logging.Test/TraceSourceScopeTest.cs
+++ b/test/Microsoft.Framework.Logging.Test/TraceSourceScopeTest.cs
@@ -3,9 +3,6 @@
 
 using System.Diagnostics;
 using Xunit;
-#if DNX451
-using Moq;
-#endif
 
 namespace Microsoft.Framework.Logging.Test
 {

--- a/test/Microsoft.Framework.Logging.Test/TraceSourceScopeTest.cs
+++ b/test/Microsoft.Framework.Logging.Test/TraceSourceScopeTest.cs
@@ -6,7 +6,6 @@ using Xunit;
 #if DNX451
 using Moq;
 #endif
-using Microsoft.Framework.Logging.TraceSource.Internal;
 
 namespace Microsoft.Framework.Logging.Test
 {
@@ -20,10 +19,14 @@ namespace Microsoft.Framework.Logging.Test
             var baseState = "base";
             Trace.CorrelationManager.StartLogicalOperation(baseState);
             var state = "1337state7331";
+            
+            var factory = new LoggerFactory();
+            var logger = factory.CreateLogger("Test");
+            factory.AddTraceSource(new SourceSwitch("TestSwitch"), new ConsoleTraceListener());
 
             // Act
             var a = Trace.CorrelationManager.LogicalOperationStack.Peek();
-            var scope = new TraceSourceScope(state);
+            var scope = logger.BeginScopeImpl(state);
             var b = Trace.CorrelationManager.LogicalOperationStack.Peek();
             scope.Dispose();
             var c = Trace.CorrelationManager.LogicalOperationStack.Peek();


### PR DESCRIPTION
I understand the reasoning behind exposing some types publicly under an `*.Internal` namespace (so its available to "use at your own risk"), but I don't think `TraceSourceScope` warrants being public. It's not providing any new functionality that can't be called directly and an instance can be accessed through `ILogger.BeginScopeImpl()`.