### PR TITLE
Cap FormattedLogValues cache

### DIFF
--- a/src/Microsoft.Extensions.Logging.Abstractions/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Extensions.Logging.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/test/Microsoft.Extensions.Logging.Test/FormattedLogValuesTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/FormattedLogValuesTest.cs
@@ -93,6 +93,23 @@ namespace Microsoft.Extensions.Logging.Test
             });
         }
 
+        [Fact]
+        public void CachedFormattersAreCapped()
+        {
+            for (var i = 0; i < FormattedLogValues.MaxCachedFormatters; ++i)
+            {
+                var ignore = new FormattedLogValues($"{i}{{i}}", i);
+            }
+
+            // check cached formatter
+            var formatter = new FormattedLogValues("0{i}", 0).Formatter;
+            Assert.Same(formatter, new FormattedLogValues("0{i}", 0).Formatter);
+
+            // check non-cached formatter
+            formatter = new FormattedLogValues("test {}", 0).Formatter;
+            Assert.NotSame(formatter, new FormattedLogValues("test {}", 0).Formatter);
+        }
+
         // message format, format arguments, expected message
         public static TheoryData<string, object[], string> FormatsEnumerableValuesData
         {


### PR DESCRIPTION
#516 
@glennc @davidfowl 

I tried a ConcurrentLru cache in the initial commit, but it looked like perf halved in that scenario.
Current thought is to just cap the cache to prevent memory leaks, and if perf is a concern then the `LoggerMessage.DefineScope` pattern can be used.

Will file an issue in docs to document that pattern: https://github.com/aspnet/Docs/issues/2810