### PR TITLE
Remove design-time facade reference from nupkg on net45

### DIFF
--- a/src/Microsoft.Framework.Logging/project.json
+++ b/src/Microsoft.Framework.Logging/project.json
@@ -17,7 +17,7 @@
     "frameworks": {
         "net45": {
             "frameworkAssemblies": {
-                "System.Collections.Concurrent": ""
+                "System.Collections.Concurrent": { "version": "", "type": "build" }
             }
         },
         "dnx451": {


### PR DESCRIPTION
Fixes aspnet/EntityFramework#2680. See also aspnet/dnx#2031.