### PR TITLE
Removing MinimumLevel from ILoggerFactory #298

### DIFF
--- a/src/Microsoft.Extensions.Logging.Abstractions/ILoggerFactory.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/ILoggerFactory.cs
@@ -12,11 +12,6 @@ namespace Microsoft.Extensions.Logging
     public interface ILoggerFactory : IDisposable
     {
         /// <summary>
-        /// The minimum level of log messages sent to loggers.
-        /// </summary>
-        LogLevel MinimumLevel { get; set; }
-
-        /// <summary>
         /// Creates a new <see cref="ILogger"/> instance.
         /// </summary>
         /// <param name="categoryName">The category name for messages produced by the logger.</param>

--- a/src/Microsoft.Extensions.Logging.Testing/NullLoggerFactory.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/NullLoggerFactory.cs
@@ -1,15 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.Extensions.Logging.Testing
 {
     public class NullLoggerFactory : ILoggerFactory
     {
         public static readonly NullLoggerFactory Instance = new NullLoggerFactory();
-
-        public LogLevel MinimumLevel { get; set; } = LogLevel.Verbose;
 
         public ILogger CreateLogger(string name)
         {

--- a/src/Microsoft.Extensions.Logging.Testing/TestLoggerFactory.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/TestLoggerFactory.cs
@@ -16,8 +16,6 @@ namespace Microsoft.Extensions.Logging.Testing
             _enabled = enabled;
         }
 
-        public LogLevel MinimumLevel { get; set; } = LogLevel.Verbose;
-
         public ILogger CreateLogger(string name)
         {
             return new TestLogger(name, _sink, _enabled);

--- a/src/Microsoft.Extensions.Logging/Logger.cs
+++ b/src/Microsoft.Extensions.Logging/Logger.cs
@@ -37,42 +37,34 @@ namespace Microsoft.Extensions.Logging
                 return;
             }
 
-            if (logLevel >= _loggerFactory.MinimumLevel)
+            List<Exception> exceptions = null;
+            foreach (var logger in _loggers)
             {
-                List<Exception> exceptions = null;
-                foreach (var logger in _loggers)
+                try
                 {
-                    try
-                    {
-                        logger.Log(logLevel, eventId, state, exception, formatter);
-                    }
-                    catch (Exception ex)
-                    {
-                        if (exceptions == null)
-                        {
-                            exceptions = new List<Exception>();
-                        }
-
-                        exceptions.Add(ex);
-                    }
+                    logger.Log(logLevel, eventId, state, exception, formatter);
                 }
-
-                if (exceptions != null && exceptions.Count > 0)
+                catch (Exception ex)
                 {
-                    throw new AggregateException(
-                        message: "An error occurred while writing to logger(s).", innerExceptions: exceptions);
+                    if (exceptions == null)
+                    {
+                        exceptions = new List<Exception>();
+                    }
+
+                    exceptions.Add(ex);
                 }
+            }
+
+            if (exceptions != null && exceptions.Count > 0)
+            {
+                throw new AggregateException(
+                    message: "An error occurred while writing to logger(s).", innerExceptions: exceptions);
             }
         }
 
         public bool IsEnabled(LogLevel logLevel)
         {
             if (_loggers == null)
-            {
-                return false;
-            }
-
-            if (logLevel < _loggerFactory.MinimumLevel)
             {
                 return false;
             }

--- a/src/Microsoft.Extensions.Logging/LoggerFactory.cs
+++ b/src/Microsoft.Extensions.Logging/LoggerFactory.cs
@@ -31,8 +31,6 @@ namespace Microsoft.Extensions.Logging
             return logger;
         }
 
-        public LogLevel MinimumLevel { get; set; } = LogLevel.Verbose;
-
         public void AddProvider(ILoggerProvider provider)
         {
             lock (_sync)

--- a/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
@@ -55,60 +55,6 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Fact]
-        public void MessagesAreNotLoggedWhenBelowMinimumLevel()
-        {
-            // arrange
-            var t = SetUpFactory(null);
-            var factory = t.Item1;
-            var sink = t.Item2;
-            var logger = factory.CreateLogger(_loggerName);
-
-
-            // act
-            logger.Log(LogLevel.Debug, 0, _state, null, null);
-            logger.Log(LogLevel.Verbose, 0, _state, null, null);
-
-            // assert
-            Assert.Equal(LogLevel.Verbose, factory.MinimumLevel);
-            Assert.Equal(3, sink.Writes.Count);
-        }
-
-        [Theory]
-        [InlineData(LogLevel.Debug, 18, true, true)]
-        [InlineData(LogLevel.Verbose, 15, false, true)]
-        [InlineData(LogLevel.Information, 12, false, true)]
-        [InlineData(LogLevel.Warning, 9, false, false)]
-        [InlineData(LogLevel.Error, 6, false, false)]
-        [InlineData(LogLevel.Critical, 3, false, false)]
-        public void MinimumLogLevelCanBeChanged(
-            LogLevel minimumLevel,
-            int expectedMessageCount,
-            bool enabledDebug,
-            bool enabledInformation)
-        {
-            var t = SetUpFactory(null);
-            var factory = t.Item1;
-            var sink = t.Item2;
-            var logger = factory.CreateLogger(_loggerName);
-
-            factory.MinimumLevel = minimumLevel;
-
-            // act
-            logger.Log(LogLevel.Debug, 0, _state, null, null);
-            logger.Log(LogLevel.Verbose, 0, _state, null, null);
-            logger.Log(LogLevel.Information, 0, _state, null, null);
-            logger.Log(LogLevel.Warning, 0, _state, null, null);
-            logger.Log(LogLevel.Error, 0, _state, null, null);
-            logger.Log(LogLevel.Critical, 0, _state, null, null);
-
-            // assert
-            Assert.Equal(minimumLevel, factory.MinimumLevel);
-            Assert.Equal(expectedMessageCount, sink.Writes.Count);
-            Assert.Equal(enabledDebug, logger.IsEnabled(LogLevel.Debug));
-            Assert.Equal(enabledInformation, logger.IsEnabled(LogLevel.Information));
-        }
-
-        [Fact]
         public void ThrowsException_WhenNoMessageAndExceptionAreProvided()
         {
             // Arrange

--- a/test/Microsoft.Extensions.Logging.Test/TestLoggerFactory.cs
+++ b/test/Microsoft.Extensions.Logging.Test/TestLoggerFactory.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.Extensions.Logging.Test
 {
     public class TestLoggerFactory : ILoggerFactory
@@ -15,8 +13,6 @@ namespace Microsoft.Extensions.Logging.Test
             _sink = sink;
             _enabled = enabled;
         }
-
-        public LogLevel MinimumLevel { get; set; } = LogLevel.Verbose;
 
         public ILogger CreateLogger(string categoryName)
         {

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/NullLoggerFactoryTest.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/NullLoggerFactoryTest.cs
@@ -1,20 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Xunit;
 
 namespace Microsoft.Extensions.Logging.Testing
 {
     public class NullLoggerFactoryTest
     {
-        [Fact]
-        public void MinimumLevelIsVerbose()
-        {
-            // Act & Assert
-            Assert.True(LogLevel.Verbose == NullLoggerFactory.Instance.MinimumLevel);
-        }
-
         [Fact]
         public void Create_GivesSameLogger()
         {


### PR DESCRIPTION
#298 

I will update the following repos:

- EntityFramework https://github.com/aspnet/EntityFramework/pull/3956
- KestrelHttpServer https://github.com/aspnet/KestrelHttpServer/pull/445
- SignalR-Redis https://github.com/aspnet/SignalR-Redis/pull/21

These repos are also affected but they are decoupled from our builds and most of them are updated only when we release. Also some don't seem relevant.

- EntityFramework.Benchmark
- NodeServices
- MusicStoreAngular2
- live.asp.net
- go.asp.net
- get.asp.net
- Docs
- KExpense
- PackageSearch