### PR TITLE
Don't reference design-time facades on net451

### DIFF
--- a/src/Microsoft.Extensions.Logging.Testing/project.json
+++ b/src/Microsoft.Extensions.Logging.Testing/project.json
@@ -20,7 +20,7 @@
   "frameworks": {
     "net451": {
       "frameworkAssemblies": {
-        "System.Runtime": ""
+        "System.Runtime": { "type": "build" }
       }
     },
     "netstandard1.3": {

--- a/src/Microsoft.Extensions.Logging.TraceSource/project.json
+++ b/src/Microsoft.Extensions.Logging.TraceSource/project.json
@@ -16,11 +16,7 @@
     "Microsoft.Extensions.Logging.Abstractions": "1.0.0-*"
   },
   "frameworks": {
-    "net451": {
-      "frameworkAssemblies": {
-        "System.Collections.Concurrent": ""
-      }
-    },
+    "net451": { },
     "netstandard1.3": {
       "dependencies": {
         "System.Collections.Concurrent": "4.0.12-*",

--- a/src/Microsoft.Extensions.Logging/project.json
+++ b/src/Microsoft.Extensions.Logging/project.json
@@ -21,11 +21,7 @@
     "xmlDoc": true
   },
   "frameworks": {
-    "net451": {
-      "frameworkAssemblies": {
-        "System.Collections.Concurrent": ""
-      }
-    },
+    "net451": { },
     "netstandard1.3": {
       "dependencies": {
         "System.Collections.Concurrent": "4.0.12-*"


### PR DESCRIPTION
Without this, the packages won't install into "classic" Full .NET projects