### PR TITLE
Addendum to #405

### DIFF
--- a/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceFactoryExtensions.cs
@@ -11,6 +11,23 @@ namespace Microsoft.Extensions.Logging
     {
         public static ILoggerFactory AddTraceSource(
             this ILoggerFactory factory,
+            string switchName)
+        {
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            if (switchName == null)
+            {
+                throw new ArgumentNullException(nameof(switchName));
+            }
+
+            return factory.AddTraceSource(new SourceSwitch(switchName));
+        }
+
+        public static ILoggerFactory AddTraceSource(
+            this ILoggerFactory factory,
             string switchName,
             TraceListener listener)
         {
@@ -30,6 +47,25 @@ namespace Microsoft.Extensions.Logging
             }
 
             return factory.AddTraceSource(new SourceSwitch(switchName), listener);
+        }
+
+        public static ILoggerFactory AddTraceSource(
+            this ILoggerFactory factory,
+            SourceSwitch sourceSwitch)
+        {
+            if (factory == null)
+            {
+                throw new ArgumentNullException(nameof(factory));
+            }
+
+            if (sourceSwitch == null)
+            {
+                throw new ArgumentNullException(nameof(sourceSwitch));
+            }
+
+            factory.AddProvider(new TraceSourceLoggerProvider(sourceSwitch));
+
+            return factory;
         }
 
         public static ILoggerFactory AddTraceSource(

--- a/test/Microsoft.Extensions.Logging.Test/TraceSourceLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/TraceSourceLoggerTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.Logging.Test
             var logger = factory.CreateLogger("Test");
 
             // Act
-            factory.AddTraceSource(testSwitch, new ConsoleTraceListener());
+            factory.AddTraceSource(testSwitch);
 
             // Assert
             Assert.True(logger.IsEnabled(LogLevel.Critical));
@@ -49,8 +49,8 @@ namespace Microsoft.Extensions.Logging.Test
             var logger = factory.CreateLogger("Test");
 
             // Act
-            factory.AddTraceSource(firstSwitch, new ConsoleTraceListener());
-            factory.AddTraceSource(secondSwitch, new ConsoleTraceListener());
+            factory.AddTraceSource(firstSwitch);
+            factory.AddTraceSource(secondSwitch);
 
             // Assert
             Assert.Equal(expected, logger.IsEnabled(LogLevel.Information));


### PR DESCRIPTION
We enabled passing null TraceListener but extension methods were not updated accordingly and would still not allow to pass a null TraceListner.