### PR TITLE
Accept existing ILoggerFactory in AddLogging()

### DIFF
--- a/src/Microsoft.Extensions.Logging/LoggingServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.Logging/LoggingServiceCollectionExtensions.cs
@@ -16,15 +16,24 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds logging services to the specified <see cref="IServiceCollection" />.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection" /> to add services to.</param>
+        /// <param name="loggerFactory">An optional existing logger factory.</param>
         /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
-        public static IServiceCollection AddLogging(this IServiceCollection services)
+        public static IServiceCollection AddLogging(this IServiceCollection services, ILoggerFactory loggerFactory = null)
         {
             if (services == null)
             {
                 throw new ArgumentNullException(nameof(services));
             }
 
-            services.TryAdd(ServiceDescriptor.Singleton<ILoggerFactory, LoggerFactory>());
+            if (loggerFactory != null)
+            {
+                services.AddSingleton(loggerFactory);
+            }
+            else
+            {
+                services.TryAdd(ServiceDescriptor.Singleton<ILoggerFactory, LoggerFactory>());
+            }
+
             services.TryAdd(ServiceDescriptor.Singleton(typeof(ILogger<>), typeof(Logger<>)));
 
             return services;


### PR DESCRIPTION
Programs often initialize their own logger factory on startup before DI is initialized to get logging as soon as possible. To add the factory to DI, we have to manually call `AddSingleton(loggerFactory)`. 

However it's easy to get this wrong - the following code will not work properly because this will add the instance for the concrete type `LoggerFactory` instead of for the interface `ILoggerFactory`. This means, the existing factory will not be used, but instead AddLogging() will register a new logger factory instance.

``` csharp
var loggerFactory = new LoggerFactory();
services.AddSingleton(loggerFactory);
services.AddLogging();
```

This PR would allow us to pass an existing logger factory to `AddLogging` and therefore make sure that this problem can't occur.

This could then also be used in [aspnet/hosting -> WebHostBuilder](https://github.com/aspnet/Hosting/blob/dev/src/Microsoft.AspNetCore.Hosting/WebHostBuilder.cs#L189) 
