### PR TITLE
let eventlogger create new logs for me (needs admin)

### DIFF
--- a/src/Microsoft.Extensions.Logging.EventLog/EventLogLogger.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/EventLogLogger.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Extensions.Logging.EventLog
             // 1. Log name & source name existence check only works on local computer.
             // 2. Source name existence check requires Administrative privileges.
 
-            EventLog = settings.EventLog ?? new WindowsEventLog(logName, machineName, sourceName);
+            EventLog = settings.EventLog ?? new WindowsEventLog(logName, machineName, sourceName, settings.AutoCreate);
 
             // Examples:
             // 1. An error occu...

--- a/src/Microsoft.Extensions.Logging.EventLog/EventLogSettings.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/EventLogSettings.cs
@@ -27,6 +27,11 @@ namespace Microsoft.Extensions.Logging.EventLog
         public string MachineName { get; set; }
 
         /// <summary>
+        /// Create the eventsoure and log if it doesn't exist. Requires running as admin.
+        /// </summary>
+        public bool AutoCreate { get; set; }
+
+        /// <summary>
         /// The function used to filter events based on the log level.
         /// </summary>
         public Func<string, LogLevel, bool> Filter { get; set; }

--- a/src/Microsoft.Extensions.Logging.EventLog/WindowsEventLog.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/WindowsEventLog.cs
@@ -16,6 +16,16 @@ namespace Microsoft.Extensions.Logging.EventLog
             DiagnosticsEventLog = new System.Diagnostics.EventLog(logName, machineName, sourceName);
         }
 
+        public WindowsEventLog(string logName, string machineName, string sourceName, bool autocreate)
+        {
+            if (autocreate && !System.Diagnostics.EventLog.SourceExists(sourceName))
+            {
+                System.Diagnostics.EventLog.CreateEventSource(sourceName, logName);
+            }
+            DiagnosticsEventLog = new System.Diagnostics.EventLog(logName, machineName, sourceName);
+        }
+
+
         public System.Diagnostics.EventLog DiagnosticsEventLog { get; }
 
         public int MaxMessageSize

--- a/test/Microsoft.Extensions.Logging.Test/EventLogLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/EventLogLoggerTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Extensions.Logging
             var sourceName = "blah";
 
             // Act
-            var windowsEventLog = new WindowsEventLog(logName, machineName, sourceName);
+            var windowsEventLog = new WindowsEventLog(logName, machineName, sourceName, false);
 
             // Assert
             Assert.NotNull(windowsEventLog.DiagnosticsEventLog);


### PR DESCRIPTION
This may be wrong headed but it's a bit confusing when you try and create  a new log by specifying a new log/source name and you just get nothing. Perhaps we should do this? Or is there better guidance around using the event log? 