### PR TITLE
Documentation comments (no code changes) for console logger

### DIFF
--- a/src/Microsoft.Extensions.Logging.Console/ConfigurationConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConfigurationConsoleLoggerSettings.cs
@@ -7,6 +7,48 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Logging.Console
 {
+    /// <summary>
+    /// Settings for a <see cref="ConsoleLoggerProvider"/> taken from a configuration source.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When <see cref="IConsoleLoggerSettings"/> are defined, then only the categories 
+    /// they return a result from <c>TryGetSwitch</c>, either for themselves or for a parent, 
+    /// are logged.
+    /// </para>
+    /// <para>
+    /// If a category is not configured then the value of the special category 'Default' (case sensitive) 
+    /// is used, or 'Default' is not specified then they are not logged at all. 
+    /// </para>
+    /// <para>
+    /// The value of the IncludeScopes setting is taken from the IncludeScopes configuration property
+    /// (of the <see cref="IConfiguration"/> passed to the constructor). 
+    /// </para>
+    /// <para>
+    /// Checking <c>TryGetSwitch</c> takes values from the "LogLevel" subsection of the provided 
+    /// configuration, checking for a configuration setting matching the category name and with the minimum 
+    /// log level setting.
+    /// </para>
+    /// <para>
+    /// If a category, or any of it's parents, is not present, then the value of the special 'Default'
+    /// category is checked, and if it is not present, then the category is not logged.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// Configures logging via a JSON configuration file, with a default level of <c>Warning</c>, 
+    /// with <c>Information</c> level for namespaces starting with "CompanyB" (inherited by all child loggers), 
+    /// and <c>Debug</c> level for any log messages from class "CompanyA.Namespace1.ClassB".
+    /// <code>
+    /// {
+    ///  "IncludeScopes" : "false",
+    ///  "LogLevel": {
+    ///    "Default": "Warning",
+    ///    "CompanyA.Namespace1.ClassB": "Debug",
+    ///    "CompanyB": "Information"
+    ///  }
+    /// }
+    /// </code>
+    /// </example>
     public class ConfigurationConsoleLoggerSettings : IConsoleLoggerSettings
     {
         private readonly IConfiguration _configuration;
@@ -19,6 +61,11 @@ namespace Microsoft.Extensions.Logging.Console
 
         public IChangeToken ChangeToken { get; private set; }
 
+        /// <summary>
+        /// Gets whether log scope information should be displayed in the output, 
+        /// from the value of the "IncludeScopes" configuration property,
+        /// or false if it is not defined.
+        /// </summary>
         public bool IncludeScopes
         {
             get
@@ -47,6 +94,21 @@ namespace Microsoft.Extensions.Logging.Console
             return new ConfigurationConsoleLoggerSettings(_configuration);
         }
 
+        /// <summary>
+        /// Gets the minimum log level for the specified category (or the special category 'Default'),
+        /// from the "LogLevel" configuration section, checking for a configuration setting matching
+        /// the category name and with the minimum log level setting.
+        /// </summary>
+        /// <param name="name">The configuration category to check.</param>
+        /// <param name="level">The minimum <c>LogLevel</c> set for the category.</param>
+        /// <returns>true if a <c>LogLevel</c> is set; false if it is not.</returns>
+        /// <remarks>
+        /// <para>
+        /// Note that the console logger calls this for a category and all parent categories until
+        /// a value is returned. If no value is returned, then the value for the special category 
+        /// 'Default' is checked, and if that returns false then the category is not logged.
+        /// </para>
+        /// </remarks>
         public bool TryGetSwitch(string name, out LogLevel level)
         {
             var switches = _configuration.GetSection("LogLevel");

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerFactoryExtensions.cs
@@ -85,6 +85,35 @@ namespace Microsoft.Extensions.Logging
             return factory;
         }
 
+        /// <summary>
+        /// Add a <see cref="ConsoleLoggerProvider"/> configured with the provided <see cref="IConsoleLoggerSettings"/>. 
+        /// </summary>
+        /// <param name="factory"></param>
+        /// <param name="settings">The console logging settings to use.</param>
+        /// <remarks>
+        /// <para>
+        /// When <see cref="IConsoleLoggerSettings"/> are defined, then only the categories 
+        /// they return a result from <c>TryGetSwitch</c>, either for themselves or for a parent, 
+        /// are logged.
+        /// </para>
+        /// <para>
+        /// If a category is not configured then the value of the special category 'Default' (case sensitive) 
+        /// is used, or 'Default' is not specified then they are not logged at all. 
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// Configures logging with a default level of <c>Warning</c>, and specific levels
+        /// for particular namespaces (inherited by all child loggers) and classes.
+        /// <code>
+        /// var consoleSettings = new ConsoleLoggerSettings();
+        /// consoleSettings.Switches = new Dictionary&lt;string, LogLevel&gt;() {
+        ///     { "Default", LogLevel.Warning },
+        ///     { "CompanyA.Namespace1.ClassB", LogLevel.Debug },
+        ///     { "CompanyB", LogLevel.Information },
+        /// };
+        /// factory.AddConsole(consoleSettings);
+        /// </code>
+        /// </example>
         public static ILoggerFactory AddConsole(
             this ILoggerFactory factory,
             IConsoleLoggerSettings settings)
@@ -93,6 +122,23 @@ namespace Microsoft.Extensions.Logging
             return factory;
         }
 
+        /// <summary>
+        /// Add a <see cref="ConsoleLoggerProvider"/> configured with <see cref="ConfigurationConsoleLoggerSettings"/> 
+        /// taken from the provided <see cref="IConfiguration"/>, e.g. from a settings file. 
+        /// </summary>
+        /// <param name="factory"></param>
+        /// <param name="configuration">The configuration to use to get the console logging settings from.</param>
+        /// <remarks>
+        /// <para>
+        /// When <see cref="IConsoleLoggerSettings"/> are defined, then only the categories 
+        /// they return a result from <c>TryGetSwitch</c>, either for themselves or for a parent, 
+        /// are logged.
+        /// </para>
+        /// <para>
+        /// If a category is not configured then the value of the special category 'Default' (case sensitive) 
+        /// is used, or 'Default' is not specified then they are not logged at all. 
+        /// </para>
+        /// </remarks>
         public static ILoggerFactory AddConsole(this ILoggerFactory factory, IConfiguration configuration)
         {
             var settings = new ConfigurationConsoleLoggerSettings(configuration);

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerProvider.cs
@@ -81,6 +81,8 @@ namespace Microsoft.Extensions.Logging.Console
 
             if (settings != null)
             {
+                // As name is fixed for a particular logger, once the relevent setting has been found,
+                // the filter function only checks level (it does not need to check name).
                 foreach (var prefix in GetKeyPrefixes(name))
                 {
                     LogLevel level;
@@ -96,6 +98,8 @@ namespace Microsoft.Extensions.Logging.Console
 
         private IEnumerable<string> GetKeyPrefixes(string name)
         {
+            // Check all parents parts, and then check the special value 'Default'
+            // NOTE: ConsoleLoggerSettings handles the category names as case sensitive.
             while (!string.IsNullOrEmpty(name))
             {
                 yield return name;

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerSettings.cs
@@ -7,12 +7,47 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Logging.Console
 {
+    /// <summary>
+    /// Basic settings for a <see cref="ConsoleLoggerProvider"/> that can configured in code.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When <see cref="IConsoleLoggerSettings"/> are defined, then only the categories 
+    /// they return a result from <c>TryGetSwitch</c>, either for themselves or for a parent, 
+    /// are logged.
+    /// </para>
+    /// <para>
+    /// If a category is not configured then the value of the special category 'Default' (case sensitive) 
+    /// is used, or 'Default' is not specified then they are not logged at all. 
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// Configures logging via code, with a default level of <c>Warning</c>, 
+    /// with <c>Information</c> level for namespaces starting with "CompanyB" (inherited by all child loggers), 
+    /// and <c>Debug</c> level for any log messages from class "CompanyA.Namespace1.ClassB".
+    /// <code>
+    /// var consoleSettings = new ConsoleLoggerSettings();
+    /// consoleSettings.Switches = new Dictionary&lt;string, LogLevel&gt;() {
+    ///     { "Default", LogLevel.Warning },
+    ///     { "CompanyA.Namespace1.ClassB", LogLevel.Debug },
+    ///     { "CompanyB", LogLevel.Information },
+    /// };
+    /// factory.AddConsole(consoleSettings);
+    /// </code>
+    /// </example>
     public class ConsoleLoggerSettings : IConsoleLoggerSettings
     {
         public IChangeToken ChangeToken { get; set; }
 
+        /// <summary>
+        /// Gets or sets whether log scope information should be displayed in the output.
+        /// </summary>
         public bool IncludeScopes { get; set; }
 
+        /// <summary>
+        /// Gets or sets a dictionary of named categories (or the special category 'Default') 
+        /// with the minimum log level for that category and inherited by child categories.
+        /// </summary>
         public IDictionary<string, LogLevel> Switches { get; set; } = new Dictionary<string, LogLevel>();
 
         public IConsoleLoggerSettings Reload()
@@ -20,6 +55,7 @@ namespace Microsoft.Extensions.Logging.Console
             return this;
         }
 
+        /// <inheritdoc/>
         public bool TryGetSwitch(string name, out LogLevel level)
         {
             return Switches.TryGetValue(name, out level);

--- a/src/Microsoft.Extensions.Logging.Console/IConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/IConsoleLoggerSettings.cs
@@ -3,12 +3,43 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Logging.Console
 {
+    /// <summary>
+    /// Settings for a <see cref="ConsoleLoggerProvider"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When <see cref="IConsoleLoggerSettings"/> are defined, then only the categories 
+    /// they return a result from <c>TryGetSwitch</c>, either for themselves or for a parent, 
+    /// are logged.
+    /// </para>
+    /// <para>
+    /// If a category is not configured then the value of the special category 'Default' (case sensitive) 
+    /// is used, or 'Default' is not specified then they are not logged at all. 
+    /// </para>
+    /// </remarks>
     public interface IConsoleLoggerSettings
     {
+        /// <summary>
+        /// Gets whether log scope information should be displayed in the output.
+        /// </summary>
         bool IncludeScopes { get; }
 
         IChangeToken ChangeToken { get; }
 
+        /// <summary>
+        /// Gets the minimum log level for the specified category (or the special category 'Default'),
+        /// or returns false if it is not defined.
+        /// </summary>
+        /// <param name="name">The configuration category to check.</param>
+        /// <param name="level">The minimum <c>LogLevel</c> set for the category.</param>
+        /// <returns>true if a <c>LogLevel</c> is set; false if it is not.</returns>
+        /// <remarks>
+        /// <para>
+        /// Note that the console logger calls this for a category and all parent categories until
+        /// a value is returned. If no value is returned, then the value for the special category 
+        /// 'Default' is checked, and if that returns false then the category is not logged.
+        /// </para>
+        /// </remarks>
         bool TryGetSwitch(string name, out LogLevel level);
 
         IConsoleLoggerSettings Reload();


### PR DESCRIPTION
The doc comments are mostly added to the configuration extension methods and settings classes, and detail how to use them, in particular how category settings are inherited and the special 'Default' category.
