### PR TITLE
[Fixes #247] ConsoleLogger doesn't use LoggerFactory.MinimumLevel by …

### DIFF
--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerFactoryExtensions.cs
@@ -13,8 +13,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         public static ILoggerFactory AddConsole(this ILoggerFactory factory)
         {
-            factory.AddProvider(new ConsoleLoggerProvider((category, logLevel) => logLevel >= LogLevel.Information));
-            return factory;
+            return factory.AddConsole(factory.MinimumLevel);
         }
 
         /// <summary>

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerProvider.cs
@@ -7,16 +7,17 @@ namespace Microsoft.Extensions.Logging.Console
 {
     public class ConsoleLoggerProvider : ILoggerProvider
     {
-        private readonly Func<string, LogLevel, bool> _filter;
-
         public ConsoleLoggerProvider(Func<string, LogLevel, bool> filter)
         {
-            _filter = filter;
+            Filter = filter;
         }
+
+        // to enable unit testing
+        internal Func<string, LogLevel, bool> Filter { get; }
 
         public ILogger CreateLogger(string name)
         {
-            return new ConsoleLogger(name, _filter);
+            return new ConsoleLogger(name, Filter);
         }
 
         public void Dispose()

--- a/src/Microsoft.Extensions.Logging.Console/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Extensions.Logging.Console/Properties/AssemblyInfo.cs
@@ -3,6 +3,8 @@
 
 using System.Reflection;
 using System.Resources;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: NeutralResourcesLanguage("en-us")]
+[assembly: InternalsVisibleTo("Microsoft.Extensions.Logging.Test")]

--- a/src/Microsoft.Extensions.Logging.Debug/DebugLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Debug/DebugLoggerFactoryExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory">The extension method argument.</param>
         public static ILoggerFactory AddDebug(this ILoggerFactory factory)
         {
-            return AddDebug(factory, LogLevel.Information);
+            return AddDebug(factory, factory.MinimumLevel);
         }
 
         /// <summary>

--- a/src/Microsoft.Extensions.Logging.Debug/DebugLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Debug/DebugLoggerProvider.cs
@@ -10,25 +10,26 @@ namespace Microsoft.Extensions.Logging.Debug
     /// </summary>
     public class DebugLoggerProvider : ILoggerProvider
     {
-        private readonly Func<string, LogLevel, bool> _filter;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DebugLoggerProvider"/> class.
         /// </summary>
         /// <param name="filter">The function used to filter events based on the log level.</param>
         public DebugLoggerProvider(Func<string, LogLevel, bool> filter)
         {
-            _filter = filter;
+            Filter = filter;
         }
 
-        /// <inheritdoc /> 
+        // to enable unit testing
+        internal Func<string, LogLevel, bool> Filter { get; }
+
+        /// <inheritdoc />
         public ILogger CreateLogger(string name)
         {
-            return new DebugLogger(name, _filter);
+            return new DebugLogger(name, Filter);
         }
 
         public void Dispose()
-        {            
+        {
         }
     }
 }

--- a/src/Microsoft.Extensions.Logging.Debug/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Extensions.Logging.Debug/Properties/AssemblyInfo.cs
@@ -3,6 +3,8 @@
 
 using System.Reflection;
 using System.Resources;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: NeutralResourcesLanguage("en-us")]
+[assembly: InternalsVisibleTo("Microsoft.Extensions.Logging.Test")]

--- a/src/Microsoft.Extensions.Logging.EventLog/EventLogLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/EventLogLoggerProvider.cs
@@ -10,8 +10,6 @@ namespace Microsoft.Extensions.Logging.EventLog
     /// </summary>
     public class EventLogLoggerProvider : ILoggerProvider
     {
-        private readonly EventLogSettings _settings;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="EventLogLoggerProvider"/> class.
         /// </summary>
@@ -26,13 +24,16 @@ namespace Microsoft.Extensions.Logging.EventLog
         /// <param name="settings">The <see cref="EventLogSettings"/>.</param>
         public EventLogLoggerProvider(EventLogSettings settings)
         {
-            _settings = settings;
+            Settings = settings;
         }
+
+        // to enable unit testing
+        internal EventLogSettings Settings { get; }
 
         /// <inheritdoc />
         public ILogger CreateLogger(string name)
         {
-            return new EventLogLogger(name, _settings ?? new EventLogSettings());
+            return new EventLogLogger(name, Settings ?? new EventLogSettings());
         }
 
         public void Dispose()

--- a/src/Microsoft.Extensions.Logging.EventLog/EventLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/EventLoggerFactoryExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Logging
                 throw new ArgumentNullException(nameof(factory));
             }
 
-            return AddEventLog(factory, LogLevel.Information);
+            return AddEventLog(factory, factory.MinimumLevel);
         }
 
         /// <summary>

