### PR TITLE
Implement add and subtract operators for EventId's

### DIFF
--- a/src/Microsoft.Extensions.Logging.Abstractions/EventId.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/EventId.cs
@@ -5,29 +5,24 @@ namespace Microsoft.Extensions.Logging
 {
     public struct EventId
     {
-        private int _id;
-        private string _name;
-
         public EventId(int id, string name = null)
         {
-            _id = id;
-            _name = name;
+            Id = id;
+            Name = name;
         }
 
-        public int Id
+        public int Id { get; }
+
+        public string Name { get; }
+
+        public static EventId operator +(EventId left, EventId right)
         {
-            get
-            {
-                return _id;
-            }
+            return new EventId(left.Id + right.Id);
         }
 
-        public string Name
+        public static EventId operator -(EventId left, EventId right)
         {
-            get
-            {
-                return _name;
-            }
+            return new EventId(left.Id - right.Id);
         }
 
         public static implicit operator EventId(int i)
@@ -37,14 +32,7 @@ namespace Microsoft.Extensions.Logging
 
         public override string ToString()
         {
-            if (_name != null)
-            {
-                return _name;
-            }
-            else
-            {
-                return _id.ToString();
-            }
+            return Name ?? Id.ToString();
         }
     }
 }

--- a/test/Microsoft.Extensions.Logging.Test/EventIdTests.cs
+++ b/test/Microsoft.Extensions.Logging.Test/EventIdTests.cs
@@ -1,0 +1,67 @@
+﻿using Xunit;
+
+namespace Microsoft.Extensions.Logging.Test
+{
+    public class EventIdTests
+    {
+        [Fact]
+        public void EventId_AddInt_ReturnsCorrectEventId()
+        {
+            // Arrange
+            var event1 = new EventId(1);
+            var adder = 2;
+
+            // Act
+            var event3 = event1 + adder;
+
+            // Assert
+            Assert.Equal(3, event3.Id);
+            Assert.Equal(new EventId(3), event3);
+        }
+
+        [Fact]
+        public void EventId_SubtractInt_ReturnsCorrectEventId()
+        {
+            // Arrange
+            var event42 = new EventId(42);
+            var subtracter = 12;
+
+            // Act
+            var event30 = event42 - subtracter;
+
+            // Assert
+            Assert.Equal(30, event30.Id);
+            Assert.Equal(new EventId(30), event30);
+        }
+
+        [Fact]
+        public void EventId_AddEventId_ReturnsCorrectEventId()
+        {
+            // Arrange
+            var event1 = new EventId(1);
+            var adder = new EventId(2);
+
+            // Act
+            var event3 = event1 + adder;
+
+            // Assert
+            Assert.Equal(3, event3.Id);
+            Assert.Equal(new EventId(3), event3);
+        }
+
+        [Fact]
+        public void EventId_SubtractEventId_ReturnsCorrectEventId()
+        {
+            // Arrange
+            var event42 = new EventId(42);
+            var subtracter = new EventId(12);
+
+            // Act
+            var event30 = event42 - subtracter;
+
+            // Assert
+            Assert.Equal(30, event30.Id);
+            Assert.Equal(new EventId(30), event30);
+        }
+    }
+}


### PR DESCRIPTION
- Implement `+` operator
- Implement `-` operator
- Added unit tests
- Use C# 6 read-only properties
- Use null coalescing in `ToString()` method

This allows for a event class like this:

``` csharp
public static class Events
{
    public static EventId Base = new EventId(100);
    public static EventId SomeEvent = Base + 1;
    public static EventId AnotherEvent = Base + 2;
    public static EventId MoreEvent = Base + 3;
}
```
