### PR TITLE
Return IServiceCollection from AddLogging so that additional calls can be chained

### DIFF
--- a/src/Microsoft.Extensions.Logging/LoggingServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Logging/LoggingServiceCollectionExtensions.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds logging services to the specified <see cref="IServiceCollection" />.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
-        public static void AddLogging(this IServiceCollection services)
+        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        public static IServiceCollection AddLogging(this IServiceCollection services)
         {
             if (services == null)
             {
@@ -25,6 +26,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.TryAdd(ServiceDescriptor.Singleton<ILoggerFactory, LoggerFactory>());
             services.TryAdd(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(Logger<>)));
+
+            return services;
         }
     }
 }

--- a/test/Microsoft.Extensions.Logging.Test/LoggingServiceCollectionExtensionsTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/LoggingServiceCollectionExtensionsTest.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Extensions.Logging.Test
+{
+    public class LoggingServiceCollectionExtensionsTest
+    {
+        [Fact]
+        public void AddLogging_allows_chaining()
+        {
+            var services = new ServiceCollection();
+
+            Assert.Same(services, services.AddLogging());
+        }
+    }
+}

--- a/test/Microsoft.Extensions.Logging.Test/project.json
+++ b/test/Microsoft.Extensions.Logging.Test/project.json
@@ -4,6 +4,7 @@
   },
   "dependencies": {
     "Microsoft.AspNetCore.Testing": "1.0.0-*",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0-*",
     "Microsoft.Extensions.Logging": "1.0.0-*",
     "Microsoft.Extensions.Logging.Console": "1.0.0-*",
     "Microsoft.Extensions.Logging.Debug": "1.0.0-*",


### PR DESCRIPTION
Previously the AddLogging method did this. It is also common in other builder methods like this. It doesn't do any harm for those that don't want to chain and allows cleaner code with fewer variable declarations for those that do.

More details:
We often write code like this:
```C#\
var appServiceProivder = new ServiceCollection()
    .AddLogging()
    .AddCaching()
    .BuildServiceProvider();
```
This is really clean and easy to read. When we are no longer able to chain we have to write this instead:
```C#
var serviceCollection = new ServiceCollection();
serviceCollection.AddLogging();
serviceCollection.AddCaching();
var appServiceProivder = serviceCollection.BuildServiceProvider();
```
This additional clutter detracts from the overall readability of the code.

Furthermore, the benefits of this kind of pattern are cascading. For example, it lets us use expression body syntax to again create very clear, very readable code:
```C#
protected virtual void ConfigureServices([NotNull] IServiceCollection services)
    => services
        .AddSingleton<CSharpHelper>()
        .AddSingleton<CSharpMigrationOperationGenerator>()
        .AddSingleton<CSharpSnapshotGenerator>()
        .AddSingleton<MigrationsCodeGenerator, CSharpMigrationsGenerator>()
        .AddScaffolding()
        .AddLogging();
```
This was the reason when these methods where designed a couple of years ago they allowed chaining. I'm not sure why we think this is no longer relevant. Also, returning the service collection as opposed to void doesn't force anybody to use chaining if they don't want to, so what is the downside?