### PR TITLE
Renaming LogLevel.Verbose to Trace #299

### DIFF
--- a/samples/SampleApp/Program.cs
+++ b/samples/SampleApp/Program.cs
@@ -43,7 +43,7 @@ namespace SampleApp
             //    IncludeScopes = true,
             //    Switches =
             //    {
-            //        ["Default"] = LogLevel.Verbose,
+            //        ["Default"] = LogLevel.Debug,
             //        ["Microsoft"] = LogLevel.Information,
             //    }
             //};

--- a/samples/SampleApp/logging.json
+++ b/samples/SampleApp/logging.json
@@ -1,7 +1,7 @@
 ﻿{
   "IncludeScopes" : "false",
   "LogLevel": {
-    "Default": "Verbose",
+    "Default": "Debug",
     "System": "Information",
     "Microsoft": "Information"
   }

--- a/src/Microsoft.Extensions.Logging.Abstractions/LogLevel.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/LogLevel.cs
@@ -12,13 +12,13 @@ namespace Microsoft.Extensions.Logging
         /// Logs that contain the most detailed messages. These messages may contain sensitive application data.
         /// These messages are disabled by default and should never be enabled in a production environment.
         /// </summary>
-        Debug = 1,
+        Trace = 1,
 
         /// <summary>
         /// Logs that are used for interactive investigation during development.  These logs should primarily contain
         /// information useful for debugging and have no long-term value.
         /// </summary>
-        Verbose = 2,
+        Debug = 2,
 
         /// <summary>
         /// Logs that track the general flow of the application. These logs should have long-term value.

--- a/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs
@@ -121,80 +121,80 @@ namespace Microsoft.Extensions.Logging
             logger.LogWithEvent(LogLevel.Debug, eventId, state, error);
         }
 
-        //------------------------------------------VERBOSE------------------------------------------//
+        //------------------------------------------TRACE------------------------------------------//
 
         /// <summary>
-        /// Writes a verbose log message.
+        /// Writes a trace log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="data">The message to log.</param>
         // FYI, this field is called data because naming it message triggers CA1303 and CA2204 for callers.
-        public static void LogVerbose(this ILogger logger, string data)
+        public static void LogTrace(this ILogger logger, string data)
         {
             if (logger == null)
             {
                 throw new ArgumentNullException(nameof(logger));
             }
 
-            logger.Log(LogLevel.Verbose, 0, data, null, _messageFormatter);
+            logger.Log(LogLevel.Trace, 0, data, null, _messageFormatter);
         }
 
         /// <summary>
-        /// Writes a verbose log message.
+        /// Writes a trace log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="eventId">The event id associated with the log.</param>
         /// <param name="data">The message to log.</param>
-        public static void LogVerbose(this ILogger logger, int eventId, string data)
+        public static void LogTrace(this ILogger logger, int eventId, string data)
         {
             if (logger == null)
             {
                 throw new ArgumentNullException(nameof(logger));
             }
 
-            logger.Log(LogLevel.Verbose, eventId, data, null, _messageFormatter);
+            logger.Log(LogLevel.Trace, eventId, data, null, _messageFormatter);
         }
 
         /// <summary>
-        /// Formats and writes a verbose log message.
+        /// Formats and writes a trace log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        public static void LogVerbose(this ILogger logger, string format, params object[] args)
+        public static void LogTrace(this ILogger logger, string format, params object[] args)
         {
             if (logger == null)
             {
                 throw new ArgumentNullException(nameof(logger));
             }
 
-            logger.Log(LogLevel.Verbose, 0, new FormattedLogValues(format, args), null, _messageFormatter);
+            logger.Log(LogLevel.Trace, 0, new FormattedLogValues(format, args), null, _messageFormatter);
         }
 
         /// <summary>
