### PR TITLE
Tracked scopes

### DIFF
--- a/samples/SampleApp/Program.cs
+++ b/samples/SampleApp/Program.cs
@@ -54,6 +54,14 @@ namespace SampleApp
                 Console.ReadLine();
             }
 
+            Console.WriteLine("Hello World - tracked");
+            using (_logger.BeginTrackedScopeImpl("Main - Tracked", LogLevel.Information, "Start", "End", true))
+            {
+                _logger.LogInformation("Waiting for user input");
+                var userInput = Console.ReadLine();
+                _logger.LogInformation("User input: {0}", userInput);
+            }
+
             var endTime = DateTimeOffset.UtcNow;
             _logger.LogInformation(2, "Stopping at '{StopTime}'", endTime);
 

--- a/src/Microsoft.Framework.Logging.Abstractions/ILogger.cs
+++ b/src/Microsoft.Framework.Logging.Abstractions/ILogger.cs
@@ -34,5 +34,16 @@ namespace Microsoft.Framework.Logging
         /// <param name="state">The identifier for the scope.</param>
         /// <returns>An IDisposable that ends the logical operation scope on dispose.</returns>
         IDisposable BeginScopeImpl(object state);
+
+        /// <summary>
+        /// Begins a logical tracked scope. This will track time elapsed in the scope as well as an enter and exit message.
+        /// </summary>
+        /// <param name="state">The identifier for the scope.</param>
+        /// <param name="endMessage">The message to log when the scope terminates.</param>
+        /// <param name="logLevel">LogLevel to log entry/exit and time taken messages at.</param>
+        /// <param name="startMessage">The message to log at the beginning of the scope.</param>
+        /// <param name="trackTime">Whether or not to log the time elapsed in the scope.</param>
+        /// <returns>An IDisposable that ends the logical operation scope on dispose.</returns>
+        IDisposable BeginTrackedScopeImpl(object state, LogLevel logLevel, string startMessage, string endMessage, bool trackTime);
     }
 }

--- a/src/Microsoft.Framework.Logging.Abstractions/LoggerExtensions.cs
+++ b/src/Microsoft.Framework.Logging.Abstractions/LoggerExtensions.cs
@@ -559,6 +559,29 @@ namespace Microsoft.Framework.Logging
             return logger.BeginScopeImpl(new FormattedLogValues(messageFormat, args));
         }
 
+        /// <summary>
+        /// Creates a scope that will automatically put an Enter/Exit message and track the time the scope is active.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to create the scope in.</param>
+        /// <param name="logLevel">Level to log the enter/exit/time messages at.</param>
+        /// <param name="startMessage">Message to display at the start of the scope.</param>
+        /// <param name="endMessage">Message to display at the end of the scope.</param>
+        /// <param name="trackTime">Whether or not to track and log how long the scope is active.</param>
+        /// <param name="messageFormat">Format string of the scope message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        /// <returns></returns>
+        public static IDisposable BeginTrackedScope(
+            [NotNull] this ILogger logger,
+            [NotNull] LogLevel logLevel,
+            string startMessage,
+            string endMessage,
+            bool trackTime,
+            string messageFormat,
+            params object[] args)
+        {
+            return logger.BeginTrackedScopeImpl(new FormattedLogValues(messageFormat, args), logLevel, startMessage, endMessage, trackTime);
+        }
+
         //------------------------------------------HELPERS------------------------------------------//
 
         private static void Log(

--- a/src/Microsoft.Framework.Logging.Console/ConsoleLogger.cs
+++ b/src/Microsoft.Framework.Logging.Console/ConsoleLogger.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Diagnostics;
 using System.Text;
 using Microsoft.Framework.Logging.Console.Internal;
 
@@ -114,6 +115,13 @@ namespace Microsoft.Framework.Logging.Console
             return new NoopDisposable();
         }
 
