### PR TITLE
Add ConfigurationFilterLoggerSettings

### DIFF
--- a/src/Microsoft.Extensions.Logging.Filter/ConfigurationFilterLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Filter/ConfigurationFilterLoggerSettings.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Extensions.Logging.Filter
+{
+    /// <summary>
+    /// Filter settings for messages logged by an <see cref="ILogger"/>.
+    /// </summary>
+    public class ConfigurationFilterLoggerSettings : IFilterLoggerSettings
+    {
+        private readonly IConfiguration _configuration;
+
+        public ConfigurationFilterLoggerSettings(IConfiguration configuration)
+        {
+            _configuration = configuration;
+            ChangeToken = configuration.GetReloadToken();
+        }
+
+        public bool TryGetSwitch(string name, out LogLevel level)
+        {
+            var switches = _configuration.GetSection("LogLevel");
+            if (switches == null)
+            {
+                level = LogLevel.None;
+                return false;
+            }
+
+            var value = switches[name];
+            if (string.IsNullOrEmpty(value))
+            {
+                level = LogLevel.None;
+                return false;
+            }
+            else if (Enum.TryParse<LogLevel>(value, out level))
+            {
+                return true;
+            }
+            else
+            {
+                var message = $"Configuration value '{value}' for category '{name}' is not supported.";
+                throw new InvalidOperationException(message);
+            }
+        }
+
+        public IFilterLoggerSettings Reload()
+        {
+            ChangeToken = null;
+            return new ConfigurationFilterLoggerSettings(_configuration);
+        }
+
+        public IChangeToken ChangeToken { get; private set; }
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Filter/FilterLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Filter/FilterLoggerFactoryExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Filter;
 using Microsoft.Extensions.Logging.Filter.Internal;
 
 namespace Microsoft.Extensions.Logging
@@ -24,6 +26,22 @@ namespace Microsoft.Extensions.Logging
         public static ILoggerFactory WithFilter(this ILoggerFactory loggerFactory, IFilterLoggerSettings settings)
         {
             return new FilterLoggerFactory(loggerFactory, settings);
+        }
+        
+        /// <summary>
+        /// Registers a wrapper logger which provides a common way to filter log messages across all registered
+        ///  <see cref="ILoggerProvider"/>s.
+        /// </summary>
+        /// <param name="loggerFactory">The logger factory.</param>
+        /// <param name="configuration">The configuration to use when creating an <see cref="IFilterLoggerSettings" />.</param>
+        /// <returns>
+        /// A wrapped <see cref="ILoggerFactory"/> which provides common filtering across all registered
+        ///  logger providers.
+        /// </returns>
+        public static ILoggerFactory WithFilter(this ILoggerFactory loggerFactory, IConfiguration configuration)
+        {
+            var settings = new ConfigurationFilterLoggerSettings(configuration);
+            return loggerFactory.WithFilter(settings);
         }
     }
 }

--- a/test/Microsoft.Extensions.Logging.Test/ConfigurationFilterLoggerSettingsTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ConfigurationFilterLoggerSettingsTest.cs
@@ -1,0 +1,142 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Filter;
+using Xunit;
+
+namespace Microsoft.Extensions.Logging.Test
+{
+    public class ConfigurationFilterLoggerSettingsTest
+    {
+        [Fact]
+        public void TryGetSwitch_OnValidConfiguration_LoadsValueFromConfiguration()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>
+            {
+                ["Logging:LogLevel:System"] = "Information"
+            };
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(dict)
+                .Build();
+            var settings = new ConfigurationFilterLoggerSettings(config.GetSection("Logging"));
+
+            // Act
+            LogLevel level;
+            var success = settings.TryGetSwitch("System", out level);
+
+            // Assert
+            Assert.True(success);
+            Assert.Equal(LogLevel.Information, level);
+        }
+
+        [Fact]
+        public void TryGetSwitch_OnMissingLogLevelSection_ReturnsLogLevelNone()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>
+            {
+                ["Logging:"] = ""
+            };
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(dict)
+                .Build();
+            var settings = new ConfigurationFilterLoggerSettings(config.GetSection("Logging"));
+
+            // Act
+            LogLevel level;
+            var success = settings.TryGetSwitch("System", out level);
+
+            // Assert
+            Assert.False(success);
+            Assert.Equal(LogLevel.None, level);
+        }
+
+        [Fact]
+        public void TryGetSwitch_OnMissingSwitch_ReturnsLogLevelNone()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>
+            {
+                ["Logging:LogLevel:System"] = "Information"
+            };
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(dict)
+                .Build();
+            var settings = new ConfigurationFilterLoggerSettings(config.GetSection("Logging"));
+
+            // Act
+            LogLevel level;
+            var success = settings.TryGetSwitch("Microsoft", out level);
+
+            // Assert
+            Assert.False(success);
+            Assert.Equal(LogLevel.None, level);
+        }
+
+        [Fact]
+        public void TryGetSwitch_IfLevelNullOrEmpty_ReturnsLogLevelNone()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>
+            {
+                ["Logging:LogLevel:System"] = ""
+            };
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(dict)
+                .Build();
+            var settings = new ConfigurationFilterLoggerSettings(config.GetSection("Logging"));
+
+            // Act
+            LogLevel level;
+            var success = settings.TryGetSwitch("System", out level);
+
+            // Assert
+            Assert.False(success);
+            Assert.Equal(LogLevel.None, level);
+        }
+
+        [Fact]
+        public void TryGetSwitch_IfInvalidEnumValue_ThrowsException()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>
+            {
+                ["Logging:LogLevel:System"] = "SomethingStrange"
+            };
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(dict)
+                .Build();
+            var settings = new ConfigurationFilterLoggerSettings(config.GetSection("Logging"));
+
+            // Act Assert
+            LogLevel level;
+            Assert.Throws<InvalidOperationException>(() => settings.TryGetSwitch("System", out level));
+        }
+
+        [Fact]
+        public void Reload_ReturnsNewObject()
+        {
+            // Arrange
+            var dict = new Dictionary<string, string>
+            {
+                ["Logging:LogLevel:System"] = "SomethingStrange"
+            };
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(dict)
+                .Build();
+            var settings = new ConfigurationFilterLoggerSettings(config.GetSection("Logging"));
+
+            // Act Assert
+            var newSettings = settings.Reload();
+
+            Assert.NotNull(newSettings);
+            Assert.NotSame(settings, newSettings);
+            Assert.IsType<ConfigurationFilterLoggerSettings>(newSettings);
+
+        }
+    }
+}

--- a/test/Microsoft.Extensions.Logging.Test/project.json
+++ b/test/Microsoft.Extensions.Logging.Test/project.json
@@ -4,6 +4,7 @@
   },
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
+    "Microsoft.Extensions.Configuration": "1.1.0-*",
     "Microsoft.Extensions.DependencyInjection": "1.1.0-*",
     "Microsoft.Extensions.Logging": "1.1.0-*",
     "Microsoft.Extensions.Logging.Console": "1.1.0-*",


### PR DESCRIPTION
Add `ConfigurationFilterLoggerSettings` for `WithFilter` configuration
- Provides similar behaviour to `ConfigurationConsoleLoggerSettings`
- Add Extension method for `WithFilter`

Addresses #437