-        /// Formats and writes a verbose log message.
+        /// Formats and writes a trace log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="eventId">The event id associated with the log.</param>
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        public static void LogVerbose(this ILogger logger, int eventId, string format, params object[] args)
+        public static void LogTrace(this ILogger logger, int eventId, string format, params object[] args)
         {
             if (logger == null)
             {
                 throw new ArgumentNullException(nameof(logger));
             }
 
-            logger.Log(LogLevel.Verbose, eventId, new FormattedLogValues(format, args), null, _messageFormatter);
+            logger.Log(LogLevel.Trace, eventId, new FormattedLogValues(format, args), null, _messageFormatter);
         }
 
         /// <summary>
-        /// Formats the given <see cref="ILogValues"/> and writes a verbose log message.
+        /// Formats the given <see cref="ILogValues"/> and writes a trace log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="state">The <see cref="ILogValues"/> to write.</param>
         /// <param name="error">The exception to log.</param>
-        public static void LogVerbose(
+        public static void LogTrace(
             this ILogger logger,
             ILogValues state,
             Exception error = null)
@@ -204,17 +204,17 @@ namespace Microsoft.Extensions.Logging
                 throw new ArgumentNullException(nameof(logger));
             }
 
-            logger.Log(LogLevel.Verbose, state, error);
+            logger.Log(LogLevel.Trace, state, error);
         }
 
         /// <summary>
-        /// Formats the given <see cref="ILogValues"/> and writes a verbose log message.
+        /// Formats the given <see cref="ILogValues"/> and writes a trace log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="eventId">The event id associated with the log.</param>
         /// <param name="state">The <see cref="ILogValues"/> to write.</param>
         /// <param name="error">The exception to log.</param>
