### PR TITLE
Logging sample that shows how the category hierarchy filtering works

### DIFF
--- a/Logging.sln
+++ b/Logging.sln
@@ -38,6 +38,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.Loggin
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.Logging.AzureAppServices.Test", "test\Microsoft.Extensions.Logging.AzureAppServices.Test\Microsoft.Extensions.Logging.AzureAppServices.Test.xproj", "{B4A43221-DE95-47BB-A2D4-2DC761FC9419}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "ConsoleHierarchySample", "samples\ConsoleHierarchySample\ConsoleHierarchySample.xproj", "{9D6E5DC1-7978-4D55-92CB-81094D0BB259}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -218,6 +220,18 @@ Global
 		{B4A43221-DE95-47BB-A2D4-2DC761FC9419}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{B4A43221-DE95-47BB-A2D4-2DC761FC9419}.Release|x86.ActiveCfg = Release|Any CPU
 		{B4A43221-DE95-47BB-A2D4-2DC761FC9419}.Release|x86.Build.0 = Release|Any CPU
+		{9D6E5DC1-7978-4D55-92CB-81094D0BB259}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D6E5DC1-7978-4D55-92CB-81094D0BB259}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D6E5DC1-7978-4D55-92CB-81094D0BB259}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{9D6E5DC1-7978-4D55-92CB-81094D0BB259}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{9D6E5DC1-7978-4D55-92CB-81094D0BB259}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9D6E5DC1-7978-4D55-92CB-81094D0BB259}.Debug|x86.Build.0 = Debug|Any CPU
+		{9D6E5DC1-7978-4D55-92CB-81094D0BB259}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D6E5DC1-7978-4D55-92CB-81094D0BB259}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D6E5DC1-7978-4D55-92CB-81094D0BB259}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{9D6E5DC1-7978-4D55-92CB-81094D0BB259}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{9D6E5DC1-7978-4D55-92CB-81094D0BB259}.Release|x86.ActiveCfg = Release|Any CPU
+		{9D6E5DC1-7978-4D55-92CB-81094D0BB259}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -238,5 +252,6 @@ Global
 		{F3B898C3-D441-4207-A92B-420D6E73CA5D} = {09920C51-6220-4D8D-94DC-E70C13446187}
 		{854133D5-6252-4A0A-B682-BDBB83B62AE6} = {699DB330-0095-4266-B7B0-3EAB3710CA49}
 		{B4A43221-DE95-47BB-A2D4-2DC761FC9419} = {09920C51-6220-4D8D-94DC-E70C13446187}
+		{9D6E5DC1-7978-4D55-92CB-81094D0BB259} = {8C1F5D80-88EA-4961-84DC-7AC6E13951F4}
 	EndGlobalSection
 EndGlobal

--- a/global.json
+++ b/global.json
@@ -3,6 +3,6 @@
     "src"
   ],
   "sdk": {
-    "version": "1.0.0-preview2-1-003177"
+    "version": "1.0.0-preview2-003131"
   }
 }

