### PR TITLE
Extension methods for Log*(exception, message, args)

### DIFF
--- a/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs
@@ -56,6 +56,23 @@ namespace Microsoft.Extensions.Logging
         /// Formats and writes a debug log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+        /// <param name="exception">The exception to log.</param>
+        /// <param name="message">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void LogDebug(this ILogger logger, Exception exception, string message, params object[] args)
+        {
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            logger.Log(LogLevel.Debug, 0, new FormattedLogValues(message, args), exception, _messageFormatter);
+        }
+
+        /// <summary>
+        /// Formats and writes a debug log message.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="message">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void LogDebug(this ILogger logger, string message, params object[] args)
@@ -103,6 +120,23 @@ namespace Microsoft.Extensions.Logging
             }
 
             logger.Log(LogLevel.Trace, eventId, new FormattedLogValues(message, args), null, _messageFormatter);
+        }
+
+        /// <summary>
+        /// Formats and writes a trace log message.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+        /// <param name="exception">The exception to log.</param>
+        /// <param name="message">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void LogTrace(this ILogger logger, Exception exception, string message, params object[] args)
+        {
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            logger.Log(LogLevel.Trace, 0, new FormattedLogValues(message, args), exception, _messageFormatter);
         }
 
         /// <summary>
@@ -162,6 +196,23 @@ namespace Microsoft.Extensions.Logging
         /// Formats and writes an informational log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+        /// <param name="exception">The exception to log.</param>
+        /// <param name="message">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void LogInformation(this ILogger logger, Exception exception, string message, params object[] args)
+        {
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            logger.Log(LogLevel.Information, 0, new FormattedLogValues(message, args), exception, _messageFormatter);
+        }
+
+        /// <summary>
+        /// Formats and writes an informational log message.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="message">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void LogInformation(this ILogger logger, string message, params object[] args)
@@ -209,6 +260,23 @@ namespace Microsoft.Extensions.Logging
             }
 
             logger.Log(LogLevel.Warning, eventId, new FormattedLogValues(message, args), null, _messageFormatter);
+        }
+
+        /// <summary>
+        /// Formats and writes a warning log message.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+        /// <param name="exception">The exception to log.</param>
+        /// <param name="message">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void LogWarning(this ILogger logger, Exception exception, string message, params object[] args)
+        {
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            logger.Log(LogLevel.Warning, 0, new FormattedLogValues(message, args), exception, _messageFormatter);
         }
 
         /// <summary>
@@ -268,6 +336,23 @@ namespace Microsoft.Extensions.Logging
         /// Formats and writes an error log message.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+        /// <param name="exception">The exception to log.</param>
+        /// <param name="message">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void LogError(this ILogger logger, Exception exception, string message, params object[] args)
+        {
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            logger.Log(LogLevel.Error, 0, new FormattedLogValues(message, args), exception, _messageFormatter);
+        }
+
+        /// <summary>
+        /// Formats and writes an error log message.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="message">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void LogError(this ILogger logger, string message, params object[] args)
@@ -315,6 +400,23 @@ namespace Microsoft.Extensions.Logging
             }
 
             logger.Log(LogLevel.Critical, eventId, new FormattedLogValues(message, args), null, _messageFormatter);
+        }
+
+        /// <summary>
+        /// Formats and writes a critical log message.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+        /// <param name="exception">The exception to log.</param>
+        /// <param name="message">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void LogCritical(this ILogger logger, Exception exception, string message, params object[] args)
+        {
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            logger.Log(LogLevel.Critical, 0, new FormattedLogValues(message, args), exception, _messageFormatter);
         }
 
         /// <summary>

--- a/test/Microsoft.Extensions.Logging.Test/LoggerExtensionsTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/LoggerExtensionsTest.cs
@@ -251,30 +251,51 @@ namespace Microsoft.Extensions.Logging.Test
             var logger = SetUp(sink);
 
             // Act
-            logger.LogWarning(0, _exception, _state);
-            logger.LogError(0, _exception, _state);
-            logger.LogCritical(0, _exception, _state);
+            logger.LogTrace(_exception, _state);
+            logger.LogInformation(_exception, _state);
+            logger.LogWarning(_exception, _state);
+            logger.LogError(_exception, _state);
+            logger.LogCritical(_exception, _state);
+            logger.LogDebug(_exception, _state);
 
             // Assert
