### PR TITLE
LoggingExtensions: Additional methods

### DIFF
--- a/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs
@@ -384,6 +384,18 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
+        /// Formats the given message and error and writes a warning log message.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+        /// <param name="error">The exception to log.</param>
+        /// <param name="format">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void LogWarning(this ILogger logger, Exception error, string format, params object[] args)
+        {
+            logger.Log(LogLevel.Warning, 0, new FormattedLogValues(format, args), error, _messageFormatter);
+        }
+
+        /// <summary>
         /// Formats and writes a warning log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
@@ -398,6 +410,19 @@ namespace Microsoft.Extensions.Logging
             }
 
             logger.Log(LogLevel.Warning, eventId, new FormattedLogValues(format, args), null, _messageFormatter);
+        }
+
+        /// <summary>
+        /// Formats the given message and error and writes a warning log message.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+        /// <param name="eventId">The event id associated with the log.</param>
+        /// <param name="error">The exception to log.</param>
+        /// <param name="format">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void LogWarning(this ILogger logger, int eventId, Exception error, string format, params object[] args)
+        {
+            logger.Log(LogLevel.Warning, eventId, new FormattedLogValues(format, args), error, _messageFormatter);
         }
 
         /// <summary>
@@ -523,6 +548,18 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
+        /// Formats the given message and error and writes an error log message.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+        /// <param name="error">The exception to log.</param>
+        /// <param name="format">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void LogError(this ILogger logger, Exception error, string format, params object[] args)
+        {
+            logger.Log(LogLevel.Error, 0, new FormattedLogValues(format, args), error, _messageFormatter);
+        }
+
+        /// <summary>
         /// Formats and writes an error log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
@@ -537,6 +574,19 @@ namespace Microsoft.Extensions.Logging
             }
 
             logger.Log(LogLevel.Error, eventId, new FormattedLogValues(format, args), null, _messageFormatter);
+        }
+
+        /// <summary>
+        /// Formats the given message and error and writes an error log message.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+        /// <param name="eventId">The event id associated with the log.</param>
+        /// <param name="error">The exception to log.</param>
+        /// <param name="format">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void LogError(this ILogger logger, int eventId, Exception error, string format, params object[] args)
+        {
+            logger.Log(LogLevel.Error, eventId, new FormattedLogValues(format, args), error, _messageFormatter);
         }
 
         /// <summary>
@@ -662,6 +712,18 @@ namespace Microsoft.Extensions.Logging
         }
 
         /// <summary>
+        /// Formats the given message and error and writes a critical log message.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+        /// <param name="error">The exception to log.</param>
+        /// <param name="format">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void LogCritical(this ILogger logger, Exception error, string format, params object[] args)
+        {
+            logger.Log(LogLevel.Critical, 0, new FormattedLogValues(format, args), error, _messageFormatter);
+        }
+
+        /// <summary>
         /// Formats and writes a critical log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
@@ -676,6 +738,19 @@ namespace Microsoft.Extensions.Logging
             }
 
             logger.Log(LogLevel.Critical, eventId, new FormattedLogValues(format, args), null, _messageFormatter);
+        }
+
+        /// <summary>
+        /// Formats the given message and error and writes a critical log message.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+        /// <param name="eventId">The event id associated with the log.</param>
+        /// <param name="error">The exception to log.</param>
+        /// <param name="format">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void LogCritical(this ILogger logger, int eventId, Exception error, string format, params object[] args)
+        {
+            logger.Log(LogLevel.Critical, eventId, new FormattedLogValues(format, args), error, _messageFormatter);
         }
 
         /// <summary>

--- a/test/Microsoft.Extensions.Logging.Test/LoggerExtensionsTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/LoggerExtensionsTest.cs
@@ -277,6 +277,40 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Fact]
+        public void FormatMessageAndError_LogsCorrectValues()
+        {
+            // Arrange
+            var sink = new TestSink();
+            var logger = SetUp(sink);
+
+            // Act
+            logger.LogWarning(_exception, _format, "test1", "test2");
+            logger.LogError(_exception, _format, "test1", "test2");
+            logger.LogCritical(_exception, _format, "test1", "test2");
+
+            // Assert
+            Assert.Equal(3, sink.Writes.Count);
+            
+            var warning = sink.Writes[0];
+            Assert.Equal(LogLevel.Warning, warning.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), warning.State?.ToString());
+            Assert.Equal(0, warning.EventId);
+            Assert.Equal(_exception, warning.Exception);
+
+            var error = sink.Writes[1];
+            Assert.Equal(LogLevel.Error, error.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), error.State?.ToString());
+            Assert.Equal(0, error.EventId);
+            Assert.Equal(_exception, error.Exception);
+
+            var critical = sink.Writes[2];
+            Assert.Equal(LogLevel.Critical, critical.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), critical.State?.ToString());
+            Assert.Equal(0, critical.EventId);
+            Assert.Equal(_exception, critical.Exception);
+        }
+
+        [Fact]
         public void MessageEventIdAndError_LogsCorrectValues()
         {
             // Arrange
@@ -306,6 +340,40 @@ namespace Microsoft.Extensions.Logging.Test
             var critical = sink.Writes[2];
             Assert.Equal(LogLevel.Critical, critical.LogLevel);
             Assert.Equal(_state, critical.State);
+            Assert.Equal(5, critical.EventId);
+            Assert.Equal(_exception, critical.Exception);
+        }
+
+        [Fact]
+        public void FormatMessageEventIdAndError_LogsCorrectValues()
+        {
+            // Arrange
+            var sink = new TestSink();
+            var logger = SetUp(sink);
+
+            // Act
+            logger.LogWarning(3, _exception, _format, "test1", "test2");
+            logger.LogError(4, _exception, _format, "test1", "test2");
+            logger.LogCritical(5, _exception, _format, "test1", "test2");
+            
+            // Assert
+            Assert.Equal(3, sink.Writes.Count);
+
+            var warning = sink.Writes[0];
+            Assert.Equal(LogLevel.Warning, warning.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), warning.State?.ToString());
+            Assert.Equal(3, warning.EventId);
+            Assert.Equal(_exception, warning.Exception);
+
+            var error = sink.Writes[1];
+            Assert.Equal(LogLevel.Error, error.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), error.State?.ToString());
+            Assert.Equal(4, error.EventId);
+            Assert.Equal(_exception, error.Exception);
+
+            var critical = sink.Writes[2];
+            Assert.Equal(LogLevel.Critical, critical.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), critical.State?.ToString());
             Assert.Equal(5, critical.EventId);
             Assert.Equal(_exception, critical.Exception);
         }


### PR DESCRIPTION
LoggingExtensions will benefit from being able to log Exceptions and messages with format values separately to allow the underlying logging framework to format the exception differently than the message, for example to support extracting the stack trace for structured logging.

This change resolves aspnet/Logging#239.