### PR TITLE
Fixed ArgumentNullException on ConsoleLoggerProvider

### DIFF
--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerProvider.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Extensions.Logging.Console
             foreach (var logger in _loggers.Values)
             {
                 logger.Filter = GetFilter(logger.Name, _settings);
-                logger.IncludeScopes = _settings.IncludeScopes;
+                logger.IncludeScopes = _settings?.IncludeScopes ?? false;
             }
 
             // The token will change each time it reloads, so we need to register again.
@@ -69,7 +69,7 @@ namespace Microsoft.Extensions.Logging.Console
 
         private ConsoleLogger CreateLoggerImplementation(string name)
         {
-            return new ConsoleLogger(name, GetFilter(name, _settings), _settings.IncludeScopes);
+            return new ConsoleLogger(name, GetFilter(name, _settings), _settings?.IncludeScopes ?? false);
         }
 
         private Func<string, LogLevel, bool> GetFilter(string name, IConsoleLoggerSettings settings)


### PR DESCRIPTION
`ConsoleLoggerProvider.OnConfigurationReload(object)` is supposed to support that `IConsoleLoggerSettings.Reload()` might return null.

This fix prevents an ArgumentNullException to be thrown when this happens.
