### PR TITLE
Fixes issue when logging test fails if console background is not black

### DIFF
--- a/test/Microsoft.Framework.Logging.Test/Console/TestConsole.cs
+++ b/test/Microsoft.Framework.Logging.Test/Console/TestConsole.cs
@@ -8,20 +8,24 @@ namespace Microsoft.Framework.Logging.Test.Console
 {
     public class TestConsole : IConsole
     {
+        public const ConsoleColor DefaultBackgroundColor = ConsoleColor.Black;
+        public const ConsoleColor DefaultForegroundColor = ConsoleColor.Gray;
+
         private ConsoleSink _sink;
-        
+
         public TestConsole(ConsoleSink sink)
         {
             _sink = sink;
         }
 
-        public ConsoleColor BackgroundColor { get; set; }
+        public ConsoleColor BackgroundColor { get; set; } = DefaultBackgroundColor;
 
-        public ConsoleColor ForegroundColor { get; set; }
+        public ConsoleColor ForegroundColor { get; set; } = DefaultForegroundColor;
 
         public void ResetColor()
         {
-            System.Console.ResetColor();
+            BackgroundColor = DefaultBackgroundColor;
+            ForegroundColor = DefaultForegroundColor;
         }
 
         public void WriteLine(string message)

--- a/test/Microsoft.Framework.Logging.Test/ConsoleLoggerTest.cs
+++ b/test/Microsoft.Framework.Logging.Test/ConsoleLoggerTest.cs
@@ -328,7 +328,7 @@ namespace Microsoft.Framework.Logging.Test
             // Assert
             Assert.Equal(1, sink.Writes.Count);
             var write = sink.Writes[0];
-            Assert.Equal(System.Console.BackgroundColor, write.BackgroundColor);
+            Assert.Equal(TestConsole.DefaultBackgroundColor, write.BackgroundColor);
             Assert.Equal(ConsoleColor.Red, write.ForegroundColor);
         }
 
@@ -346,7 +346,7 @@ namespace Microsoft.Framework.Logging.Test
             // Assert
             Assert.Equal(1, sink.Writes.Count);
             var write = sink.Writes[0];
-            Assert.Equal(System.Console.BackgroundColor, write.BackgroundColor);
+            Assert.Equal(TestConsole.DefaultBackgroundColor, write.BackgroundColor);
             Assert.Equal(ConsoleColor.Yellow, write.ForegroundColor);
         }
 
@@ -364,7 +364,7 @@ namespace Microsoft.Framework.Logging.Test
             // Assert
             Assert.Equal(1, sink.Writes.Count);
             var write = sink.Writes[0];
-            Assert.Equal(System.Console.BackgroundColor, write.BackgroundColor);
+            Assert.Equal(TestConsole.DefaultBackgroundColor, write.BackgroundColor);
             Assert.Equal(ConsoleColor.White, write.ForegroundColor);
         }
 
@@ -382,7 +382,7 @@ namespace Microsoft.Framework.Logging.Test
             // Assert
             Assert.Equal(1, sink.Writes.Count);
             var write = sink.Writes[0];
-            Assert.Equal(System.Console.BackgroundColor, write.BackgroundColor);
+            Assert.Equal(TestConsole.DefaultBackgroundColor, write.BackgroundColor);
             Assert.Equal(ConsoleColor.Gray, write.ForegroundColor);
         }
 


### PR DESCRIPTION
TestConsole now has the own implementation of ResetColor() and ConsoleLoggerTest use a TestConsole instead System.Console. This fixes aspnet/Logging#235.