--- a/samples/ConsoleHierarchySample/ConsoleHierarchySample.xproj
+++ b/samples/ConsoleHierarchySample/ConsoleHierarchySample.xproj
@@ -4,16 +4,14 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>9d6e5dc1-7978-4d55-92cb-81094d0bb259</ProjectGuid>
-    <RootNamespace>ConsoleSample</RootNamespace>
+    <RootNamespace>ConsoleHierarchySample</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/samples/ConsoleHierarchySample/ConsoleHierarchySample.xproj
+++ b/samples/ConsoleHierarchySample/ConsoleHierarchySample.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>9d6e5dc1-7978-4d55-92cb-81094d0bb259</ProjectGuid>
+    <RootNamespace>ConsoleSample</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/samples/ConsoleHierarchySample/LoggingEvents.cs
+++ b/samples/ConsoleHierarchySample/LoggingEvents.cs
@@ -1,0 +1,74 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ConsoleHierarchySample
+{
+    /// <summary>
+    /// Sample generic logging event IDs. 
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// NOTE: This enum is provided as an example only; it is recommended that each applications
+    /// use their own custom logging event IDs.
+    /// </para>
+    /// <para>
+    /// The structure of the event IDs are based on a structure similar to the theory of 
+    /// response codes used for Internet systems such as SMTP and HTTP.
+    /// </para>
+    /// <para>
+    /// In this case; the event IDs are based on a 4 digit system.
+    /// </para>
+    /// <para>
+    /// The first digit is the class of the event: 
+    /// 1 for startup code; 2 for events that have occurred (completed); 
+    /// 3 for actions the program initiates; 4 for warnings; 5 for errors; 8 for shutdown or
+    /// end events; and 9 for unknown or critical issues.
+    /// </para>
+    /// <para>
+    /// The class is similar to the event level (e.g. events starting with 5 will usually
+    /// be logged at the Error level).
+    /// </para>
+    /// <para>
+    /// The second digit is the area of the program: 0 for configuration or syntax; 1 for
+    /// system level; 2 for connnections; 3 for security and authentication; and 9 for 
+    /// an unknown area; such as an unhandled general exception.
+    /// </para>
+    /// <para>
+    /// Applications can use the second digit 4-8 for the major subsystems; which will
+    /// vary between applications.
+    /// </para>
+    /// </remarks>
+    public static class LoggingEvents
+    {
+        public static EventId ConfigurationStart = 1000;
+        public static EventId SystemStart = 1100;
+        public static EventId ConnectionStart = 1200;
+
+        public static EventId SystemEvent = 2100;
+        public static EventId ConnectionEvent = 2200;
+        public static EventId AuthenticationSuccess = 2300;
+
+        public static EventId ConfigurationAction = 3000;
+        public static EventId SystemAction = 3100;
+        public static EventId ConnectionAction = 3200;
+
+        public static EventId ConfigurationWarning = 4000;
+        public static EventId SystemWarning = 4100;
+        public static EventId ConnectionWarning = 4200;
+        public static EventId AuthenticationFailure = 4300;
+
+        public static EventId ConfigurationError = 5000;
+        public static EventId SystemError = 5100;
+        public static EventId ConnectionError = 5200;
+        public static EventId AuthenticationError = 5300;
+        public static EventId UnknownError = 5900;
+
+        public static EventId SystemStop = 8100;
+        public static EventId ConnectionStop = 8200;
+
+        public static EventId ConfigurationCriticalError = 9000;
+        public static EventId SystemCriticalError = 9100;
+        public static EventId ConnectionCriticalError = 9200;
+        public static EventId AuthenticationCriticalError = 9300;
+        public static EventId UnknownCriticalError = 9900;
+    }
+}