+        public IDisposable BeginTrackedScopeImpl(object state, LogLevel logLevel, string startMessage, string endMessage, bool trackTime)
+        {
+            Log(logLevel, 0, startMessage, null, null);
+
+            return new TrackedDisposable(this, logLevel, endMessage, trackTime);
+        }
+
         private void FormatLogValues(StringBuilder builder, ILogValues logValues, int level, bool bullet)
         {
             var values = logValues.GetValues();
@@ -197,6 +205,55 @@ namespace Microsoft.Framework.Logging.Console
         {
             public void Dispose()
             {
+            }
+        }
+
+        private class TrackedDisposable : IDisposable
+        {
+            private readonly ILogger _logger;
+            private readonly string _endMessage;
+            private readonly Stopwatch _stopwatch;
+            private readonly bool _trackTime;
+            private readonly LogLevel _logLevel;
+            private bool _disposed;
+
+            public TrackedDisposable(ILogger logger, LogLevel logLevel, string endMessage, bool trackTime)
+            {
+                _endMessage = endMessage;
+                _logger = logger;
+                _logLevel = logLevel;
+                _trackTime = trackTime;
+
+                if (trackTime)
+                {
+                    _stopwatch = new Stopwatch();
+                    _stopwatch.Start();
+                }
+            }
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (!_disposed)
+                {
+                    if (disposing)
+                    {
+                        if (_endMessage != null && _logger.IsEnabled(_logLevel))
+                        {
+                            _logger.Log(_logLevel, 0, _endMessage, null, null);
+                            if (_trackTime)
+                            {
+                                _logger.Log(_logLevel, 0, $"Elapsed: {_stopwatch.Elapsed}", null, null);
+                            }
+                        }
+                    }
+
+                    _disposed = true;
+                }
+            }
+
+            public void Dispose()
+            {
+                Dispose(true);
             }
         }
     }

--- a/src/Microsoft.Framework.Logging.EventLog/EventLogLogger.cs
+++ b/src/Microsoft.Framework.Logging.EventLog/EventLogLogger.cs
@@ -51,6 +51,13 @@ namespace Microsoft.Framework.Logging.EventLog
             return new NoopDisposable();
         }
 
+        public IDisposable BeginTrackedScopeImpl(object state, LogLevel logLevel, string startMessage, string endMessage, bool trackTime)
+        {
+            Log(logLevel, 0, startMessage, null, null);
+
+            return new TrackedDisposable(this, logLevel, endMessage, trackTime);
+        }
+
         /// <inheritdoc />
         public bool IsEnabled(LogLevel logLevel)
         {
@@ -120,6 +127,55 @@ namespace Microsoft.Framework.Logging.EventLog
         {
             public void Dispose()
             {
+            }
+        }
+
+        private class TrackedDisposable : IDisposable
+        {
+            private readonly ILogger _logger;
+            private readonly string _endMessage;
+            private readonly Stopwatch _stopwatch;
+            private readonly bool _trackTime;
+            private readonly LogLevel _logLevel;
+            private bool _disposed;
+
+            public TrackedDisposable(ILogger logger, LogLevel logLevel, string endMessage, bool trackTime )
+            {
+                _endMessage = endMessage;
+                _logger = logger;
+                _logLevel = logLevel;
+                _trackTime = trackTime;
+
+                if (trackTime)
+                {
+                    _stopwatch = new Stopwatch();
+                    _stopwatch.Start();
+                }
+            }
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (!_disposed)
+                {
+                    if (disposing)
+                    {
+                        if (_endMessage != null && _logger.IsEnabled(_logLevel))
+                        {
+                            _logger.Log(_logLevel, 0, _endMessage, null, null);
+                            if (_trackTime)
+                            {
+                                _logger.Log(_logLevel, 0, $"Elapsed: {_stopwatch.Elapsed}", null, null);
+                            }
+                        }
+                    }
+
+                    _disposed = true;
+                }
+            }
+
+            public void Dispose()
+            {
+                Dispose(true);
             }
         }
     }

--- a/src/Microsoft.Framework.Logging.NLog/NLogLoggerProvider.cs
+++ b/src/Microsoft.Framework.Logging.NLog/NLogLoggerProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using Microsoft.Framework.Internal;
 using NLog;
 
