### PR TITLE
Use a platform determiner which is available on all platforms

### DIFF
--- a/src/Microsoft.Extensions.Logging.Abstractions/project.json
+++ b/src/Microsoft.Extensions.Logging.Abstractions/project.json
@@ -16,7 +16,7 @@
     }
   },
   "frameworks": {
-    "net451": {},
+    "net451": { },
     "dotnet5.4": {
       "dependencies": {
         "System.Collections": "4.0.11-*",
@@ -25,8 +25,7 @@
         "System.Globalization": "4.0.11-*",
         "System.Reflection": "4.1.0-*",
         "System.Runtime": "4.0.21-*",
-        "System.Runtime.Extensions": "4.0.11-*",
-        "System.Runtime.InteropServices": "4.0.21-*"
+        "System.Runtime.Extensions": "4.0.11-*"
       }
     },
     "netcore50": {
@@ -38,7 +37,6 @@
         "System.Linq": "4.0.0",
         "System.Reflection": "4.0.10",
         "System.Resources.ResourceManager": "4.0.0",
-        "System.Runtime": "4.0.20",
         "System.Runtime.Extensions": "4.0.10"
       }
     }

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Collections;
-using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Extensions.Logging.Console.Internal;
+using Microsoft.Extensions.PlatformAbstractions;
 
 namespace Microsoft.Extensions.Logging.Console
 {
@@ -37,12 +37,11 @@ namespace Microsoft.Extensions.Logging.Console
             {
                 throw new ArgumentNullException(nameof(name));
             }
-            
+
             Name = name;
             Filter = filter ?? ((category, logLevel) => true);
             IncludeScopes = includeScopes;
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (PlatformServices.Default.Runtime.OperatingSystem.Equals("Windows", StringComparison.OrdinalIgnoreCase))
             {
                 Console = new WindowsLogConsole();
             }

--- a/src/Microsoft.Extensions.Logging.Console/project.json
+++ b/src/Microsoft.Extensions.Logging.Console/project.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "Microsoft.Extensions.Configuration.Abstractions": "1.0.0-*",
     "Microsoft.Extensions.Logging.Abstractions": "1.0.0-*",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-*"
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*"
   },
   "frameworks": {
     "net451": {

--- a/src/Microsoft.Extensions.Logging/project.json
+++ b/src/Microsoft.Extensions.Logging/project.json
@@ -29,14 +29,6 @@
     },
     "netcore50": {
       "dependencies": {
-        "System.Collections": "4.0.10",
-        "System.Diagnostics.Debug": "4.0.10",
-        "System.Linq": "4.0.0",
-        "System.Resources.ResourceManager": "4.0.0",
-        "System.Runtime": "4.0.20",
-        "System.Runtime.Extensions": "4.0.10",
-        "System.Threading": "4.0.10",
-        "System.Threading.Tasks": "4.0.10"
       }
     }
   }


### PR DESCRIPTION
Should fix test failures in Entropy on Mac.