-        public static void LogVerbose(
+        public static void LogTrace(
             this ILogger logger,
             int eventId,
             ILogValues state,
@@ -225,7 +225,7 @@ namespace Microsoft.Extensions.Logging
                 throw new ArgumentNullException(nameof(logger));
             }
 
-            logger.LogWithEvent(LogLevel.Verbose, eventId, state, error);
+            logger.LogWithEvent(LogLevel.Trace, eventId, state, error);
         }
 
         //------------------------------------------INFORMATION------------------------------------------//

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
@@ -254,10 +254,10 @@ namespace Microsoft.Extensions.Logging.Console
         {
             switch (logLevel)
             {
+                case LogLevel.Trace:
+                    return "trce";
                 case LogLevel.Debug:
                     return "dbug";
-                case LogLevel.Verbose:
-                    return "verb";
                 case LogLevel.Information:
                     return "info";
                 case LogLevel.Warning:
@@ -285,7 +285,7 @@ namespace Microsoft.Extensions.Logging.Console
                 case LogLevel.Information:
                     return new ConsoleColors(ConsoleColor.DarkGreen, DefaultConsoleColor);
                 case LogLevel.Debug:
-                case LogLevel.Verbose:
+                case LogLevel.Trace:
                 default:
                     return new ConsoleColors(ConsoleColor.Gray, DefaultConsoleColor);
             }

--- a/src/Microsoft.Extensions.Logging.EventLog/EventLogLogger.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/EventLogLogger.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Extensions.Logging.EventLog
             {
                 case LogLevel.Information:
                 case LogLevel.Debug:
-                case LogLevel.Verbose:
+                case LogLevel.Trace:
                     return EventLogEntryType.Information;
                 case LogLevel.Warning:
                     return EventLogEntryType.Warning;

--- a/src/Microsoft.Extensions.Logging.NLog/NLogLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.NLog/NLogLoggerProvider.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Extensions.Logging.NLog
             {
                 switch (logLevel)
                 {
-                    case LogLevel.Verbose: return global::NLog.LogLevel.Trace;
+                    case LogLevel.Trace: return global::NLog.LogLevel.Trace;
                     case LogLevel.Debug: return global::NLog.LogLevel.Debug;
                     case LogLevel.Information: return global::NLog.LogLevel.Info;
                     case LogLevel.Warning: return global::NLog.LogLevel.Warn;

--- a/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceLogger.cs
+++ b/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceLogger.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Extensions.Logging.TraceSource
                 case LogLevel.Error: return TraceEventType.Error;
                 case LogLevel.Warning: return TraceEventType.Warning;
                 case LogLevel.Information: return TraceEventType.Information;
-                case LogLevel.Verbose:
+                case LogLevel.Trace:
                 default: return TraceEventType.Verbose;
             }
         }

--- a/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Extensions.Logging.Test
             var sink = t.Item2;
 
             // Act
-            logger.Log(LogLevel.Verbose, 0, _state, null, null);
+            logger.Log(LogLevel.Debug, 0, _state, null, null);
 
             // Assert
             Assert.Equal(0, sink.Writes.Count);
@@ -241,10 +241,31 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Fact]
-        public void VerboseFilter_LogsWhenAppropriate()
+        public void DebugFilter_LogsWhenAppropriate()
         {
             // Arrange
-            var t = SetUp((category, logLevel) => logLevel >= LogLevel.Verbose);
+            var t = SetUp((category, logLevel) => logLevel >= LogLevel.Debug);
+            var logger = t.Item1;
+            var sink = t.Item2;
+
+            // Act
+            logger.Log(LogLevel.Trace, 0, _state, null, null);
+
+            // Assert
+            Assert.Equal(0, sink.Writes.Count);
+
+            // Act
+            logger.Log(LogLevel.Debug, 0, _state, null, null);
+
+            // Assert
+            Assert.Equal(3, sink.Writes.Count);
+        }
+
+        [Fact]
+        public void TraceFilter_LogsWhenAppropriate()
+        {
+            // Arrange
+            var t = SetUp((category, logLevel) => logLevel >= LogLevel.Trace);
             var logger = t.Item1;
             var sink = t.Item2;
 
@@ -253,10 +274,11 @@ namespace Microsoft.Extensions.Logging.Test
             logger.Log(LogLevel.Error, 0, _state, null, null);
             logger.Log(LogLevel.Warning, 0, _state, null, null);
             logger.Log(LogLevel.Information, 0, _state, null, null);
-            logger.Log(LogLevel.Verbose, 0, _state, null, null);
+            logger.Log(LogLevel.Debug, 0, _state, null, null);
+            logger.Log(LogLevel.Trace, 0, _state, null, null);
 
             // Assert
-            Assert.Equal(15, sink.Writes.Count);
+            Assert.Equal(18, sink.Writes.Count);
         }
 
         [Fact]
@@ -356,7 +378,7 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Fact]
-        public void WriteVerbose_LogsCorrectColors()
+        public void WriteDebug_LogsCorrectColors()
         {
             // Arrange
             var t = SetUp(null);
@@ -364,7 +386,31 @@ namespace Microsoft.Extensions.Logging.Test
             var sink = t.Item2;
 
             // Act
-            logger.Log(LogLevel.Verbose, 0, _state, null, null);
+            logger.Log(LogLevel.Debug, 0, _state, null, null);
+
+            // Assert
+            Assert.Equal(3, sink.Writes.Count);
+            var write = sink.Writes[0];
+            Assert.Equal(TestConsole.DefaultBackgroundColor, write.BackgroundColor);
+            Assert.Equal(ConsoleColor.Gray, write.ForegroundColor);
+            write = sink.Writes[1];
+            Assert.Equal(TestConsole.DefaultBackgroundColor, write.BackgroundColor);
+            Assert.Equal(ConsoleColor.Gray, write.ForegroundColor);
+            write = sink.Writes[2];
+            Assert.Equal(TestConsole.DefaultBackgroundColor, write.BackgroundColor);
+            Assert.Equal(ConsoleColor.White, write.ForegroundColor);
+        }
+
+        [Fact]
+        public void WriteTrace_LogsCorrectColors()
+        {
+            // Arrange
+            var t = SetUp(null);
+            var logger = t.Item1;
+            var sink = t.Item2;
+
+            // Act
+            logger.Log(LogLevel.Trace, 0, _state, null, null);
 
             // Assert
             Assert.Equal(3, sink.Writes.Count);
@@ -394,8 +440,8 @@ namespace Microsoft.Extensions.Logging.Test
             logger.Log(LogLevel.Error, 0, _state, ex, _theMessageAndError);
             logger.Log(LogLevel.Warning, 0, _state, ex, _theMessageAndError);
             logger.Log(LogLevel.Information, 0, _state, ex, _theMessageAndError);
-            logger.Log(LogLevel.Verbose, 0, _state, ex, _theMessageAndError);
             logger.Log(LogLevel.Debug, 0, _state, ex, _theMessageAndError);
+            logger.Log(LogLevel.Trace, 0, _state, ex, _theMessageAndError);
 
             // Assert
             Assert.Equal(18, sink.Writes.Count);
@@ -403,8 +449,8 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(GetMessage("fail", 0, ex), GetMessage(sink.Writes.GetRange(3, 3)));
             Assert.Equal(GetMessage("warn", 0, ex), GetMessage(sink.Writes.GetRange(6, 3)));
             Assert.Equal(GetMessage("info", 0, ex), GetMessage(sink.Writes.GetRange(9, 3)));
-            Assert.Equal(GetMessage("verb", 0, ex), GetMessage(sink.Writes.GetRange(12, 3)));
-            Assert.Equal(GetMessage("dbug", 0, ex), GetMessage(sink.Writes.GetRange(15, 3)));
+            Assert.Equal(GetMessage("dbug", 0, ex), GetMessage(sink.Writes.GetRange(12, 3)));
+            Assert.Equal(GetMessage("trce", 0, ex), GetMessage(sink.Writes.GetRange(15, 3)));
         }
 
         [Fact]
