### PR TITLE
Fix EventLogger in .NET 4.5.2

### DIFF
--- a/src/Microsoft.Extensions.Logging.EventSource/EventSourceLogger.cs
+++ b/src/Microsoft.Extensions.Logging.EventSource/EventSourceLogger.cs
@@ -37,7 +37,22 @@ namespace Microsoft.Extensions.Logging.EventSourceLogger
 
         public string CategoryName { get; }
 
-        public LogLevel Level { get; set; }
+        private LogLevel _level;
+
+        public LogLevel Level
+        {
+            get
+            {
+                // need to check if the filter spec and internal event source level has changed
+                // and update the loggers level if it has
+                _eventSource.ApplyFilterSpec();
+                return _level;
+            }
+            set
+            {
+                _level = value;
+            }
+        }
 
         // Loggers created by a single provider form a linked list
         public EventSourceLogger Next { get; }

--- a/src/Microsoft.Extensions.Logging.EventSource/EventSourceLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.EventSource/EventSourceLoggerProvider.cs
@@ -37,6 +37,9 @@ namespace Microsoft.Extensions.Logging.EventSourceLogger
         /// </summary>
         public ILogger CreateLogger(string categoryName)
         {
+            // need to check if the filter spec and internal event source level has changed
+            // and update the _defaultLevel if it has
+            _eventSource.ApplyFilterSpec();
             var newLogger = _loggers = new EventSourceLogger(categoryName, _factoryID, _eventSource, _loggers);
             newLogger.Level = ParseLevelSpecs(_filterSpec, _defaultLevel, newLogger.CategoryName);
             return newLogger;

--- a/test/Microsoft.Extensions.Logging.EventSource.Test/EventSourceLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.EventSource.Test/EventSourceLoggerTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Extensions.Logging.Test
                 factory.AddEventSourceLogger();
 
                 var listenerSettings = new TestEventListener.ListenerSettings();
-                listenerSettings.Keywords = EventKeywords.None;
+                listenerSettings.Keywords = (EventKeywords)(-1);
                 listenerSettings.FilterSpec = null;
                 listenerSettings.Level = default(EventLevel);
                 testListener.EnableEvents(listenerSettings);


### PR DESCRIPTION
The behavior of `OnEventCommand` callback changed between `.NET 4.5.2` and `.NET 4.6`. In the latter the internal `EventSource` level has changed before calling the `OnEventCommand` callback which was behavior we relied on to set the loggers level. Because it isn't set before the callback in `.NET 4.5.2` we delay the original behavior of the callback until a time after the Event change occurs.
#328