-            Assert.Equal(3, sink.Writes.Count);
+            Assert.Equal(6, sink.Writes.Count);
 
-            var warning = sink.Writes[0];
+            var trace = sink.Writes[0];
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Equal(_state, trace.State.ToString());
+            Assert.Equal(0, trace.EventId);
+            Assert.Equal(_exception, trace.Exception);
+
+            var information = sink.Writes[1];
+            Assert.Equal(LogLevel.Information, information.LogLevel);
+            Assert.Equal(_state, information.State.ToString());
+            Assert.Equal(0, information.EventId);
+            Assert.Equal(_exception, information.Exception);
+
+            var warning = sink.Writes[2];
             Assert.Equal(LogLevel.Warning, warning.LogLevel);
             Assert.Equal(_state, warning.State.ToString());
             Assert.Equal(0, warning.EventId);
             Assert.Equal(_exception, warning.Exception);
 
-            var error = sink.Writes[1];
+            var error = sink.Writes[3];
             Assert.Equal(LogLevel.Error, error.LogLevel);
             Assert.Equal(_state, error.State.ToString());
             Assert.Equal(0, error.EventId);
             Assert.Equal(_exception, error.Exception);
 
-            var critical = sink.Writes[2];
+            var critical = sink.Writes[4];
             Assert.Equal(LogLevel.Critical, critical.LogLevel);
             Assert.Equal(_state, critical.State.ToString());
             Assert.Equal(0, critical.EventId);
             Assert.Equal(_exception, critical.Exception);
+
+            var debug = sink.Writes[5];
+            Assert.Equal(LogLevel.Debug, debug.LogLevel);
+            Assert.Equal(_state, debug.State.ToString());
+            Assert.Equal(0, debug.EventId);
+            Assert.Equal(_exception, debug.Exception);
         }
 
         [Fact]
@@ -285,30 +306,51 @@ namespace Microsoft.Extensions.Logging.Test
             var logger = SetUp(sink);
 
             // Act
+            logger.LogTrace(1, _exception, _state);
+            logger.LogInformation(2, _exception, _state);
             logger.LogWarning(3, _exception, _state);
             logger.LogError(4, _exception, _state);
             logger.LogCritical(5, _exception, _state);
+            logger.LogDebug(6, _exception, _state);
 
             // Assert
-            Assert.Equal(3, sink.Writes.Count);
+            Assert.Equal(6, sink.Writes.Count);
 
-            var warning = sink.Writes[0];
+            var trace = sink.Writes[0];
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Equal(_state, trace.State.ToString());
+            Assert.Equal(1, trace.EventId);
+            Assert.Equal(_exception, trace.Exception);
+
+            var information = sink.Writes[1];
+            Assert.Equal(LogLevel.Information, information.LogLevel);
+            Assert.Equal(_state, information.State.ToString());
+            Assert.Equal(2, information.EventId);
+            Assert.Equal(_exception, information.Exception);
+
+            var warning = sink.Writes[2];
             Assert.Equal(LogLevel.Warning, warning.LogLevel);
             Assert.Equal(_state, warning.State.ToString());
             Assert.Equal(3, warning.EventId);
             Assert.Equal(_exception, warning.Exception);
 
-            var error = sink.Writes[1];
+            var error = sink.Writes[3];
             Assert.Equal(LogLevel.Error, error.LogLevel);
             Assert.Equal(_state, error.State.ToString());
             Assert.Equal(4, error.EventId);
             Assert.Equal(_exception, error.Exception);
 
-            var critical = sink.Writes[2];
+            var critical = sink.Writes[4];
             Assert.Equal(LogLevel.Critical, critical.LogLevel);
             Assert.Equal(_state, critical.State.ToString());
             Assert.Equal(5, critical.EventId);
             Assert.Equal(_exception, critical.Exception);
+
+            var debug = sink.Writes[5];
+            Assert.Equal(LogLevel.Debug, debug.LogLevel);
+            Assert.Equal(_state, debug.State.ToString());
+            Assert.Equal(6, debug.EventId);
+            Assert.Equal(_exception, debug.Exception);
         }
 
         [Fact]


### PR DESCRIPTION
This PR adds the following extension method: 

`Log....(this ILogger logger, Exception exception, string message, params object[] args);`

This has been requested in #350 and #294.

I think this would be a great addition for two reasons:
- There already are other extension methods without EventId - having this method makes it more consistent
- This makes EventIds completely optional for people who don't want to use them