--- a/samples/ConsoleHierarchySample/LoggingEvents.cs
+++ b/samples/ConsoleHierarchySample/LoggingEvents.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
 
 namespace ConsoleHierarchySample
 {

--- a/samples/ConsoleHierarchySample/Program.cs
+++ b/samples/ConsoleHierarchySample/Program.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
+
+namespace ConsoleHierarchySample
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            // This example shows how the category hierarchy works for the console logger.
+
+            // Normally loggers are created through the strongly typed CreateLogger<T>, 
+            // which means the hierarchy of namespaces can be used to selectively turn
+            // sections of logging on and off.
+
+            var factory = new LoggerFactory();
+
+            // Qhen console settings are defined, then only the categories listed are logged;
+            // other categories default to the value of the special 'Default' (case sensitive) 
+            // category, or if not specified then they are not logged at all.
+            var consoleSettings = new ConsoleLoggerSettings();
+            consoleSettings.Switches = new Dictionary<string, LogLevel>() {
+                { "Default", LogLevel.Warning },
+                { "CompanyA.Namespace1.ClassB", LogLevel.Debug },
+                { "CompanyB", LogLevel.Information },
+            };
+            factory.AddConsole(consoleSettings);
+
+            // Normally these are created by an injected ILogger<T> and automatically extract the full class name.
+            var logger_A_1 = factory.CreateLogger("CompanyA.Namespace1");
+            var logger_A_1_a = factory.CreateLogger("CompanyA.Namespace1.ClassA");
+            var logger_A_1_b = factory.CreateLogger("CompanyA.Namespace1.ClassB");
+            var logger_A_2 = factory.CreateLogger("CompanyA.Namespace2");
+            var logger_A_2_c = factory.CreateLogger("CompanyA.Namespace2.ClassC");
+            var logger_B_3_d = factory.CreateLogger("CompanyB.Namespace3.ClassD");
+
+            logger_A_1.LogInformation(1001, "A_1 Information");
+            logger_A_1_a.LogInformation(1101, "A_1_a Information");
+            logger_A_1_b.LogInformation(1201, "A_1_b Information");
+            logger_A_2.LogInformation(1301, "A_2 Information");
+            logger_A_2_c.LogInformation(1401, "A_2_c Information");
+            logger_B_3_d.LogInformation(1501, "B_3_d Information");
+
+            logger_A_1.LogDebug("A_1 Debug");
+            logger_A_1_a.LogDebug("A_1_a Debug");
+            logger_A_1_b.LogDebug("A_1_b Debug");
+            logger_A_2.LogDebug("A_2 Debug");
+            logger_A_2_c.LogDebug("A_2_c Debug");
+            logger_B_3_d.LogDebug("B_3_d Debug");
+
+            logger_A_1.LogInformation(1002, "A_1 Information 2");
+            logger_A_1_a.LogInformation(1102, "A_1_a Information 2");
+            logger_A_1_b.LogInformation(1202, "A_1_b Information 2");
+            logger_A_2.LogInformation(1302, "A_2 Information 2");
+            logger_A_2_c.LogInformation(1402, "A_2_c Information 2");
+            logger_B_3_d.LogInformation(1502, "B_3_d Information 2");
+
+            logger_A_1.LogDebug("A_1 Debug 2");
+            logger_A_1_a.LogDebug("A_1_a Debug 2");
+            logger_A_1_b.LogDebug("A_1_b Debug 2");
+            logger_A_2.LogDebug("A_2 Debug 2");
+            logger_A_2_c.LogDebug("A_2_c Debug 2");
+            logger_B_3_d.LogDebug("B_3_d Debug 2");
+
+            logger_A_1.LogWarning(4001, "A_1 Warning");
+            logger_A_1_a.LogWarning(4101, "A_1_a Warning");
+            logger_A_1_b.LogError(5201, "A_1_b Error");
+            logger_A_2.LogWarning(4301, "A_2 Warning");
+            logger_A_2_c.LogWarning(4401, "A_2_c Warning");
+            try
+            {
+                throw new Exception("Sample");
+            }
+            catch (Exception ex)
+            {
+                logger_B_3_d.LogCritical(9501, ex, "B_3_d Critical");
+            }
+        }
+    }
+}

--- a/samples/ConsoleHierarchySample/Program.cs
+++ b/samples/ConsoleHierarchySample/Program.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Logging;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using System;
 using System.Collections.Generic;
@@ -85,26 +88,5 @@ namespace ConsoleHierarchySample
         {
             throw new NotImplementedException();
         }
-    }
-}
-
-namespace CompanyA
-{
-    namespace Namespace1
-    {
-        class ClassA { }
-        class ClassB { }
-    }
-    namespace Namespace2
-    {
-        class ClassC { }
-    }
-}
-
-namespace CompanyB
-{
-    namespace Namespace3
-    {
-        class ClassD { }
     }
 }

