### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ This project is part of ASP.NET 5. You can find samples, documentation and getti
 
 Community projects adapt _Microsoft.Extensions.Logging_ for use with different back-ends.
 
- * [Serilog](https://github.com/serilog/serilog-framework-logging) - provider for the Serilog library
+ * [Serilog](https://github.com/serilog/serilog-extensions-logging) - provider for the Serilog library
  * [elmah.io](https://github.com/elmahio/Elmah.Io.Framework.Logging) - provider for the elmah.io service
  * [Loggr](https://github.com/imobile3/Loggr.Extensions.Logging) - provider for the Loggr service
- * [NLog](https://github.com/NLog/NLog.Framework.logging) - provider for the NLog library
+ * [NLog](https://github.com/NLog/NLog.Extensions.Logging) - provider for the NLog library
  


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/NLog/NLog.Framework.logging | https://github.com/NLog/NLog.Extensions.Logging 
https://github.com/serilog/serilog-framework-logging | https://github.com/serilog/serilog-extensions-logging 