@@ -613,9 +659,9 @@ namespace Microsoft.Extensions.Logging.Test
             loggerFactory.AddConsole(settings);
 
             var logger = loggerFactory.CreateLogger("Test");
-            Assert.False(logger.IsEnabled(LogLevel.Verbose));
+            Assert.False(logger.IsEnabled(LogLevel.Trace));
 
-            settings.Switches["Test"] = LogLevel.Verbose;
+            settings.Switches["Test"] = LogLevel.Trace;
 
             var cancellationTokenSource = settings.Cancel;
             settings.Cancel = new CancellationTokenSource();
@@ -624,7 +670,7 @@ namespace Microsoft.Extensions.Logging.Test
             cancellationTokenSource.Cancel();
 
             // Assert
-            Assert.True(logger.IsEnabled(LogLevel.Verbose));
+            Assert.True(logger.IsEnabled(LogLevel.Trace));
         }
 
         [Fact]
@@ -644,19 +690,19 @@ namespace Microsoft.Extensions.Logging.Test
             loggerFactory.AddConsole(settings);
 
             var logger = loggerFactory.CreateLogger("Test");
-            Assert.False(logger.IsEnabled(LogLevel.Verbose));
+            Assert.False(logger.IsEnabled(LogLevel.Trace));
 
             // Act & Assert
             for (var i = 0; i < 10; i++)
             {
-                settings.Switches["Test"] = i % 2 == 0 ? LogLevel.Information : LogLevel.Verbose;
+                settings.Switches["Test"] = i % 2 == 0 ? LogLevel.Information : LogLevel.Trace;
 
                 var cancellationTokenSource = settings.Cancel;
                 settings.Cancel = new CancellationTokenSource();
 
                 cancellationTokenSource.Cancel();
 
-                Assert.Equal(i % 2 == 1, logger.IsEnabled(LogLevel.Verbose));
+                Assert.Equal(i % 2 == 1, logger.IsEnabled(LogLevel.Trace));
             }
         }
 

--- a/test/Microsoft.Extensions.Logging.Test/LoggerExtensionsTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/LoggerExtensionsTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Extensions.Logging.Test
             var logger = SetUp(sink);
 
             // Act
-            logger.LogVerbose(_state);
+            logger.LogTrace(_state);
             logger.LogInformation(_state);
             logger.LogWarning(_state);
             logger.LogError(_state);