--- a/samples/ConsoleHierarchySample/Program.cs
+++ b/samples/ConsoleHierarchySample/Program.cs
@@ -30,60 +30,81 @@ namespace ConsoleHierarchySample
 
             // Normally these are created by an injected ILogger<T> and automatically extract the full class name.
             // Loggers at other levels (e.g. namespace) would need to be created manually.
-            var logger_A_1 = factory.CreateLogger("CompanyA.Namespace1");
-            var logger_A_1_a = factory.CreateLogger("CompanyA.Namespace1.ClassA");
-            var logger_A_1_b = factory.CreateLogger("CompanyA.Namespace1.ClassB");
-            var logger_A_2_c = factory.CreateLogger("CompanyA.Namespace2.ClassC");
-            var logger_B_3 = factory.CreateLogger("CompanyB.Namespace3");
-            var logger_B_3_d = factory.CreateLogger("CompanyB.Namespace3.ClassD");
+            var loggerNamespace1 = factory.CreateLogger("CompanyA.Namespace1");
+            var loggerClassA = factory.CreateLogger<CompanyA.Namespace1.ClassA>();
+            var loggerClassB = factory.CreateLogger<CompanyA.Namespace1.ClassB>();
+            var loggerClassC = factory.CreateLogger<CompanyA.Namespace2.ClassC>();
+            var loggerNameace3 = factory.CreateLogger("CompanyB.Namespace3");
+            var loggerClassD = factory.CreateLogger<CompanyB.Namespace3.ClassD>();
 
