### PR TITLE
Switched URL to elmah.io extensions logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project is part of ASP.NET Core. You can find samples, documentation and ge
 Community projects adapt _Microsoft.Extensions.Logging_ for use with different back-ends.
 
  * [Serilog](https://github.com/serilog/serilog-framework-logging) - provider for the Serilog library
- * [elmah.io](https://github.com/elmahio/Elmah.Io.Framework.Logging) - provider for the elmah.io service
+ * [elmah.io](https://github.com/elmahio/Elmah.Io.Extensions.Logging) - provider for the elmah.io service
  * [Loggr](https://github.com/imobile3/Loggr.Extensions.Logging) - provider for the Loggr service
  * [NLog](https://github.com/NLog/NLog.Extensions.Logging) - provider for the NLog library
  

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project is part of ASP.NET Core. You can find samples, documentation and ge
 Community projects adapt _Microsoft.Extensions.Logging_ for use with different back-ends.
 
  * [Serilog](https://github.com/serilog/serilog-framework-logging) - provider for the Serilog library
- * [elmah.io](https://github.com/elmahio/Elmah.Io.AspNetCore) - provider for the elmah.io service
+ * [elmah.io](https://github.com/elmahio/Elmah.Io.Extensions.Logging) - provider for the elmah.io service
  * [Loggr](https://github.com/imobile3/Loggr.Extensions.Logging) - provider for the Loggr service
  * [NLog](https://github.com/NLog/NLog.Extensions.Logging) - provider for the NLog library
  

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This project is part of ASP.NET Core. You can find samples, documentation and ge
 Community projects adapt _Microsoft.Extensions.Logging_ for use with different back-ends.
 
  * [Serilog](https://github.com/serilog/serilog-framework-logging) - provider for the Serilog library
- * [elmah.io](https://github.com/elmahio/Elmah.Io.Extensions.Logging) - provider for the elmah.io service
+ * [elmah.io](https://github.com/elmahio/Elmah.Io.AspNetCore) - provider for the elmah.io service
  * [Loggr](https://github.com/imobile3/Loggr.Extensions.Logging) - provider for the Loggr service
  * [NLog](https://github.com/NLog/NLog.Extensions.Logging) - provider for the NLog library
  


### PR DESCRIPTION
We've created a new logger for elmah.io based on .NET Core.