@@ -40,11 +40,11 @@ namespace Microsoft.Extensions.Logging.Test
             // Assert
             Assert.Equal(6, sink.Writes.Count);
 
-            var verbose = sink.Writes[0];
-            Assert.Equal(LogLevel.Verbose, verbose.LogLevel);
-            Assert.Equal(_state, verbose.State);
-            Assert.Equal(0, verbose.EventId);
-            Assert.Equal(null, verbose.Exception);
+            var trace = sink.Writes[0];
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Equal(_state, trace.State);
+            Assert.Equal(0, trace.EventId);
+            Assert.Equal(null, trace.Exception);
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
@@ -85,7 +85,7 @@ namespace Microsoft.Extensions.Logging.Test
             var logger = SetUp(sink);
 
             // Act
-            logger.LogVerbose(_format, "test1", "test2");
+            logger.LogTrace(_format, "test1", "test2");
             logger.LogInformation(_format, "test1", "test2");
             logger.LogWarning(_format, "test1", "test2");
             logger.LogError(_format, "test1", "test2");
@@ -95,11 +95,11 @@ namespace Microsoft.Extensions.Logging.Test
             // Assert
             Assert.Equal(6, sink.Writes.Count);
 
-            var verbose = sink.Writes[0];
-            Assert.Equal(LogLevel.Verbose, verbose.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), verbose.State?.ToString());
-            Assert.Equal(0, verbose.EventId);
-            Assert.Equal(null, verbose.Exception);
+            var trace = sink.Writes[0];
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), trace.State?.ToString());
+            Assert.Equal(0, trace.EventId);
+            Assert.Equal(null, trace.Exception);
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
@@ -140,7 +140,7 @@ namespace Microsoft.Extensions.Logging.Test
             var logger = SetUp(sink);
 
             // Act
-            logger.LogVerbose(1, _state);
+            logger.LogTrace(1, _state);
             logger.LogInformation(2, _state);
             logger.LogWarning(3, _state);
             logger.LogError(4, _state);
@@ -150,11 +150,11 @@ namespace Microsoft.Extensions.Logging.Test
             // Assert
             Assert.Equal(6, sink.Writes.Count);
 
-            var verbose = sink.Writes[0];
-            Assert.Equal(LogLevel.Verbose, verbose.LogLevel);
-            Assert.Equal(_state, verbose.State);
-            Assert.Equal(1, verbose.EventId);
-            Assert.Equal(null, verbose.Exception);
+            var trace = sink.Writes[0];
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Equal(_state, trace.State);
+            Assert.Equal(1, trace.EventId);
+            Assert.Equal(null, trace.Exception);
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
@@ -195,7 +195,7 @@ namespace Microsoft.Extensions.Logging.Test
             var logger = SetUp(sink);
 
             // Act
-            logger.LogVerbose(1, _format, "test1", "test2");
+            logger.LogTrace(1, _format, "test1", "test2");
             logger.LogInformation(2, _format, "test1", "test2");
             logger.LogWarning(3, _format, "test1", "test2");
             logger.LogError(4, _format, "test1", "test2");
@@ -205,11 +205,11 @@ namespace Microsoft.Extensions.Logging.Test
             // Assert
             Assert.Equal(6, sink.Writes.Count);
 
-            var verbose = sink.Writes[0];
-            Assert.Equal(LogLevel.Verbose, verbose.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), verbose.State?.ToString());
-            Assert.Equal(1, verbose.EventId);
-            Assert.Equal(null, verbose.Exception);
+            var trace = sink.Writes[0];
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), trace.State?.ToString());
+            Assert.Equal(1, trace.EventId);
+            Assert.Equal(null, trace.Exception);
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
@@ -322,7 +322,7 @@ namespace Microsoft.Extensions.Logging.Test
             };
 
             // Act
-            logger.LogVerbose(testLogValues);
+            logger.LogTrace(testLogValues);
             logger.LogInformation(testLogValues);
             logger.LogWarning(testLogValues);
             logger.LogError(testLogValues);
