### PR TITLE
Changing BuildScopeImpl to BuildScope<TState>

### DIFF
--- a/samples/SampleApp/Program.cs
+++ b/samples/SampleApp/Program.cs
@@ -129,7 +129,7 @@ namespace SampleApp
                     _logger.LogWarning("Unexpected warning", ex);
                 }
 
-                using (_logger.BeginScopeImpl("Main"))
+                using (_logger.BeginScope("Main"))
                 {
 
                     _logger.LogInformation("Waiting for user input");

--- a/src/Microsoft.Extensions.Logging.Abstractions/ILogger.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/ILogger.cs
@@ -33,6 +33,6 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="state">The identifier for the scope.</param>
         /// <returns>An IDisposable that ends the logical operation scope on dispose.</returns>
-        IDisposable BeginScopeImpl(object state);
+        IDisposable BeginScope<TState>(TState state);
     }
 }

--- a/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs
@@ -357,7 +357,7 @@ namespace Microsoft.Extensions.Logging
                 throw new ArgumentNullException(nameof(messageFormat));
             }
 
-            return logger.BeginScopeImpl(new FormattedLogValues(messageFormat, args));
+            return logger.BeginScope(new FormattedLogValues(messageFormat, args));
         }
 
         //------------------------------------------HELPERS------------------------------------------//

--- a/src/Microsoft.Extensions.Logging.Abstractions/LoggerMessage.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/LoggerMessage.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Logging
         {
             var logValues = new LogValues(new LogValuesFormatter(formatString));
 
-            return logger => logger.BeginScopeImpl(logValues);
+            return logger => logger.BeginScope(logValues);
         }
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.Logging
         {
             var formatter = new LogValuesFormatter(formatString);
 
-            return (logger, arg1) => logger.BeginScopeImpl(new LogValues<T1>(formatter, arg1));
+            return (logger, arg1) => logger.BeginScope(new LogValues<T1>(formatter, arg1));
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.Logging
         {
             var formatter = new LogValuesFormatter(formatString);
 
-            return (logger, arg1, arg2) => logger.BeginScopeImpl(new LogValues<T1, T2>(formatter, arg1, arg2));
+            return (logger, arg1, arg2) => logger.BeginScope(new LogValues<T1, T2>(formatter, arg1, arg2));
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Microsoft.Extensions.Logging
         {
             var formatter = new LogValuesFormatter(formatString);
 
-            return (logger, arg1, arg2, arg3) => logger.BeginScopeImpl(new LogValues<T1, T2, T3>(formatter, arg1, arg2, arg3));
+            return (logger, arg1, arg2, arg3) => logger.BeginScope(new LogValues<T1, T2, T3>(formatter, arg1, arg2, arg3));
         }
 
         /// <summary>

--- a/src/Microsoft.Extensions.Logging.Abstractions/LoggerOfT.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/LoggerOfT.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Extensions.Logging
             _logger = factory.CreateLogger(TypeNameHelper.GetTypeDisplayName(typeof(T)));
         }
 
-        IDisposable ILogger.BeginScopeImpl(object state)
+        IDisposable ILogger.BeginScope<TState>(TState state)
         {
-            return _logger.BeginScopeImpl(state);
+            return _logger.BeginScope(state);
         }
 
         bool ILogger.IsEnabled(LogLevel logLevel)

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Extensions.Logging.Console
             return Filter(Name, logLevel);
         }
 
