### PR TITLE
Disable API Check for package that we do not push to NuGet

### DIFF
--- a/src/Microsoft.Extensions.Logging.Testing/Microsoft.Extensions.Logging.Testing.csproj
+++ b/src/Microsoft.Extensions.Logging.Testing/Microsoft.Extensions.Logging.Testing.csproj
@@ -8,6 +8,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>logging;testing</PackageTags>
+    <EnableApiCheck>false</EnableApiCheck>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
@Eilon FYI if we have plans to ship this on NuGet, we'll need a follow-up issue to create baselines and revert this change after that release.