### PR TITLE
Remove System.Diagnostics.TraceSource dependency

### DIFF
--- a/src/Microsoft.Framework.Logging/project.json
+++ b/src/Microsoft.Framework.Logging/project.json
@@ -30,7 +30,6 @@
                 "System.Collections.Concurrent": "4.0.10-beta-*",
                 "System.Collections": "4.0.10-beta-*",
                 "System.ComponentModel": "4.0.0-*",
-                "System.Diagnostics.TraceSource": "4.0.0-beta-*",
                 "System.Globalization": "4.0.10-beta-*",
                 "System.Linq": "4.0.0-beta-*",
                 "System.Threading": "4.0.10-beta-*"


### PR DESCRIPTION
It was unused and prevented the package from installing on UWP projects.

@rowanmiller @natemcmaster 