@@ -77,6 +78,67 @@ namespace Microsoft.Framework.Logging.NLog
             public IDisposable BeginScopeImpl([NotNull] object state)
             {
                 return NestedDiagnosticsContext.Push(state.ToString());
+            }
+
+            public IDisposable BeginTrackedScopeImpl(object state, LogLevel logLevel, string startMessage, string endMessage, bool trackTime)
+            {
+                var nlogScope = NestedDiagnosticsContext.Push(state.ToString());
+                Log(logLevel, 0, startMessage, null, null);
+
+                return new TrackedDisposable(this, logLevel, endMessage, trackTime, nlogScope);
+            }
+
+            private class TrackedDisposable : IDisposable
+            {
+                private readonly ILogger _logger;
+                private readonly string _endMessage;
+                private readonly Stopwatch _stopwatch;
+                private readonly bool _trackTime;
+                private readonly LogLevel _logLevel;
+                private readonly IDisposable _nlogScope;
+                private bool _disposed;
+
+                public TrackedDisposable(ILogger logger, LogLevel logLevel, string endMessage, bool trackTime, IDisposable nlogScope)
+                {
+                    _endMessage = endMessage;
+                    _logger = logger;
+                    _logLevel = logLevel;
+                    _nlogScope = nlogScope;
+                    _trackTime = trackTime;
+
+                    if (trackTime)
+                    {
+                        _stopwatch = new Stopwatch();
+                        _stopwatch.Start();
+                    }
+                }
+
+                protected virtual void Dispose(bool disposing)
+                {
+                    if (!_disposed)
+                    {
+                        if (disposing)
+                        {
+                            if (_endMessage != null && _logger.IsEnabled(_logLevel))
+                            {
+                                _logger.Log(_logLevel, 0, _endMessage, null, null);
+                                if (_trackTime)
+                                {
+                                    _logger.Log(_logLevel, 0, $"Elapsed: {_stopwatch.Elapsed}", null, null);
+                                }
+                            }
+                        }
+
+                        _disposed = true;
+                    }
+
+                    _nlogScope.Dispose();
+                }
+
+                public void Dispose()
+                {
+                    Dispose(true);
+                }
             }
         }
     }

--- a/src/Microsoft.Framework.Logging.NLog/project.json
+++ b/src/Microsoft.Framework.Logging.NLog/project.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "Microsoft.Framework.Logging.Abstractions": "1.0.0-*",
         "Microsoft.Framework.NotNullAttribute.Sources": { "type": "build", "version": "1.0.0-*" },
-        "NLog": "3.1.0"
+        "NLog": "3.2.0"
     },
     "frameworks": {
         "net45": { },

--- a/src/Microsoft.Framework.Logging.TraceSource/TraceSourceLogger.cs
+++ b/src/Microsoft.Framework.Logging.TraceSource/TraceSourceLogger.cs
@@ -67,5 +67,12 @@ namespace Microsoft.Framework.Logging.TraceSource
         {
             return new TraceSourceScope(state);
         }
+
+        public IDisposable BeginTrackedScopeImpl(object state, LogLevel logLevel, string startMessage, string endMessage, bool trackTime)
+        {
+            Log(logLevel, 0, startMessage, null, null);
+
+            return new TraceSourceTrackedScope(state, this, logLevel, endMessage, trackTime);
+        }
     }
 }

