### PR TITLE
[Prototype] Using Configuration Monitor in Logging

### DIFF
--- a/samples/SampleApp/Program.cs
+++ b/samples/SampleApp/Program.cs
@@ -30,9 +30,12 @@ namespace SampleApp
             // How to configure the console logger to reload based on a configuration file.
             //
             //
-            var loggingConfiguration = new ConfigurationBuilder().AddJsonFile("logging.json").Build();
+            var loggingConfiguration = new ConfigurationBuilder().AddJsonFile(source => 
+            {
+                source.Path = "logging.json";
+                source.ReloadOnChange = true;
+            }).Build();
             factory.AddConsole(loggingConfiguration);
-            loggingConfiguration.ReloadOnChanged("logging.json");
 
             // How to configure the console logger to use settings provided in code.
             //
@@ -60,26 +63,20 @@ namespace SampleApp
 
             public RandomReloadingConsoleSettings()
             {
-                Reload();
-            }
-
-            public IChangeToken ChangeToken { get; private set; }
-
-            public bool IncludeScopes { get; }
-
-            private Dictionary<string, LogLevel> Switches { get; set; }
-
-            public IConsoleLoggerSettings Reload()
-            {
+                Monitor = new ChangeMonitor<IConsoleLoggerSettings>(this);
                 ChangeToken = _files.Watch("logging.json");
                 Switches = new Dictionary<string, LogLevel>()
                 {
                     ["Default"] = (LogLevel)(DateTimeOffset.Now.Second % 5 + 1),
                     ["Microsoft"] = (LogLevel)(DateTimeOffset.Now.Second % 5 + 1),
                 };
-
-                return this;
             }
+
+            public bool IncludeScopes { get; }
+
+            public IChangeMonitor<IConsoleLoggerSettings> Monitor { get; }
+
+            private Dictionary<string, LogLevel> Switches { get; set; }
 
             public bool TryGetSwitch(string name, out LogLevel level)
             {

--- a/samples/SampleApp/Program.cs
+++ b/samples/SampleApp/Program.cs
@@ -57,6 +57,7 @@ namespace SampleApp
             //factory.AddConsole(new RandomReloadingConsoleSettings());
         }
 
