### PR TITLE
Logging shouldn't throw after dispose

### DIFF
--- a/src/Microsoft.Extensions.Logging.Console/Internal/ConsoleLoggerProcessor.cs
+++ b/src/Microsoft.Extensions.Logging.Console/Internal/ConsoleLoggerProcessor.cs
@@ -27,7 +27,10 @@ namespace Microsoft.Extensions.Logging.Console.Internal
 
         public virtual void EnqueueMessage(LogMessageEntry message)
         {
-            _messageQueue.Add(message);
+            if (!_messageQueue.IsAddingCompleted)
+            {
+                _messageQueue.Add(message);
+            }
         }
 
         // for testing

--- a/src/Microsoft.Extensions.Logging.Console/Internal/ConsoleLoggerProcessor.cs
+++ b/src/Microsoft.Extensions.Logging.Console/Internal/ConsoleLoggerProcessor.cs
@@ -29,8 +29,16 @@ namespace Microsoft.Extensions.Logging.Console.Internal
         {
             if (!_messageQueue.IsAddingCompleted)
             {
-                _messageQueue.Add(message);
+                try
+                {
+                    _messageQueue.Add(message);
+                    return;
+                }
+                catch (InvalidOperationException) { }
             }
+
+            // Adding is completed so just log the message
+            WriteMessage(message);
         }
 
         // for testing

--- a/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
@@ -769,12 +769,12 @@ namespace Microsoft.Extensions.Logging.Test
             var expected = ex.ToString() + Environment.NewLine;
 
             // Act
-            logger.Log(LogLevel.Critical, 0, message, ex, (s,e) => s);
-            logger.Log(LogLevel.Error, 0, message, ex, (s,e) => s);
-            logger.Log(LogLevel.Warning, 0, message, ex, (s,e) => s);
-            logger.Log(LogLevel.Information, 0, message, ex, (s,e) => s);
-            logger.Log(LogLevel.Debug, 0, message, ex, (s,e) => s);
-            logger.Log(LogLevel.Trace, 0, message, ex, (s,e) => s);
+            logger.Log(LogLevel.Critical, 0, message, ex, (s, e) => s);
+            logger.Log(LogLevel.Error, 0, message, ex, (s, e) => s);
+            logger.Log(LogLevel.Warning, 0, message, ex, (s, e) => s);
+            logger.Log(LogLevel.Information, 0, message, ex, (s, e) => s);
+            logger.Log(LogLevel.Debug, 0, message, ex, (s, e) => s);
+            logger.Log(LogLevel.Trace, 0, message, ex, (s, e) => s);
 
             // Assert
             Assert.Equal(6, sink.Writes.Count);
@@ -796,12 +796,12 @@ namespace Microsoft.Extensions.Logging.Test
             Exception ex = null;
 
             // Act
-            logger.Log(LogLevel.Critical, 0, _state, ex, (s,e) => s);
-            logger.Log(LogLevel.Error, 0, _state, ex, (s,e) => s);
-            logger.Log(LogLevel.Warning, 0, _state, ex, (s,e) => s);
-            logger.Log(LogLevel.Information, 0, _state, ex, (s,e) => s);
-            logger.Log(LogLevel.Debug, 0, _state, ex, (s,e) => s);
-            logger.Log(LogLevel.Trace, 0, _state, ex, (s,e) => s);
+            logger.Log(LogLevel.Critical, 0, _state, ex, (s, e) => s);
+            logger.Log(LogLevel.Error, 0, _state, ex, (s, e) => s);
+            logger.Log(LogLevel.Warning, 0, _state, ex, (s, e) => s);
+            logger.Log(LogLevel.Information, 0, _state, ex, (s, e) => s);
+            logger.Log(LogLevel.Debug, 0, _state, ex, (s, e) => s);
+            logger.Log(LogLevel.Trace, 0, _state, ex, (s, e) => s);
 
             // Assert
             Assert.Equal(12, sink.Writes.Count);
@@ -824,15 +824,27 @@ namespace Microsoft.Extensions.Logging.Test
             string message = null;
 
             // Act
-            logger.Log(LogLevel.Critical, 0, message, ex, (s,e) => s);
-            logger.Log(LogLevel.Error, 0, message, ex, (s,e) => s);
-            logger.Log(LogLevel.Warning, 0, message, ex, (s,e) => s);
-            logger.Log(LogLevel.Information, 0, message, ex, (s,e) => s);
-            logger.Log(LogLevel.Debug, 0, message, ex, (s,e) => s);
-            logger.Log(LogLevel.Trace, 0, message, ex, (s,e) => s);
+            logger.Log(LogLevel.Critical, 0, message, ex, (s, e) => s);
+            logger.Log(LogLevel.Error, 0, message, ex, (s, e) => s);
+            logger.Log(LogLevel.Warning, 0, message, ex, (s, e) => s);
+            logger.Log(LogLevel.Information, 0, message, ex, (s, e) => s);
+            logger.Log(LogLevel.Debug, 0, message, ex, (s, e) => s);
+            logger.Log(LogLevel.Trace, 0, message, ex, (s, e) => s);
 
             // Assert
             Assert.Equal(0, sink.Writes.Count);
+        }
+
+        [Fact]
+        public void LogAfterDisposeDoesNotThrow()
+        {
+            var sink = new ConsoleSink();
+            var console = new TestConsole(sink);
+            var processor = new ConsoleLoggerProcessor();
+            var logger = new ConsoleLogger(_loggerName, filter: null, includeScopes: false, loggerProcessor: processor);
+            logger.Console = console;
+            processor.Dispose();
+            logger.LogInformation("Logging after dispose");
         }
 
         private string GetMessage(string logLevelString, int eventId, Exception exception)
@@ -849,9 +861,9 @@ namespace Microsoft.Extensions.Logging.Test
                 + _paddingString
                 + ReplaceMessageNewLinesWithPadding(state?.ToString())
                 + Environment.NewLine
-                + ( exception != null
+                + (exception != null
                     ? exception.ToString() + Environment.NewLine
-                    : string.Empty );
+                    : string.Empty);
         }
 
         private string ReplaceMessageNewLinesWithPadding(string message)

--- a/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
@@ -836,15 +836,21 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Fact]
-        public void LogAfterDisposeDoesNotThrow()
+        public void LogAfterDisposeWritesLog()
         {
+            // Arrange
             var sink = new ConsoleSink();
             var console = new TestConsole(sink);
             var processor = new ConsoleLoggerProcessor();
             var logger = new ConsoleLogger(_loggerName, filter: null, includeScopes: false, loggerProcessor: processor);
             logger.Console = console;
+
+            // Act
             processor.Dispose();
             logger.LogInformation("Logging after dispose");
+
+            // Assert
+            Assert.True(sink.Writes.Count == 2);
         }
 
         private string GetMessage(string logLevelString, int eventId, Exception exception)


### PR DESCRIPTION
- Check complete adding before adding new messages
to the list.
- Added a test

#563

PS: I didn't measure the performance of checking that bool on every write.