--- a/src/Microsoft.Extensions.Logging.EventLog/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/Properties/AssemblyInfo.cs
@@ -3,6 +3,8 @@
 
 using System.Reflection;
 using System.Resources;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: NeutralResourcesLanguage("en-us")]
+[assembly: InternalsVisibleTo("Microsoft.Extensions.Logging.Test")]

--- a/src/Microsoft.Extensions.Logging/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Extensions.Logging/Properties/AssemblyInfo.cs
@@ -3,6 +3,8 @@
 
 using System.Reflection;
 using System.Resources;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: NeutralResourcesLanguage("en-us")]
+[assembly: InternalsVisibleTo("Microsoft.Extensions.Logging.Test")]

--- a/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Globalization;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Logging.Test.Console;
@@ -447,6 +448,33 @@ namespace Microsoft.Extensions.Logging.Test
 
             // Assert
             Assert.NotNull(disposable);
+        }
+
+        [Fact]
+        public void ConsoleLoggerProvider_UsesLoggerFactoryDefault_MinimumLevel()
+        {
+            // Arrange
+            var loggerFactory = new LoggerFactory();
+            var minimumLogLevel = loggerFactory.MinimumLevel;
+
+            // Act
+            loggerFactory.AddConsole();
+
+            // Assert
+            var providers = loggerFactory.GetProviders();
+            var consoleProvider = Assert.IsType<ConsoleLoggerProvider>(providers.FirstOrDefault());
+            var filter = consoleProvider.Filter;
+            Assert.NotNull(filter);
+            Assert.True(filter("testlogger", minimumLogLevel));
+
+            // less than minimum log level
+            LogLevel level;
+            Assert.True(Enum.TryParse(Enum.GetName(typeof(LogLevel), (int)minimumLogLevel - 1), out level));
+            Assert.False(filter("testlogger", level));
+
+            // more than minimum log level
+            Assert.True(Enum.TryParse(Enum.GetName(typeof(LogLevel), (int)minimumLogLevel + 1), out level));
+            Assert.True(filter("testlogger", level));
         }
 
         private string getMessage(string logLevelString, Exception exception)

--- a/test/Microsoft.Extensions.Logging.Test/DebugLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/DebugLoggerTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using Microsoft.Extensions.Logging.Debug;
 using Xunit;
 
@@ -35,6 +37,33 @@ namespace Microsoft.Extensions.Logging
 
             // Assert
             Assert.NotNull(disposable);
+        }
+
+        [Fact]
+        public void DebugLoggerProvider_UsesLoggerFactoryDefault_MinimumLevel()
+        {
+            // Arrange
+            var loggerFactory = new LoggerFactory();
+            var minimumLogLevel = loggerFactory.MinimumLevel;
+
+            // Act
+            loggerFactory.AddDebug();
+
+            // Assert
+            var providers = loggerFactory.GetProviders();
+            var debugLogProvider = Assert.IsType<DebugLoggerProvider>(providers.FirstOrDefault());
+            var filter = debugLogProvider.Filter;
+            Assert.NotNull(filter);
+            Assert.True(filter("testlogger", minimumLogLevel));
+
+            // less than minimum log level
+            LogLevel level;
+            Assert.True(Enum.TryParse(Enum.GetName(typeof(LogLevel), (int)minimumLogLevel - 1), out level));
+            Assert.False(filter("testlogger", level));
+
+            // more than minimum log level
+            Assert.True(Enum.TryParse(Enum.GetName(typeof(LogLevel), (int)minimumLogLevel + 1), out level));
+            Assert.True(filter("testlogger", level));
         }
     }
 }


### PR DESCRIPTION
@Eilon @AspNetSmurfLab Currently, the default level on logger factory is `Verbose`, which we want to change to `Information`, right? https://github.com/aspnet/Logging/blob/dev/src/Microsoft.Extensions.Logging/LoggerFactory.cs#L34