-            logger_A_1.LogInformation(LoggingEvents.ConfigurationStart, "A_1 Information - namespace level Configuration Start");
-            logger_A_1_a.LogInformation(LoggingEvents.SystemStart, "A_1_a Information - System Start");
-            logger_A_1_b.LogInformation(LoggingEvents.SystemEvent, "A_1_b Information - System Event");
-            logger_A_2_c.LogInformation(LoggingEvents.ConnectionEvent, "A_2_c Information - Connection Event");
-            logger_B_3.LogInformation(2301, "B_3 Information - namespace level");
-            logger_B_3_d.LogInformation(LoggingEvents.AuthenticationSuccess, "B_3_d Information - Authentication Success");
+            loggerNamespace1.LogInformation(LoggingEvents.ConfigurationStart, "A_1 Information - namespace level Configuration Start");
+            loggerClassA.LogInformation(LoggingEvents.SystemStart, "A_1_a Information - System Start");
+            loggerClassB.LogInformation(LoggingEvents.SystemEvent, "A_1_b Information - System Event");
+            loggerClassC.LogInformation(LoggingEvents.ConnectionEvent, "A_2_c Information - Connection Event");
+            loggerNameace3.LogInformation(2301, "B_3 Information - namespace level");
+            loggerClassD.LogInformation(LoggingEvents.AuthenticationSuccess, "B_3_d Information - Authentication Success");
 
             try
             {
-                logger_A_1.LogDebug("A_1 Debug");
-                logger_A_1_a.LogDebug("A_1_a Debug - Class A detail");
-                logger_A_1_b.LogDebug("A_1_b Debug - Class B detail");
-                logger_A_2_c.LogDebug("A_2_c Debug");
-                logger_B_3.LogDebug("A_2 Debug");
-                logger_B_3_d.LogDebug("B_3_d Debug");
+                loggerNamespace1.LogDebug("A_1 Debug");
+                loggerClassA.LogDebug("A_1_a Debug - Class A detail");
+                loggerClassB.LogDebug("A_1_b Debug - Class B detail");
+                loggerClassC.LogDebug("A_2_c Debug");
+                loggerNameace3.LogDebug("A_2 Debug");
+                loggerClassD.LogDebug("B_3_d Debug");
 
-                logger_A_1_a.LogDebug("A_1_a Debug 2 - Class A more detail");
-                logger_A_1_b.LogDebug("A_1_b Debug 2 - Class B more detail");
-                logger_A_2_c.LogDebug("A_2_c Debug 2");
-                logger_B_3_d.LogDebug("B_3_d Debug 2");
+                loggerClassA.LogDebug("A_1_a Debug 2 - Class A more detail");
+                loggerClassB.LogDebug("A_1_b Debug 2 - Class B more detail");
+                loggerClassC.LogDebug("A_2_c Debug 2");
+                loggerClassD.LogDebug("B_3_d Debug 2");
 
-                logger_A_1_a.LogDebug("A_1_a Debug 3 - Class A even more detail");
-                logger_A_1_b.LogDebug("A_1_b Debug 3 - Class B even more detail");
+                loggerClassA.LogDebug("A_1_a Debug 3 - Class A even more detail");
+                loggerClassB.LogDebug("A_1_b Debug 3 - Class B even more detail");
 
-                logger_A_1_a.LogDebug("A_1_a Debug 4 - Class A still going");
-                logger_A_1_b.LogDebug("A_1_b Debug 4 - Class B still going");
+                loggerClassA.LogDebug("A_1_a Debug 4 - Class A still going");
+                loggerClassB.LogDebug("A_1_b Debug 4 - Class B still going");
 
-                logger_A_1.LogWarning(LoggingEvents.ConfigurationWarning, "A_1 Warning - namespace level Configuration Warning");
-                logger_A_1_a.LogWarning(LoggingEvents.SystemWarning, "A_1_a Warning - System Warning");
-                logger_A_1_b.LogError(LoggingEvents.SystemError, "A_1_b Error - System Error");
-                logger_A_2_c.LogWarning(LoggingEvents.ConnectionWarning, "A_2_c Warning - Connection Warning");
+                loggerNamespace1.LogWarning(LoggingEvents.ConfigurationWarning, "A_1 Warning - namespace level Configuration Warning");
+                loggerClassA.LogWarning(LoggingEvents.SystemWarning, "A_1_a Warning - System Warning");
+                loggerClassB.LogError(LoggingEvents.SystemError, "A_1_b Error - System Error");
+                loggerClassC.LogWarning(LoggingEvents.ConnectionWarning, "A_2_c Warning - Connection Warning");
 
                 TestExceptionLogging();
             }
             catch (Exception ex)
             {
-                logger_B_3_d.LogCritical(LoggingEvents.AuthenticationCriticalError, ex, "B_3_d Critical = Authentication Critical Error");
+                loggerClassD.LogCritical(LoggingEvents.AuthenticationCriticalError, ex, "B_3_d Critical = Authentication Critical Error");
             }
 
-            logger_A_2_c.LogInformation(LoggingEvents.ConnectionStop, "B_3_d Information 2 - Connection Stop");
-            logger_A_1_b.LogInformation(LoggingEvents.SystemStop, "A_1_b Information 2 - System Stop");
-            logger_A_1_a.LogInformation(6102, "A_1_a Information 2");
+            loggerClassC.LogInformation(LoggingEvents.ConnectionStop, "B_3_d Information 2 - Connection Stop");
+            loggerClassB.LogInformation(LoggingEvents.SystemStop, "A_1_b Information 2 - System Stop");
+            loggerClassA.LogInformation(6102, "A_1_a Information 2");
         }
 
         private static void TestExceptionLogging()
         {
             throw new NotImplementedException();
         }
+    }
+}
+
+namespace CompanyA
+{
+    namespace Namespace1
+    {
+        class ClassA { }
+        class ClassB { }
+    }
+    namespace Namespace2
+    {
+        class ClassC { }
+    }
+}
+
+namespace CompanyB
+{
+    namespace Namespace3
+    {
+        class ClassD { }
     }
 }

