### PR TITLE
Allow console logger settings case insensitive

### DIFF
--- a/src/Microsoft.Extensions.Logging.Console/ConfigurationConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConfigurationConsoleLoggerSettings.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Extensions.Logging.Console
                 level = LogLevel.None;
                 return false;
             }
-            else if (Enum.TryParse<LogLevel>(value, out level))
+            else if (Enum.TryParse<LogLevel>(value, true, out level))
             {
                 return true;
             }


### PR DESCRIPTION
Allow console logger settings define in case insensitive manner:
```json
  "logSettings": {
    "logLevel": {
      "default": "information",
      "Foo.Bar.ReaderHandler": "trace"
    }
```