### PR TITLE
Cleanup EventSource logging provider

### DIFF
--- a/src/Microsoft.Extensions.Logging.EventSource/EventSourceLogger.cs
+++ b/src/Microsoft.Extensions.Logging.EventSource/EventSourceLogger.cs
@@ -8,7 +8,7 @@ using System.IO;
 using System.Threading;
 using Newtonsoft.Json;
 
-namespace Microsoft.Extensions.Logging.EventSourceLogger
+namespace Microsoft.Extensions.Logging.EventSource
 {
     /// <summary>
     /// A logger that writes messages to EventSource instance.
@@ -19,9 +19,9 @@ namespace Microsoft.Extensions.Logging.EventSourceLogger
     /// </remarks>
     internal class EventSourceLogger : ILogger
     {
+        private static int _activityIds;
         private readonly LoggingEventSource _eventSource;
         private readonly int _factoryID;
-        private static int s_activityIds;
 
         public EventSourceLogger(string categoryName, int factoryID, LoggingEventSource eventSource, EventSourceLogger next)
         {
@@ -131,7 +131,7 @@ namespace Microsoft.Extensions.Logging.EventSourceLogger
                 return NoopDisposable.Instance;
             }
 
-            var id = Interlocked.Increment(ref s_activityIds);
+            var id = Interlocked.Increment(ref _activityIds);
 
             // If JsonMessage is on, use JSON format
             if (_eventSource.IsEnabled(EventLevel.Critical, LoggingEventSource.Keywords.JsonMessage))
@@ -188,7 +188,7 @@ namespace Microsoft.Extensions.Logging.EventSourceLogger
 
         private class NoopDisposable : IDisposable
         {
-            public static NoopDisposable Instance = new NoopDisposable();
+            public static readonly NoopDisposable Instance = new NoopDisposable();
 
             public void Dispose()
             {

--- a/src/Microsoft.Extensions.Logging.EventSource/EventSourceLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.EventSource/EventSourceLoggerFactoryExtensions.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Extensions.Logging.EventSourceLogger;
+using Microsoft.Extensions.Logging.EventSource;
 
 namespace Microsoft.Extensions.Logging
 {

--- a/src/Microsoft.Extensions.Logging.EventSource/EventSourceLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.EventSource/EventSourceLoggerProvider.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Diagnostics.Tracing;
 
-namespace Microsoft.Extensions.Logging.EventSourceLogger
+namespace Microsoft.Extensions.Logging.EventSource
 {
     /// <summary>
     /// The provider for the <see cref="EventSourceLogger"/>.
@@ -32,9 +32,7 @@ namespace Microsoft.Extensions.Logging.EventSourceLogger
 
         public EventSourceLoggerProvider Next { get; }
 
-        /// <summary>
         /// <inheritdoc />
-        /// </summary>
         public ILogger CreateLogger(string categoryName)
         {
             // need to check if the filter spec and internal event source level has changed
@@ -51,7 +49,7 @@ namespace Microsoft.Extensions.Logging.EventSourceLogger
         }
 
         // Sets the filtering for a particular logger provider
-        public void SetFilterSpec(string filterSpec)
+        internal void SetFilterSpec(string filterSpec)
         {
             _filterSpec = filterSpec;
             _defaultLevel = GetDefaultLevel();

--- a/src/Microsoft.Extensions.Logging.EventSource/ExceptionInfo.cs
+++ b/src/Microsoft.Extensions.Logging.EventSource/ExceptionInfo.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.Extensions.Logging.EventSourceLogger
+namespace Microsoft.Extensions.Logging.EventSource
 {
     /// <summary>
     /// Represents information about exceptions that is captured by EventSourceLogger
@@ -14,6 +14,6 @@ namespace Microsoft.Extensions.Logging.EventSourceLogger
         public string TypeName { get; set; }
         public string Message { get; set; }
         public int HResult { get; set; }
-        public string VerboseMessage { get; set; }       // This is the ToString() of the Exception
+        public string VerboseMessage { get; set; } // This is the ToString() of the Exception
     }
 }

--- a/src/Microsoft.Extensions.Logging.EventSource/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Extensions.Logging.EventSource/Properties/AssemblyInfo.cs
@@ -3,6 +3,9 @@
 
 using System.Reflection;
 using System.Resources;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Extensions.Logging.EventSource.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]
 
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: NeutralResourcesLanguage("en-us")]

--- a/test/Microsoft.Extensions.Logging.EventSource.Test/EventSourceLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.EventSource.Test/EventSourceLoggerTest.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.IO;
 using System.Linq;
-using Microsoft.Extensions.Logging.EventSourceLogger;
+using Microsoft.Extensions.Logging.EventSource;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -421,7 +421,7 @@ namespace Microsoft.Extensions.Logging.Test
                 public string FilterSpec;
             }
 
-            private EventSource _loggingEventSource;
+            private System.Diagnostics.Tracing.EventSource _loggingEventSource;
 
             public TestEventListener()
             {
@@ -449,7 +449,7 @@ namespace Microsoft.Extensions.Logging.Test
                 EnableEvents(_loggingEventSource, settings.Level, settings.Keywords, args);
             }
 
-            protected override void OnEventSourceCreated(EventSource eventSource)
+            protected override void OnEventSourceCreated(System.Diagnostics.Tracing.EventSource eventSource)
             {
                 if (eventSource.Name == "Microsoft-Extensions-Logging")
                 {

--- a/test/Microsoft.Extensions.Logging.EventSource.Test/project.json
+++ b/test/Microsoft.Extensions.Logging.EventSource.Test/project.json
@@ -1,5 +1,6 @@
 {
   "buildOptions": {
+    "keyFile": "../../tools/Key.snk",
     "warningsAsErrors": true
   },
   "dependencies": {


### PR DESCRIPTION
1. Change namespace to be the same as project name.
2. Make LoggingEventSource internal.
3. Minor code style fixes.

@pranavkm 
