### PR TITLE
Remove Abstractions Linq dependency

### DIFF
--- a/src/Microsoft.Extensions.Logging.Abstractions/Internal/LogValuesFormatter.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/Internal/LogValuesFormatter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Globalization;
 using System.Text;
 
@@ -140,12 +139,20 @@ namespace Microsoft.Extensions.Logging.Internal
                     var enumerable = value as IEnumerable;
                     if (enumerable != null)
                     {
-                        values[i] = string.Join(", ", enumerable.Cast<object>().Select(o => o ?? NullValue));
+                        values[i] = string.Join(", ", CastIteratorToString(enumerable));
                     }
                 }
             }
 
             return string.Format(CultureInfo.InvariantCulture, _format, values ?? EmptyArray);
+        }
+
+        private static IEnumerable<string> CastIteratorToString(IEnumerable source)
+        {
+            foreach (var obj in source)
+            {
+                yield return obj?.ToString() ?? NullValue;
+            }
         }
 
         public KeyValuePair<string, object> GetValue(object[] values, int index)

--- a/src/Microsoft.Extensions.Logging.Abstractions/project.json
+++ b/src/Microsoft.Extensions.Logging.Abstractions/project.json
@@ -27,8 +27,7 @@
         "System.Globalization": "4.0.11-*",
         "System.Reflection": "4.1.0-*",
         "System.Resources.ResourceManager": "4.0.1-*",
-        "System.Runtime.Extensions": "4.1.0-*",
-        "System.Runtime.InteropServices": "4.1.0-*"
+        "System.Runtime.Extensions": "4.1.0-*"
       }
     }
   }

--- a/src/Microsoft.Extensions.Logging.Abstractions/project.json
+++ b/src/Microsoft.Extensions.Logging.Abstractions/project.json
@@ -25,7 +25,6 @@
         "System.Collections.Concurrent": "4.0.12-*",
         "System.Diagnostics.Debug": "4.0.11-*",
         "System.Globalization": "4.0.11-*",
-        "System.Linq": "4.1.0-*",
         "System.Reflection": "4.1.0-*",
         "System.Resources.ResourceManager": "4.0.1-*",
         "System.Runtime.Extensions": "4.1.0-*",


### PR DESCRIPTION
Don't need to reference Linq for a tiny function and its a 125Kb dependency 

(As well as casting through object, to a `IEnumerator<object>`, to then Select for the `null`s back to `IEnumerator<object>` to then to `Join(String separator, IEnumerable<object> values)` rather than `Join(String separator, IEnumerable<String> values)` not being the greatest code path)
