### PR TITLE
Remove dependency on System.Runtime.InteropServices.RuntimeInformation

### DIFF
--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Extensions.Logging.Console.Internal;
+using Microsoft.Extensions.PlatformAbstractions;
 
 namespace Microsoft.Extensions.Logging.Console
 {
@@ -37,12 +38,12 @@ namespace Microsoft.Extensions.Logging.Console
             {
                 throw new ArgumentNullException(nameof(name));
             }
-            
+
             Name = name;
             Filter = filter ?? ((category, logLevel) => true);
             IncludeScopes = includeScopes;
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (PlatformServices.Default.Runtime.OperatingSystem.Equals("Windows", StringComparison.OrdinalIgnoreCase))
             {
                 Console = new WindowsLogConsole();
             }

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections;
-using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Extensions.Logging.Console.Internal;
 using Microsoft.Extensions.PlatformAbstractions;

--- a/src/Microsoft.Extensions.Logging.Console/project.json
+++ b/src/Microsoft.Extensions.Logging.Console/project.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "Microsoft.Extensions.Configuration.Abstractions": "1.0.0-*",
     "Microsoft.Extensions.Logging.Abstractions": "1.0.0-*",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-*"
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*"
   },
   "frameworks": {
     "net451": {


### PR DESCRIPTION
@ryanbrandenburg I see that your commit had more changes than this one. Not sure why they were required, but here after making this change I built EF against this change and it built just fine...so I assume all is good to check this in.

Should fix https://github.com/aspnet/Logging/issues/311