@@ -332,12 +332,12 @@ namespace Microsoft.Extensions.Logging.Test
             // Assert
             Assert.Equal(6, sink.Writes.Count);
 
-            var verbose = sink.Writes[0];
-            Assert.Equal(LogLevel.Verbose, verbose.LogLevel);
-            Assert.Same(testLogValues, verbose.State);
-            Assert.Equal(0, verbose.EventId);
-            Assert.Equal(null, verbose.Exception);
-            Assert.Equal("Test 1", verbose.Formatter(verbose.State, verbose.Exception));
+            var trace = sink.Writes[0];
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Same(testLogValues, trace.State);
+            Assert.Equal(0, trace.EventId);
+            Assert.Equal(null, trace.Exception);
+            Assert.Equal("Test 1", trace.Formatter(trace.State, trace.Exception));
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
@@ -387,7 +387,7 @@ namespace Microsoft.Extensions.Logging.Test
             };
 
             // Act
-            logger.LogVerbose(1, testLogValues);
+            logger.LogTrace(1, testLogValues);
             logger.LogInformation(2, testLogValues);
             logger.LogWarning(3, testLogValues);
             logger.LogError(4, testLogValues);
@@ -397,12 +397,12 @@ namespace Microsoft.Extensions.Logging.Test
             // Assert
             Assert.Equal(6, sink.Writes.Count);
 
-            var verbose = sink.Writes[0];
-            Assert.Equal(LogLevel.Verbose, verbose.LogLevel);
-            Assert.Same(testLogValues, verbose.State);
-            Assert.Equal(1, verbose.EventId);
-            Assert.Equal(null, verbose.Exception);
-            Assert.Equal("Test 1", verbose.Formatter(verbose.State, verbose.Exception));
+            var trace = sink.Writes[0];
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Same(testLogValues, trace.State);
+            Assert.Equal(1, trace.EventId);
+            Assert.Equal(null, trace.Exception);
+            Assert.Equal("Test 1", trace.Formatter(trace.State, trace.Exception));
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
@@ -452,7 +452,7 @@ namespace Microsoft.Extensions.Logging.Test
             };
 
             // Act
-            logger.LogVerbose(testLogValues, _exception);
+            logger.LogTrace(testLogValues, _exception);
             logger.LogInformation(testLogValues, _exception);
             logger.LogWarning(testLogValues, _exception);
             logger.LogError(testLogValues, _exception);
@@ -462,14 +462,14 @@ namespace Microsoft.Extensions.Logging.Test
             // Assert
             Assert.Equal(6, sink.Writes.Count);
 
-            var verbose = sink.Writes[0];
-            Assert.Equal(LogLevel.Verbose, verbose.LogLevel);
-            Assert.Same(testLogValues, verbose.State);
-            Assert.Equal(0, verbose.EventId);
-            Assert.Equal(_exception, verbose.Exception);
+            var trace = sink.Writes[0];
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Same(testLogValues, trace.State);
+            Assert.Equal(0, trace.EventId);
+            Assert.Equal(_exception, trace.Exception);
             Assert.Equal(
                 "Test 1" + Environment.NewLine + _exception,
-                verbose.Formatter(verbose.State, verbose.Exception));
+                trace.Formatter(trace.State, trace.Exception));
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
@@ -528,7 +528,7 @@ namespace Microsoft.Extensions.Logging.Test
             };
 
             // Act
-            logger.LogVerbose(1, testLogValues, _exception);
+            logger.LogTrace(1, testLogValues, _exception);
             logger.LogInformation(2, testLogValues, _exception);
             logger.LogWarning(3, testLogValues, _exception);
             logger.LogError(4, testLogValues, _exception);
@@ -538,14 +538,14 @@ namespace Microsoft.Extensions.Logging.Test
             // Assert
             Assert.Equal(6, sink.Writes.Count);
 
