### PR TITLE
Add IncludeTimestamp and TimestampFormat

### DIFF
--- a/samples/SampleApp/Program.cs
+++ b/samples/SampleApp/Program.cs
@@ -25,7 +25,7 @@ namespace SampleApp
             // providers may be added to an ILoggerFactory at any time, existing ILoggers are updated
 #if !DNXCORE50
             factory.AddNLog(new global::NLog.LogFactory());
-            factory.AddEventLog();
+            //factory.AddEventLog();
 #endif
 
             // How to configure the console logger to reload based on a configuration file.
@@ -67,6 +67,8 @@ namespace SampleApp
             public IChangeToken ChangeToken { get; private set; }
 
             public bool IncludeScopes { get; }
+            public string TimestampFormat { get; }
+            public bool IncludeTimestamp => DateTime.Now.Second % 2 == 0;
 
             private Dictionary<string, LogLevel> Switches { get; set; }
 

--- a/samples/SampleApp/logging.json
+++ b/samples/SampleApp/logging.json
@@ -1,5 +1,7 @@
 ﻿{
-  "IncludeScopes" : "false",
+  "IncludeScopes": "true",
+  "IncludeTimestamp": "true",
+  "TimestampFormat": "s",
   "LogLevel": {
     "Default": "Verbose",
     "System": "Information",

--- a/src/Microsoft.Extensions.Logging.Console/ConfigurationConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConfigurationConsoleLoggerSettings.cs
@@ -19,6 +19,30 @@ namespace Microsoft.Extensions.Logging.Console
 
         public IChangeToken ChangeToken { get; private set; }
 
+        public string TimestampFormat => _configuration["TimestampFormat"];
+
+        public bool IncludeTimestamp
+        {
+            get
+            {
+                bool includeTimestamp;
+                var value = _configuration["IncludeTimestamp"];
+                if (string.IsNullOrEmpty(value))
+                {
+                    return false;
+                }
+                else if (bool.TryParse(value, out includeTimestamp))
+                {
+                    return includeTimestamp;
+                }
+                else
+                {
+                    var message = $"Configuration value '{value}' for setting '{nameof(IncludeTimestamp)}' is not supported.";
+                    throw new InvalidOperationException(message);
+                }
+            }
+        }
+
         public bool IncludeScopes
         {
             get

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.Logging.Console
             _messagePadding = new string(' ', logLevelString.Length + _loglevelPadding.Length);
         }
 
-        public ConsoleLogger(string name, Func<string, LogLevel, bool> filter, bool includeScopes)
+        public ConsoleLogger(string name, Func<string, LogLevel, bool> filter, bool includeScopes, bool includeTimestamp, string timeStampFormat)
         {
             if (name == null)
             {
@@ -41,6 +41,8 @@ namespace Microsoft.Extensions.Logging.Console
             Name = name;
             Filter = filter ?? ((category, logLevel) => true);
             IncludeScopes = includeScopes;
+            IncludeTimestamp = includeTimestamp;
+            TimeStampFormat = timeStampFormat;
 
             if (RuntimeEnvironmentHelper.IsWindows)
             {
@@ -81,6 +83,9 @@ namespace Microsoft.Extensions.Logging.Console
         }
 
         public bool IncludeScopes { get; set; }
+        public bool IncludeTimestamp { get; set; }
+        public string TimeStampFormat { get; set; }
+        public string TimestampFormat { get; set; }
 
         public string Name { get; }
 
@@ -144,10 +149,18 @@ namespace Microsoft.Extensions.Logging.Console
 
                 // category and event id
                 // use default colors
+
+                var header = new StringBuilder(_loglevelPadding);
+                if (IncludeTimestamp)
+                {
+                    header.Append($"[{DateTime.Now.ToString(TimeStampFormat)}] ");
+                }
+                header.Append(logName + $"[{eventId}]");
+
                 WriteWithColor(
                     ConsoleColor.Gray,
                     DefaultConsoleColor,
-                    _loglevelPadding + logName + $"[{eventId}]",
+                    header.ToString(),
                     newLine: true);
 
                 // scope information

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerFactoryExtensions.cs
@@ -25,13 +25,14 @@ namespace Microsoft.Extensions.Logging
         /// in the output.</param>
         public static ILoggerFactory AddConsole(this ILoggerFactory factory, bool includeScopes)
         {
-            factory.AddConsole((n, l) => l >= LogLevel.Information, includeScopes);
+            factory.AddConsole((n, l) => l >= LogLevel.Information, includeScopes, includeTimestamp: false);
             return factory;
         }
 
         /// <summary>
         /// Adds a console logger that is enabled for <see cref="LogLevel"/>s of minLevel or higher.
         /// </summary>
+        /// <param name="factory"></param>
         /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged</param>
         public static ILoggerFactory AddConsole(this ILoggerFactory factory, LogLevel minLevel)
         {
@@ -51,7 +52,7 @@ namespace Microsoft.Extensions.Logging
             LogLevel minLevel,
             bool includeScopes)
         {
-            factory.AddConsole((category, logLevel) => logLevel >= minLevel, includeScopes);
+            factory.AddConsole((category, logLevel) => logLevel >= minLevel, includeScopes, includeTimestamp: false);
             return factory;
         }
 
@@ -64,7 +65,7 @@ namespace Microsoft.Extensions.Logging
             this ILoggerFactory factory,
             Func<string, LogLevel, bool> filter)
         {
-            factory.AddConsole(filter, includeScopes: false);
+            factory.AddConsole(filter, includeScopes: false, includeTimestamp: false);
             return factory;
         }
 
@@ -75,12 +76,13 @@ namespace Microsoft.Extensions.Logging
         /// <param name="filter"></param>
         /// <param name="includeScopes">A value which indicates whether log scope information should be displayed
         /// in the output.</param>
+        /// <param name="includeTimestamp"></param>
         public static ILoggerFactory AddConsole(
             this ILoggerFactory factory,
             Func<string, LogLevel, bool> filter,
-            bool includeScopes)
+            bool includeScopes, bool includeTimestamp)
         {
-            factory.AddProvider(new ConsoleLoggerProvider(filter, includeScopes));
+            factory.AddProvider(new ConsoleLoggerProvider(filter, includeScopes, includeTimestamp));
             return factory;
         }
 

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerSettings.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Extensions.Logging.Console
         public IChangeToken ChangeToken { get; set; }
 
         public bool IncludeScopes { get; set; }
+        public string TimestampFormat { get; set; } = "s";
+        public bool IncludeTimestamp { get; set; }
 
         public IDictionary<string, LogLevel> Switches { get; set; } = new Dictionary<string, LogLevel>();
 

--- a/src/Microsoft.Extensions.Logging.Console/IConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/IConsoleLoggerSettings.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Extensions.Logging.Console
         bool IncludeScopes { get; }
 
         IChangeToken ChangeToken { get; }
+        string TimestampFormat { get; }
+
+        bool IncludeTimestamp { get; }
 
         bool TryGetSwitch(string name, out LogLevel level);
 

--- a/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.Logging.Test
             // Arrange
             var sink = new ConsoleSink();
             var console = new TestConsole(sink);
-            var logger = new ConsoleLogger(_loggerName, filter, includeScopes, includeTimestamp);
+            var logger = new ConsoleLogger(_loggerName, filter, includeScopes, includeTimestamp, null);
             logger.Console = console;
             return new Tuple<ConsoleLogger, ConsoleSink>(logger, sink);
         }

--- a/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
@@ -746,8 +746,8 @@ namespace Microsoft.Extensions.Logging.Test
             public IDictionary<string, LogLevel> Switches { get; } = new Dictionary<string, LogLevel>();
 
             public bool IncludeScopes { get; set; }
-            string TimestampFormat { get; set; }
-            bool IncludeTimestamp { get; set; }
+            public string TimestampFormat { get; set; }
+            public bool IncludeTimestamp { get; set; }
 
             public IConsoleLoggerSettings Reload()
             {

--- a/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
@@ -22,12 +22,12 @@ namespace Microsoft.Extensions.Logging.Test
         private const string _state = "This is a test, and {curly braces} are just fine!";
         private readonly Func<object, Exception, string> _theMessageAndError;
 
-        private Tuple<ConsoleLogger, ConsoleSink> SetUp(Func<string, LogLevel, bool> filter, bool includeScopes = false)
+        private Tuple<ConsoleLogger, ConsoleSink> SetUp(Func<string, LogLevel, bool> filter, bool includeScopes = false, bool includeTimestamp = false)
         {
             // Arrange
             var sink = new ConsoleSink();
             var console = new TestConsole(sink);
-            var logger = new ConsoleLogger(_loggerName, filter, includeScopes);
+            var logger = new ConsoleLogger(_loggerName, filter, includeScopes, includeTimestamp);
             logger.Console = console;
             return new Tuple<ConsoleLogger, ConsoleSink>(logger, sink);
         }
@@ -746,6 +746,8 @@ namespace Microsoft.Extensions.Logging.Test
             public IDictionary<string, LogLevel> Switches { get; } = new Dictionary<string, LogLevel>();
 
             public bool IncludeScopes { get; set; }
+            string TimestampFormat { get; set; }
+            bool IncludeTimestamp { get; set; }
 
             public IConsoleLoggerSettings Reload()
             {


### PR DESCRIPTION
ConsoleLogger now has the capability to include timestamps along with the message and with the optional format. 