### PR TITLE
Bump test projects up to .NET 4.5.2

### DIFF
--- a/test/Microsoft.Extensions.Logging.AzureAppServices.Test/Microsoft.Extensions.Logging.AzureAppServices.Test.csproj
+++ b/test/Microsoft.Extensions.Logging.AzureAppServices.Test/Microsoft.Extensions.Logging.AzureAppServices.Test.csproj
@@ -3,8 +3,9 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">$(PackageTargetFallback);portable-net40+sl5+win8+wp8+wpa81;portable-net45+win8+wp8+wpa81</PackageTargetFallback>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Extensions.Logging.EventSource.Test/Microsoft.Extensions.Logging.EventSource.Test.csproj
+++ b/test/Microsoft.Extensions.Logging.EventSource.Test/Microsoft.Extensions.Logging.EventSource.Test.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,7 +15,7 @@
     <PackageReference Include="xunit" Version="2.2.0-*" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <DefineConstants>$(DefineConstants);NO_EVENTSOURCE_COMPLEX_TYPE_SUPPORT</DefineConstants>
   </PropertyGroup>
 

--- a/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
@@ -648,7 +648,7 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.NotNull(disposable);
         }
 
-#if NET451
+#if NET452
         private static void DomainFunc()
         {
             var t = SetUp(filter: null, includeScopes: true);

--- a/test/Microsoft.Extensions.Logging.Test/EventLogLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/EventLogLoggerTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET451
+#if NET452
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/test/Microsoft.Extensions.Logging.Test/Microsoft.Extensions.Logging.Test.csproj
+++ b/test/Microsoft.Extensions.Logging.Test/Microsoft.Extensions.Logging.Test.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,7 +21,7 @@
     <PackageReference Include="xunit" Version="2.2.0-*" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <ProjectReference Include="..\..\src\Microsoft.Extensions.Logging.EventLog\Microsoft.Extensions.Logging.EventLog.csproj" />
   </ItemGroup>
 

--- a/test/Microsoft.Extensions.Logging.Test/TraceSourceLoggerProviderTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/TraceSourceLoggerProviderTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET451
+#if NET452
 using System.Diagnostics;
 using Microsoft.Extensions.Logging.TraceSource;
 using Xunit;

--- a/test/Microsoft.Extensions.Logging.Test/TraceSourceLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/TraceSourceLoggerTest.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET451
+#if NET452
 using System.Diagnostics;
 using Xunit;
 

--- a/test/Microsoft.Extensions.Logging.Test/TraceSourceScopeTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/TraceSourceScopeTest.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Logging.Test
 {
     public class TraceSourceScopeTest
     {
-#if NET451
+#if NET452
         [Fact]
         public static void DiagnosticsScope_PushesAndPops_LogicalOperationStack()
         {

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/Microsoft.Extensions.Logging.Testing.Tests.csproj
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/Microsoft.Extensions.Logging.Testing.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- aspnet/Testing#248
- xUnit no longer supports .NET 4.5.1
- build tests for desktop .NET only on Windows