-            var verbose = sink.Writes[0];
-            Assert.Equal(LogLevel.Verbose, verbose.LogLevel);
-            Assert.Same(testLogValues, verbose.State);
-            Assert.Equal(1, verbose.EventId);
-            Assert.Equal(_exception, verbose.Exception);
+            var trace = sink.Writes[0];
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Same(testLogValues, trace.State);
+            Assert.Equal(1, trace.EventId);
+            Assert.Equal(_exception, trace.Exception);
             Assert.Equal(
                 "Test 1" + Environment.NewLine + _exception,
-                verbose.Formatter(verbose.State, verbose.Exception));
+                trace.Formatter(trace.State, trace.Exception));
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);

--- a/test/Microsoft.Extensions.Logging.Test/TraceSourceLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/TraceSourceLoggerTest.cs
@@ -27,7 +27,8 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.True(logger.IsEnabled(LogLevel.Error));
             Assert.True(logger.IsEnabled(LogLevel.Warning));
             Assert.False(logger.IsEnabled(LogLevel.Information));
-            Assert.False(logger.IsEnabled(LogLevel.Verbose));
+            Assert.False(logger.IsEnabled(LogLevel.Debug));
+            Assert.False(logger.IsEnabled(LogLevel.Trace));
         }
 
         [Theory]

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/NullLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/NullLoggerTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.Logging.Testing
 
             // Act & Assert
             Assert.False(logger.IsEnabled(LogLevel.Debug));
-            Assert.False(logger.IsEnabled(LogLevel.Verbose));
+            Assert.False(logger.IsEnabled(LogLevel.Trace));
             Assert.False(logger.IsEnabled(LogLevel.Information));
             Assert.False(logger.IsEnabled(LogLevel.Warning));
             Assert.False(logger.IsEnabled(LogLevel.Error));
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.Logging.Testing
             bool isCalled = false;
 
             // Act
-            logger.Log(LogLevel.Verbose, eventId: 0, state: null, exception: null, formatter: (ex, message) => { isCalled = true; return string.Empty; });
+            logger.Log(LogLevel.Trace, eventId: 0, state: null, exception: null, formatter: (ex, message) => { isCalled = true; return string.Empty; });
 
             // Assert
             Assert.False(isCalled);


### PR DESCRIPTION
Issue #299 
Renaming `LogLevel`s in logging so that `Verbose` is renamed to `Trace` and is considered less severe than `Debug`.

Most severe level listed first:

Current Levels  | New Levels
------------- | -------------
Critical  | Critical 
Error | Error 
Warning | Warning 
Information  | Information 
Verbose | Debug 
Debug | Trace 

I will update the affected repos:
- DataProtection https://github.com/aspnet/DataProtection/pull/112
- UserSecrets https://github.com/aspnet/UserSecrets/pull/52
- dnx-watch https://github.com/aspnet/dnx-watch/pull/39
- Hosting https://github.com/aspnet/Hosting/pull/512
- WebListener https://github.com/aspnet/WebListener/pull/157
- EntityFramework https://github.com/aspnet/EntityFramework/pull/3998
- StaticFiles https://github.com/aspnet/StaticFiles/pull/95
- Routing https://github.com/aspnet/Routing/pull/246
- Diagnostics https://github.com/aspnet/Diagnostics/pull/224
- Session https://github.com/aspnet/Session/pull/77
- Security https://github.com/aspnet/Security/pull/608
- MVC https://github.com/aspnet/Mvc/pull/3701
- Identity https://github.com/aspnet/Identity/pull/667
- SignalR-Server https://github.com/aspnet/SignalR-Server/pull/142
- SignalR-Redis https://github.com/aspnet/SignalR-Redis/pull/22
- SignalR-SqlServer https://github.com/aspnet/SignalR-SqlServer/pull/17
- SignalR-ServiceBus https://github.com/aspnet/SignalR-ServiceBus/pull/11
- Performance https://github.com/aspnet/Performance/pull/12

To keep the current order of severity existing `Verbose` messages will be changed to `Debug` and existing `Debug` messages will be changed to `Trace`.