### PR TITLE
Console Logger Settings should not have to respect Enum case

### DIFF
--- a/src/Microsoft.Extensions.Logging.Console/ConfigurationConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConfigurationConsoleLoggerSettings.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Extensions.Logging.Console
                 level = LogLevel.None;
                 return false;
             }
-            else if (Enum.TryParse<LogLevel>(value, out level))
+            else if (Enum.TryParse<LogLevel>(value, true, out level))
             {
                 return true;
             }


### PR DESCRIPTION
See https://github.com/aspnet/Logging/issues/381