--- a/samples/ConsoleHierarchySample/Program.cs
+++ b/samples/ConsoleHierarchySample/Program.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
+using System;
+using System.Collections.Generic;
 
 namespace ConsoleHierarchySample
 {
@@ -19,7 +17,7 @@ namespace ConsoleHierarchySample
 
             var factory = new LoggerFactory();
 
-            // Qhen console settings are defined, then only the categories listed are logged;
+            // When console settings are defined, then only the categories listed are logged;
             // other categories default to the value of the special 'Default' (case sensitive) 
             // category, or if not specified then they are not logged at all.
             var consoleSettings = new ConsoleLoggerSettings();
@@ -31,54 +29,61 @@ namespace ConsoleHierarchySample
             factory.AddConsole(consoleSettings);
 
             // Normally these are created by an injected ILogger<T> and automatically extract the full class name.
+            // Loggers at other levels (e.g. namespace) would need to be created manually.
             var logger_A_1 = factory.CreateLogger("CompanyA.Namespace1");
             var logger_A_1_a = factory.CreateLogger("CompanyA.Namespace1.ClassA");
             var logger_A_1_b = factory.CreateLogger("CompanyA.Namespace1.ClassB");
-            var logger_A_2 = factory.CreateLogger("CompanyA.Namespace2");
             var logger_A_2_c = factory.CreateLogger("CompanyA.Namespace2.ClassC");
+            var logger_B_3 = factory.CreateLogger("CompanyB.Namespace3");
             var logger_B_3_d = factory.CreateLogger("CompanyB.Namespace3.ClassD");
 
-            logger_A_1.LogInformation(1001, "A_1 Information");
-            logger_A_1_a.LogInformation(1101, "A_1_a Information");
-            logger_A_1_b.LogInformation(1201, "A_1_b Information");
-            logger_A_2.LogInformation(1301, "A_2 Information");
-            logger_A_2_c.LogInformation(1401, "A_2_c Information");
-            logger_B_3_d.LogInformation(1501, "B_3_d Information");
+            logger_A_1.LogInformation(LoggingEvents.ConfigurationStart, "A_1 Information - namespace level Configuration Start");
+            logger_A_1_a.LogInformation(LoggingEvents.SystemStart, "A_1_a Information - System Start");
+            logger_A_1_b.LogInformation(LoggingEvents.SystemEvent, "A_1_b Information - System Event");
+            logger_A_2_c.LogInformation(LoggingEvents.ConnectionEvent, "A_2_c Information - Connection Event");
+            logger_B_3.LogInformation(2301, "B_3 Information - namespace level");
+            logger_B_3_d.LogInformation(LoggingEvents.AuthenticationSuccess, "B_3_d Information - Authentication Success");
 
-            logger_A_1.LogDebug("A_1 Debug");
-            logger_A_1_a.LogDebug("A_1_a Debug");
-            logger_A_1_b.LogDebug("A_1_b Debug");
-            logger_A_2.LogDebug("A_2 Debug");
-            logger_A_2_c.LogDebug("A_2_c Debug");
-            logger_B_3_d.LogDebug("B_3_d Debug");
-
-            logger_A_1.LogInformation(1002, "A_1 Information 2");
-            logger_A_1_a.LogInformation(1102, "A_1_a Information 2");
-            logger_A_1_b.LogInformation(1202, "A_1_b Information 2");
-            logger_A_2.LogInformation(1302, "A_2 Information 2");
-            logger_A_2_c.LogInformation(1402, "A_2_c Information 2");
-            logger_B_3_d.LogInformation(1502, "B_3_d Information 2");
-
-            logger_A_1.LogDebug("A_1 Debug 2");
-            logger_A_1_a.LogDebug("A_1_a Debug 2");
-            logger_A_1_b.LogDebug("A_1_b Debug 2");
-            logger_A_2.LogDebug("A_2 Debug 2");
-            logger_A_2_c.LogDebug("A_2_c Debug 2");
-            logger_B_3_d.LogDebug("B_3_d Debug 2");
-
-            logger_A_1.LogWarning(4001, "A_1 Warning");
-            logger_A_1_a.LogWarning(4101, "A_1_a Warning");
-            logger_A_1_b.LogError(5201, "A_1_b Error");
-            logger_A_2.LogWarning(4301, "A_2 Warning");
-            logger_A_2_c.LogWarning(4401, "A_2_c Warning");
             try
             {
-                throw new Exception("Sample");
+                logger_A_1.LogDebug("A_1 Debug");
+                logger_A_1_a.LogDebug("A_1_a Debug - Class A detail");
+                logger_A_1_b.LogDebug("A_1_b Debug - Class B detail");
+                logger_A_2_c.LogDebug("A_2_c Debug");
+                logger_B_3.LogDebug("A_2 Debug");
+                logger_B_3_d.LogDebug("B_3_d Debug");
+
+                logger_A_1_a.LogDebug("A_1_a Debug 2 - Class A more detail");
+                logger_A_1_b.LogDebug("A_1_b Debug 2 - Class B more detail");
+                logger_A_2_c.LogDebug("A_2_c Debug 2");
+                logger_B_3_d.LogDebug("B_3_d Debug 2");
+
+                logger_A_1_a.LogDebug("A_1_a Debug 3 - Class A even more detail");
+                logger_A_1_b.LogDebug("A_1_b Debug 3 - Class B even more detail");
+
+                logger_A_1_a.LogDebug("A_1_a Debug 4 - Class A still going");
+                logger_A_1_b.LogDebug("A_1_b Debug 4 - Class B still going");
+
+                logger_A_1.LogWarning(LoggingEvents.ConfigurationWarning, "A_1 Warning - namespace level Configuration Warning");
+                logger_A_1_a.LogWarning(LoggingEvents.SystemWarning, "A_1_a Warning - System Warning");
+                logger_A_1_b.LogError(LoggingEvents.SystemError, "A_1_b Error - System Error");
+                logger_A_2_c.LogWarning(LoggingEvents.ConnectionWarning, "A_2_c Warning - Connection Warning");
+
+                TestExceptionLogging();
             }
             catch (Exception ex)
             {
-                logger_B_3_d.LogCritical(9501, ex, "B_3_d Critical");
+                logger_B_3_d.LogCritical(LoggingEvents.AuthenticationCriticalError, ex, "B_3_d Critical = Authentication Critical Error");
             }
+
+            logger_A_2_c.LogInformation(LoggingEvents.ConnectionStop, "B_3_d Information 2 - Connection Stop");
+            logger_A_1_b.LogInformation(LoggingEvents.SystemStop, "A_1_b Information 2 - System Stop");
+            logger_A_1_a.LogInformation(6102, "A_1_a Information 2");
+        }
+
+        private static void TestExceptionLogging()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/samples/ConsoleHierarchySample/SampleClasses.cs
+++ b/samples/ConsoleHierarchySample/SampleClasses.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace CompanyA
+{
+    namespace Namespace1
+    {
+        class ClassA { }
+        class ClassB { }
+    }
+    namespace Namespace2
+    {
+        class ClassC { }
+    }
+}
+
+namespace CompanyB
+{
+    namespace Namespace3
+    {
+        class ClassD { }
+    }
+}

--- a/samples/ConsoleHierarchySample/project.json
+++ b/samples/ConsoleHierarchySample/project.json
@@ -1,0 +1,20 @@
+{
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+
+  "dependencies": {
+    "Microsoft.Extensions.Logging": "1.1.0",
+    "Microsoft.Extensions.Logging.Console": "1.0.0",
+    "Microsoft.NETCore.App": {
+      "type": "platform",
+      "version": "1.0.1"
+    }
+  },
+
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": "dnxcore50"
+    }
+  }
+}


### PR DESCRIPTION
This contains a sample application only, there is no code change to the main library.

How the category filters are inherited, and how to configure them, is not immediately obvious from looking at the API. 

The example demonstrates this concept, by showing how the hierarchy works and can be configured (including the special 'Default' category).