+
         private class RandomReloadingConsoleSettings : IConsoleLoggerSettings
         {
             private PhysicalFileProvider _files = new PhysicalFileProvider(PlatformServices.Default.Application.ApplicationBasePath);
@@ -64,7 +65,9 @@ namespace SampleApp
             public RandomReloadingConsoleSettings()
             {
                 Monitor = new ChangeMonitor<IConsoleLoggerSettings>(this);
-                ChangeToken = _files.Watch("logging.json");
+                // TODO: we should push Monitor into FileSystem as well
+                //_files.Monitor.RegisterOnChanged(_ => Monitor.RaiseChanged());
+                //ChangeToken = _files.Watch("logging.json");
                 Switches = new Dictionary<string, LogLevel>()
                 {
                     ["Default"] = (LogLevel)(DateTimeOffset.Now.Second % 5 + 1),

--- a/src/Microsoft.Extensions.Logging.Console/ConfigurationConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConfigurationConsoleLoggerSettings.cs
@@ -14,10 +14,11 @@ namespace Microsoft.Extensions.Logging.Console
         public ConfigurationConsoleLoggerSettings(IConfiguration configuration)
         {
             _configuration = configuration;
-            ChangeToken = configuration.GetReloadToken();
-        }
+            Monitor = new ChangeMonitor<IConsoleLoggerSettings>(this);
 
-        public IChangeToken ChangeToken { get; private set; }
+            // Just chain the notifaction from config
+            configuration.Monitor.RegisterOnChanged(_ => Monitor.RaiseChanged());
+        }
 
         public bool IncludeScopes
         {
@@ -41,11 +42,7 @@ namespace Microsoft.Extensions.Logging.Console
             }
         }
 
-        public IConsoleLoggerSettings Reload()
-        {
-            ChangeToken = null;
-            return new ConfigurationConsoleLoggerSettings(_configuration);
-        }
+        public IChangeMonitor<IConsoleLoggerSettings> Monitor { get; }
 
         public bool TryGetSwitch(string name, out LogLevel level)
         {

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerProvider.cs
@@ -37,28 +37,21 @@ namespace Microsoft.Extensions.Logging.Console
 
             _settings = settings;
 
-            if (_settings.ChangeToken != null)
+            if (_settings.Monitor != null)
             {
-                _settings.ChangeToken.RegisterChangeCallback(OnConfigurationReload, null);
+                _settings.Monitor.RegisterOnChanged(OnSettingsChange);
             }
         }
 
-        private void OnConfigurationReload(object state)
+        private void OnSettingsChange(IConsoleLoggerSettings settings)
         {
-            // The settings object needs to change here, because the old one is probably holding on
-            // to an old change token.
-            _settings = _settings.Reload();
+            // This is most likely the same object
+            _settings = settings;
 
             foreach (var logger in _loggers.Values)
             {
                 logger.Filter = GetFilter(logger.Name, _settings);
                 logger.IncludeScopes = _settings.IncludeScopes;
-            }
-
-            // The token will change each time it reloads, so we need to register again.
-            if (_settings?.ChangeToken != null)
-            {
-                _settings.ChangeToken.RegisterChangeCallback(OnConfigurationReload, null);
             }
         }
 

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerSettings.cs
@@ -9,16 +9,12 @@ namespace Microsoft.Extensions.Logging.Console
 {
     public class ConsoleLoggerSettings : IConsoleLoggerSettings
     {
-        public IChangeToken ChangeToken { get; set; }
 
         public bool IncludeScopes { get; set; }
 
-        public IDictionary<string, LogLevel> Switches { get; set; } = new Dictionary<string, LogLevel>();
+        public IChangeMonitor<IConsoleLoggerSettings> Monitor { get; set; }
 
-        public IConsoleLoggerSettings Reload()
-        {
-            return this;
-        }
+        public IDictionary<string, LogLevel> Switches { get; set; } = new Dictionary<string, LogLevel>();
 
         public bool TryGetSwitch(string name, out LogLevel level)
         {

--- a/src/Microsoft.Extensions.Logging.Console/IConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/IConsoleLoggerSettings.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.Extensions.Primitives;
+﻿using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Logging.Console
 {
@@ -7,10 +6,8 @@ namespace Microsoft.Extensions.Logging.Console
     {
         bool IncludeScopes { get; }
 
-        IChangeToken ChangeToken { get; }
+        IChangeMonitor<IConsoleLoggerSettings> Monitor { get; }
 
         bool TryGetSwitch(string name, out LogLevel level);
-
-        IConsoleLoggerSettings Reload();
     }
 }

--- a/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
@@ -725,6 +725,11 @@ namespace Microsoft.Extensions.Logging.Test
 
         private class MockConsoleLoggerSettings : IConsoleLoggerSettings
         {
+            public MockConsoleLoggerSettings()
+            {
+                Monitor = new ChangeMonitor<IConsoleLoggerSettings>(this);
+            }
+
             public CancellationTokenSource Cancel { get; set; }
 
             public IChangeToken ChangeToken => new CancellationChangeToken(Cancel.Token);
@@ -733,10 +738,7 @@ namespace Microsoft.Extensions.Logging.Test
 
             public bool IncludeScopes { get; set; }
 
-            public IConsoleLoggerSettings Reload()
-            {
-                return this;
-            }
+            public IChangeMonitor<IConsoleLoggerSettings> Monitor { get; }
 
             public bool TryGetSwitch(string name, out LogLevel level)
             {

--- a/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
@@ -645,7 +645,6 @@ namespace Microsoft.Extensions.Logging.Test
             // Arrange
             var settings = new MockConsoleLoggerSettings()
             {
-                Cancel = new CancellationTokenSource(),
                 Switches =
                 {
                     ["Test"] = LogLevel.Information,
@@ -660,11 +659,8 @@ namespace Microsoft.Extensions.Logging.Test
 
             settings.Switches["Test"] = LogLevel.Trace;
 
-            var cancellationTokenSource = settings.Cancel;
-            settings.Cancel = new CancellationTokenSource();
-
             // Act
-            cancellationTokenSource.Cancel();
+            settings.Monitor.RaiseChanged();
 
             // Assert
             Assert.True(logger.IsEnabled(LogLevel.Trace));
@@ -676,7 +672,6 @@ namespace Microsoft.Extensions.Logging.Test
             // Arrange
             var settings = new MockConsoleLoggerSettings()
             {
-                Cancel = new CancellationTokenSource(),
                 Switches =
                 {
                     ["Test"] = LogLevel.Information,
@@ -694,10 +689,7 @@ namespace Microsoft.Extensions.Logging.Test
             {
                 settings.Switches["Test"] = i % 2 == 0 ? LogLevel.Information : LogLevel.Trace;
 
-                var cancellationTokenSource = settings.Cancel;
-                settings.Cancel = new CancellationTokenSource();
-
-                cancellationTokenSource.Cancel();
+                settings.Monitor.RaiseChanged();
 
                 Assert.Equal(i % 2 == 1, logger.IsEnabled(LogLevel.Trace));
             }
@@ -729,11 +721,6 @@ namespace Microsoft.Extensions.Logging.Test
             {
                 Monitor = new ChangeMonitor<IConsoleLoggerSettings>(this);
             }
-
-            public CancellationTokenSource Cancel { get; set; }
-
-            public IChangeToken ChangeToken => new CancellationChangeToken(Cancel.Token);
-
             public IDictionary<string, LogLevel> Switches { get; } = new Dictionary<string, LogLevel>();
 
             public bool IncludeScopes { get; set; }


### PR DESCRIPTION
Logging consumption side of the proposed changes to move away from IChangeToken, we should expose something similar for the equivalent of IFileProvider.Watch as well...

https://github.com/aspnet/Configuration/pull/412

@divega @lodejard thoughts?  I definitely think hiding the logic revolving change token subscriptions is worth doing if we can