### PR TITLE
LoggerFactoryExtension.CreateLogger<T> now returns an ILogger<T>

### DIFF
--- a/src/Microsoft.Extensions.Logging.Abstractions/LoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/LoggerFactoryExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Extensions.Internal;
 
 namespace Microsoft.Extensions.Logging
 {
@@ -16,14 +15,14 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <typeparam name="T">The type.</typeparam>
         /// <param name="factory">The factory.</param>
-        public static ILogger CreateLogger<T>(this ILoggerFactory factory)
+        public static ILogger<T> CreateLogger<T>(this ILoggerFactory factory)
         {
             if (factory == null)
             {
                 throw new ArgumentNullException(nameof(factory));
             }
 
-            return factory.CreateLogger(TypeNameHelper.GetTypeDisplayName(typeof(T), fullName: true));
+            return new Logger<T>(factory);
         }
     }
 }

--- a/src/Microsoft.Extensions.Logging.Abstractions/LoggerOfT.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/LoggerOfT.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.Extensions.Logging
 {
@@ -13,14 +14,19 @@ namespace Microsoft.Extensions.Logging
     public class Logger<T> : ILogger<T>
     {
         private readonly ILogger _logger;
-        
+
         /// <summary>
         /// Creates a new <see cref="Logger{T}"/>.
         /// </summary>
         /// <param name="factory">The factory.</param>
         public Logger(ILoggerFactory factory)
         {
-            _logger = factory.CreateLogger<T>();
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            _logger = factory.CreateLogger(TypeNameHelper.GetTypeDisplayName(typeof(T), fullName: true));
         }
 
         IDisposable ILogger.BeginScopeImpl(object state)


### PR DESCRIPTION
As proposed in #312, `LoggerFactoryExtensions.CreateLogger<T>()` now returns an `ILogger<T>` instead of an `ILogger`.

In order to achieve this, I moved `Logger<T>` from `Microsoft.Extensions.Logging` to `Microsoft.Extensions.Logging.Abstractions`. I thought about moving `LoggerFactoryExtension` to `Microsoft.Extensions.Logging` instead but that seemed to do more harm than good.