-        public IDisposable BeginScopeImpl(object state)
+        public IDisposable BeginScope<TState>(TState state)
         {
             if (state == null)
             {

--- a/src/Microsoft.Extensions.Logging.Debug/DebugLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Debug/DebugLogger.cs
@@ -36,9 +36,9 @@ namespace Microsoft.Extensions.Logging.Debug
 
 
         /// <inheritdoc />
-        public IDisposable BeginScopeImpl(object state)
+        public IDisposable BeginScope<TState>(TState state)
         {
-            return new NoopDisposable();
+            return NoopDisposable.Instance;
         }
 
         /// <inheritdoc />
@@ -82,6 +82,8 @@ namespace Microsoft.Extensions.Logging.Debug
 
         private class NoopDisposable : IDisposable
         {
+            public static NoopDisposable Instance = new NoopDisposable();
+
             public void Dispose()
             {
             }

--- a/src/Microsoft.Extensions.Logging.EventLog/EventLogLogger.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/EventLogLogger.cs
@@ -61,9 +61,9 @@ namespace Microsoft.Extensions.Logging.EventLog
         public IEventLog EventLog { get; }
 
         /// <inheritdoc />
-        public IDisposable BeginScopeImpl(object state)
+        public IDisposable BeginScope<TState>(TState state)
         {
-            return new NoopDisposable();
+            return NoopDisposable.Instance;
         }
 
         /// <inheritdoc />
@@ -172,6 +172,8 @@ namespace Microsoft.Extensions.Logging.EventLog
 
         private class NoopDisposable : IDisposable
         {
+            public static NoopDisposable Instance = new NoopDisposable();
+
             public void Dispose()
             {
             }

--- a/src/Microsoft.Extensions.Logging.Filter/Internal/FilterLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Filter/Internal/FilterLogger.cs
@@ -40,9 +40,9 @@ namespace Microsoft.Extensions.Logging.Filter.Internal
             }
         }
 
-        public IDisposable BeginScopeImpl(object state)
+        public IDisposable BeginScope<TState>(TState state)
         {
-            return _innerLogger.BeginScopeImpl(state);
+            return _innerLogger.BeginScope(state);
         }
 
         private Func<LogLevel, bool> GetFilter()

--- a/src/Microsoft.Extensions.Logging.Testing/NullLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/NullLogger.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.Logging.Testing
     {
         public static readonly NullLogger Instance = new NullLogger();
 
-        public IDisposable BeginScopeImpl(object state)
+        public IDisposable BeginScope<TState>(TState state)
         {
             return NullDisposable.Instance;
         }

--- a/src/Microsoft.Extensions.Logging.Testing/NullLoggerOfT.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/NullLoggerOfT.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.Logging.Testing
     {
         public static readonly NullLogger<T> Instance = new NullLogger<T>();
 
-        public IDisposable BeginScopeImpl(object state)
+        public IDisposable BeginScope<TState>(TState state)
         {
             return NullDisposable.Instance;
         }

--- a/src/Microsoft.Extensions.Logging.Testing/TestLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/TestLogger.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.Logging.Testing
 
         public string Name { get; set; }
 
-        public IDisposable BeginScopeImpl(object state)
+        public IDisposable BeginScope<TState>(TState state)
         {
             _scope = state;
 

--- a/src/Microsoft.Extensions.Logging.Testing/TestLoggerOfT.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/TestLoggerOfT.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Extensions.Logging.Testing
             _logger = factory.CreateLogger<T>();
         }
 
-        public IDisposable BeginScopeImpl(object state)
+        public IDisposable BeginScope<TState>(TState state)
         {
-            return _logger.BeginScopeImpl(state);
+            return _logger.BeginScope(state);
         }
 
         public bool IsEnabled(LogLevel logLevel)

--- a/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceLogger.cs
+++ b/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceLogger.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.Logging.TraceSource
             }
         }
 
-        public IDisposable BeginScopeImpl(object state)
+        public IDisposable BeginScope<TState>(TState state)
         {
             return new TraceSourceScope(state);
         }

--- a/src/Microsoft.Extensions.Logging/Logger.cs
+++ b/src/Microsoft.Extensions.Logging/Logger.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Extensions.Logging
             return false;
         }
 
-        public IDisposable BeginScopeImpl(object state)
+        public IDisposable BeginScope<TState>(TState state)
         {
             if (_loggers == null)
             {
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.Logging
 
             if (_loggers.Length == 1)
             {
-                return _loggers[0].BeginScopeImpl(state);
+                return _loggers[0].BeginScope(state);
             }
 
             var loggers = _loggers;
@@ -120,7 +120,7 @@ namespace Microsoft.Extensions.Logging
             {
                 try
                 {
-                    var disposable = loggers[index].BeginScopeImpl(state);
+                    var disposable = loggers[index].BeginScope(state);
                     scope.SetDisposable(index, disposable);
                 }
                 catch (Exception ex)

--- a/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
@@ -615,8 +615,8 @@ namespace Microsoft.Extensions.Logging.Test
             var sink = t.Item2;
 
             // Act
-            var disposable1 = logger.BeginScopeImpl("Scope1");
-            var disposable2 = logger.BeginScopeImpl("Scope2");
+            var disposable1 = logger.BeginScope("Scope1");
+            var disposable2 = logger.BeginScope("Scope2");
 
             // Assert
             Assert.NotNull(disposable1);
@@ -633,7 +633,7 @@ namespace Microsoft.Extensions.Logging.Test
             var sink = t.Item2;
 
             // Act
-            var disposable = logger.BeginScopeImpl("Scope1");
+            var disposable = logger.BeginScope("Scope1");
 
             // Assert
             Assert.NotNull(disposable);

--- a/test/Microsoft.Extensions.Logging.Test/DebugLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/DebugLoggerTest.cs
@@ -10,29 +10,13 @@ namespace Microsoft.Extensions.Logging
     public class DebugLoggerTest
     {
         [Fact]
-        public void CallingBeginScopeOnLogger_AlwaysReturnsNewDisposableInstance()
-        {
-            // Arrange
-            var logger = new DebugLogger("Test");
-
-            // Act
-            var disposable1 = logger.BeginScopeImpl("Scope1");
-            var disposable2 = logger.BeginScopeImpl("Scope2");
-
-            // Assert
-            Assert.NotNull(disposable1);
-            Assert.NotNull(disposable2);
-            Assert.NotSame(disposable1, disposable2);
-        }
-
-        [Fact]
         public void CallingBeginScopeOnLogger_ReturnsNonNullableInstance()
         {
             // Arrange
             var logger = new DebugLogger("Test");
 
             // Act
-            var disposable = logger.BeginScopeImpl("Scope1");
+            var disposable = logger.BeginScope("Scope1");
 
             // Assert
             Assert.NotNull(disposable);

--- a/test/Microsoft.Extensions.Logging.Test/EventLogLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/EventLogLoggerTest.cs
@@ -15,29 +15,13 @@ namespace Microsoft.Extensions.Logging
     public class EventLogLoggerTest
     {
         [Fact]
-        public void CallingBeginScopeOnLogger_AlwaysReturnsNewDisposableInstance()
-        {
-            // Arrange
-            var logger = new EventLogLogger("Test");
-
-            // Act
-            var disposable1 = logger.BeginScopeImpl("Scope1");
-            var disposable2 = logger.BeginScopeImpl("Scope2");
-
-            // Assert
-            Assert.NotNull(disposable1);
-            Assert.NotNull(disposable2);
-            Assert.NotSame(disposable1, disposable2);
-        }
-
-        [Fact]
         public void CallingBeginScopeOnLogger_ReturnsNonNullableInstance()
         {
             // Arrange
             var logger = new EventLogLogger("Test");
 
             // Act
-            var disposable = logger.BeginScopeImpl("Scope1");
+            var disposable = logger.BeginScope("Scope1");
 
             // Assert
             Assert.NotNull(disposable);

--- a/test/Microsoft.Extensions.Logging.Test/LoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/LoggerTest.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Extensions.Logging
                 _store = store;
             }
 
-            public IDisposable BeginScopeImpl(object state)
+            public IDisposable BeginScope<TState>(TState state)
             {
                 if (_throwExceptionAt == ThrowExceptionAt.BeginScope)
                 {

--- a/test/Microsoft.Extensions.Logging.Test/TestLogger.cs
+++ b/test/Microsoft.Extensions.Logging.Test/TestLogger.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.Logging.Test
 
         public string Name { get; set; }
 
-        public IDisposable BeginScopeImpl(object state)
+        public IDisposable BeginScope<TState>(TState state)
         {
             _scope = state;
 
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.Logging.Test
                 Scope = state,
             });
 
-            return new NoopDisposable();
+            return NoopDisposable.Instance;
         }
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
@@ -65,6 +65,8 @@ namespace Microsoft.Extensions.Logging.Test
 
         private class NoopDisposable : IDisposable
         {
+            public static NoopDisposable Instance = new NoopDisposable();
+
             public void Dispose()
             {
             }

--- a/test/Microsoft.Extensions.Logging.Test/TraceSourceScopeTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/TraceSourceScopeTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.Logging.Test
 
             // Act
             var a = Trace.CorrelationManager.LogicalOperationStack.Peek();
-            var scope = logger.BeginScopeImpl(state);
+            var scope = logger.BeginScope(state);
             var b = Trace.CorrelationManager.LogicalOperationStack.Peek();
             scope.Dispose();
             var c = Trace.CorrelationManager.LogicalOperationStack.Peek();

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/NullLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/NullLoggerTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.Logging.Testing
             var logger = NullLogger.Instance;
 
             // Act & Assert
-            using (logger.BeginScopeImpl(null))
+            using (logger.BeginScope("48656c6c6f20576f726c64"))
             {
             }
         }


### PR DESCRIPTION
Reduces allocations when none of the registered loggers are tracking scope state. In particular when there are no loggers at all.

Closes #366 