--- a/src/Microsoft.Framework.Logging.TraceSource/TraceSourceTrackedScope.cs
+++ b/src/Microsoft.Framework.Logging.TraceSource/TraceSourceTrackedScope.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.Framework.Logging.Internal;
+
+namespace Microsoft.Framework.Logging.TraceSource
+{
+    /// <summary>
+    /// Provides an IDisposable that represents a logical operation scope based on System.Diagnostics LogicalOperationStack
+    /// </summary>
+    internal class TraceSourceTrackedScope : IDisposable
+    {
+        // To detect redundant calls
+        private bool _isDisposed;
+        private readonly ILogger _logger;
+        private readonly string _endMessage;
+        private readonly Stopwatch _stopwatch;
+        private readonly bool _trackTime;
+        private readonly LogLevel _logLevel;
+
+
+        /// <summary>
+        /// Pushes state onto the LogicalOperationStack by calling 
+        /// <see cref="Trace.CorrelationManager.StartLogicalOperation(object operationId)"/>
+        /// </summary>
+        /// <param name="state">The state.</param>
+        public TraceSourceTrackedScope(object state, ILogger logger, LogLevel logLevel, string endMessage, bool trackTime)
+        {
+            _endMessage = endMessage;
+            _logger = logger;
+            _logLevel = logLevel;
+            _trackTime = trackTime;
+
+            if (trackTime)
+            {
+                _stopwatch = new Stopwatch();
+                _stopwatch.Start();
+            }
+
+#if NET45 || DNX451
+            Trace.CorrelationManager.StartLogicalOperation(state);
+#endif
+        }
+
+        /// <summary>
+        /// Pops a state off the LogicalOperationStack by calling
+        /// <see cref="Trace.CorrelationManager.StopLogicalOperation()"/>
+        /// </summary>
+        /// <param name="state">The state.</param>
+        public void Dispose()
+        {
+            if (!_isDisposed)
+            {
+#if NET45 || DNX451
+                Trace.CorrelationManager.StopLogicalOperation();
+#endif
+                if (_endMessage != null && _logger.IsEnabled(_logLevel))
+                {
+                    _logger.Log(_logLevel, 0, new FormattedLogValues(_endMessage), null, null);
+                    if (_trackTime)
+                    {
+                        _logger.Log(_logLevel, 0, new FormattedLogValues("{0}", _stopwatch.Elapsed), null, null);
+                    }
+                }
+
+                _isDisposed = true;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Framework.Logging/LoggerOfT.cs
+++ b/src/Microsoft.Framework.Logging/LoggerOfT.cs
@@ -28,6 +28,11 @@ namespace Microsoft.Framework.Logging
             return _logger.BeginScopeImpl(state);
         }
 
+        IDisposable ILogger.BeginTrackedScopeImpl(object state, LogLevel logLevel, string startMessage, string endMessage, bool trackTime)
+        {
+            return _logger.BeginTrackedScopeImpl(state, logLevel, startMessage, endMessage, trackTime);
+        }
+
         bool ILogger.IsEnabled(LogLevel logLevel)
         {
             return _logger.IsEnabled(logLevel);

--- a/test/Microsoft.Framework.Logging.Test/TestLogger.cs
+++ b/test/Microsoft.Framework.Logging.Test/TestLogger.cs
@@ -34,6 +34,21 @@ namespace Microsoft.Framework.Logging.Test
             return null;
         }
 
+        public IDisposable BeginTrackedScopeImpl(object state, LogLevel logLevel, string startMessage, string endMessage, bool trackTime)
+        {
+            _scope = state;
+
+            _sink.Begin(new BeginScopeContext()
+            {
+                LoggerName = _name,
+                Scope = state,
+            });
+
+            Log(logLevel, 0, startMessage, null, null);
+
+            return new TrackedScopeContext(this, logLevel, endMessage, trackTime);
+        }
+
         public void Log(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
         {
             _sink.Write(new WriteContext()

--- a/test/Microsoft.Framework.Logging.Test/TrackedScopeContext.cs
+++ b/test/Microsoft.Framework.Logging.Test/TrackedScopeContext.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Framework.Logging.Internal;
+
+namespace Microsoft.Framework.Logging.Test
+{
+    public class TrackedScopeContext : IDisposable
+    {
+        private readonly ILogger _logger;
+        private readonly string _endMessage;
+        private readonly Stopwatch _stopwatch;
+        private readonly bool _trackTime;
+        private readonly LogLevel _logLevel;
+        private bool _disposed;
+
+        public TrackedScopeContext(ILogger logger, LogLevel logLevel, string endMessage, bool trackTime)
+        {
+            _endMessage = endMessage;
+            _logger = logger;
+            _logLevel = logLevel;
+            _trackTime = trackTime;
+
+            if (trackTime)
+            {
+                _stopwatch = new Stopwatch();
+                _stopwatch.Start();
+            }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    if (_endMessage != null && _logger.IsEnabled(_logLevel))
+                    {
+                        _logger.Log(_logLevel, 0, _endMessage, null, null);
+                        if (_trackTime)
+                        {
+                            _logger.Log(_logLevel, 0, $"Elapsed: {_stopwatch.Elapsed}", null, null);
+                        }
+                    }
+                }
+
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+    }
+}


### PR DESCRIPTION
This adds a very useful feature that we use in our logging where we automatically add Enter/Exit messages and timings to the logging so you can do something like

using (_logger.BeginTrackedScope(LogLevel.Information, "Start", "End", true, "Prefix {0} ", "xxx"))
{
}