### PR TITLE
copy test logging stuff from IntegrationTesting here

### DIFF
--- a/Logging.sln
+++ b/Logging.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26127.0
+VisualStudioVersion = 15.0.26413.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.Logging", "src\Microsoft.Extensions.Logging\Microsoft.Extensions.Logging.csproj", "{19D1B6C5-8A62-4387-8816-C54874D1DF5F}"
 EndProject
@@ -35,6 +35,13 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.Logging.AzureAppServices", "src\Microsoft.Extensions.Logging.AzureAppServices\Microsoft.Extensions.Logging.AzureAppServices.csproj", "{854133D5-6252-4A0A-B682-BDBB83B62AE6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Extensions.Logging.AzureAppServices.Test", "test\Microsoft.Extensions.Logging.AzureAppServices.Test\Microsoft.Extensions.Logging.AzureAppServices.Test.csproj", "{B4A43221-DE95-47BB-A2D4-2DC761FC9419}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{C3F6BF54-2427-4477-A1D1-8CD43A3EDDBE}"
+	ProjectSection(SolutionItems) = preProject
+		build\common.props = build\common.props
+		build\dependencies.props = build\dependencies.props
+		build\Key.snk = build\Key.snk
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
     <CoreFxVersion>4.3.0</CoreFxVersion>
@@ -10,6 +10,7 @@
     <SerilogExtensionsLoggingVersion>1.4.0</SerilogExtensionsLoggingVersion>
     <SerilogPeriodicBatchingVersion>2.1.0</SerilogPeriodicBatchingVersion>
     <SerilogRollingFileVersion>3.3.0</SerilogRollingFileVersion>
+    <SerilogFileSinkVersion>3.2.0</SerilogFileSinkVersion>
     <TestSdkVersion>15.0.0</TestSdkVersion>
     <WindowsAzureStorageVersion>8.1.1</WindowsAzureStorageVersion>
     <XunitVersion>2.2.0</XunitVersion>

--- a/src/Microsoft.Extensions.Logging.Testing/AssemblyTestLog.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/AssemblyTestLog.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/src/Microsoft.Extensions.Logging.Testing/AssemblyTestLog.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/AssemblyTestLog.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Serilog;
+using Xunit.Abstractions;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class AssemblyTestLog : IDisposable
+    {
+        public static readonly string OutputDirectoryEnvironmentVariableName = "ASPNETCORE_TEST_LOG_DIR";
+
+        private static readonly object _lock = new object();
+        private static readonly Dictionary<Assembly, AssemblyTestLog> _logs = new Dictionary<Assembly, AssemblyTestLog>();
+
+        private readonly ILoggerFactory _globalLoggerFactory;
+        private readonly ILogger _globalLogger;
+        private readonly string _baseDirectory;
+        private readonly string _assemblyName;
+
+        private AssemblyTestLog(ILoggerFactory globalLoggerFactory, ILogger globalLogger, string baseDirectory, string assemblyName)
+        {
+            _globalLoggerFactory = globalLoggerFactory;
+            _globalLogger = globalLogger;
+            _baseDirectory = baseDirectory;
+            _assemblyName = assemblyName;
+        }
+
+        public IDisposable StartTestLog(ITestOutputHelper output, string className, out ILoggerFactory loggerFactory, [CallerMemberName] string testName = null)
+        {
+            var factory = CreateLoggerFactory(output, className, testName);
+            loggerFactory = factory;
+            var logger = factory.CreateLogger("TestLifetime");
+
+            var stopwatch = Stopwatch.StartNew();
+            _globalLogger.LogInformation("Starting test {testName}", testName);
+            logger.LogInformation("Starting test {testName}", testName);
+
+            return new Disposable(() =>
+            {
+                stopwatch.Stop();
+                _globalLogger.LogInformation("Finished test {testName} in {duration}s", testName, stopwatch.Elapsed.TotalSeconds);
+                logger.LogInformation("Finished test {testName} in {duration}s", testName, stopwatch.Elapsed.TotalSeconds);
+                factory.Dispose();
+            });
+        }
+
+        public ILoggerFactory CreateLoggerFactory(ITestOutputHelper output, string className, [CallerMemberName] string testName = null)
+        {
+            var loggerFactory = new LoggerFactory();
+            if (output != null)
+            {
+                loggerFactory.AddXunit(output, LogLevel.Debug);
+            }
+
+            // Try to shorten the class name using the assembly name
+            if (className.StartsWith(_assemblyName + "."))
+            {
+                className = className.Substring(_assemblyName.Length + 1);
+            }
+
+            if (!string.IsNullOrEmpty(_baseDirectory))
+            {
+                var testOutputFile = Path.Combine(_baseDirectory, _assemblyName, className, $"{testName}.log");
+
+                AddFileLogging(loggerFactory, testOutputFile);
+            }
+
+            return loggerFactory;
+        }
+
+        public static AssemblyTestLog Create(string assemblyName, string baseDirectory)
+        {
+            var loggerFactory = new LoggerFactory();
+
+            // Let the global logger log to the console, it's just "Starting X..." "Finished X..."
+            loggerFactory.AddConsole();
+
+            if (!string.IsNullOrEmpty(baseDirectory))
+            {
+                var globalLogFileName = Path.Combine(baseDirectory, assemblyName, "global.log");
+                AddFileLogging(loggerFactory, globalLogFileName);
+            }
+
+            var logger = loggerFactory.CreateLogger("GlobalTestLog");
+            logger.LogInformation($"Global Test Logging initialized. Set the '{OutputDirectoryEnvironmentVariableName}' Environment Variable in order to create log files on disk.");
+            return new AssemblyTestLog(loggerFactory, logger, baseDirectory, assemblyName);
+        }
+
+        public static AssemblyTestLog ForAssembly(Assembly assembly)
+        {
+            lock (_lock)
+            {
+                if (!_logs.TryGetValue(assembly, out var log))
+                {
+                    log = Create(assembly.GetName().Name, Environment.GetEnvironmentVariable(OutputDirectoryEnvironmentVariableName));
+                    _logs[assembly] = log;
+                }
+                return log;
+            }
+        }
+
+        private static void AddFileLogging(LoggerFactory loggerFactory, string fileName)
+        {
+            var dir = Path.GetDirectoryName(fileName);
+            if (!Directory.Exists(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+
+            if (File.Exists(fileName))
+            {
+                File.Delete(fileName);
+            }
+
+            var serilogger = new LoggerConfiguration()
+                .Enrich.FromLogContext()
+                .MinimumLevel.Verbose()
+                .WriteTo.File(fileName, outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{SourceContext}] [{Level}] {Message}{NewLine}{Exception}", flushToDiskInterval: TimeSpan.FromSeconds(1), shared: true)
+                .CreateLogger();
+            loggerFactory.AddSerilog(serilogger, dispose: true);
+        }
+
+        public void Dispose()
+        {
+            _globalLoggerFactory.Dispose();
+        }
+
+        private class Disposable : IDisposable
+        {
+            private Action _action;
+
+            public Disposable(Action action)
+            {
+                _action = action;
+            }
+
+            public void Dispose()
+            {
+                _action();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/LoggedTest.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/LoggedTest.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit.Abstractions;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public abstract class LoggedTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public LoggedTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        public IDisposable StartLog(out ILoggerFactory loggerFactory, [CallerMemberName] string testName = null)
+        {
+            return AssemblyTestLog.ForAssembly(GetType().GetTypeInfo().Assembly).StartTestLog(_output, GetType().FullName, out loggerFactory, testName);
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/LoggedTest.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/LoggedTest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Xunit.Abstractions;

--- a/src/Microsoft.Extensions.Logging.Testing/Microsoft.Extensions.Logging.Testing.csproj
+++ b/src/Microsoft.Extensions.Logging.Testing/Microsoft.Extensions.Logging.Testing.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Helpers for writing tests that use Microsoft.Extensions.Logging. Contains null implementations of the abstractions that do nothing, as well as test implementations that are observable.</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>logging;testing</PackageTags>
@@ -12,12 +12,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Extensions.Logging.Abstractions\Microsoft.Extensions.Logging.Abstractions.csproj" />
+    <ProjectReference Include="..\Microsoft.Extensions.Logging.Console\Microsoft.Extensions.Logging.Console.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="xunit.abstractions" Version="$(XunitAbstractionsVersion)" />
     <PackageReference Include="xunit.assert" Version="$(XunitVersion)" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="$(SerilogExtensionsLoggingVersion)" />
+    <PackageReference Include="Serilog.Sinks.File" Version="$(SerilogFileSinkVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Extensions.Logging.Testing.Tests
+{
+    public class AssemblyTestLogTests : LoggedTest
+    {
+        private static readonly Assembly ThisAssembly = typeof(AssemblyTestLog).GetTypeInfo().Assembly;
+
+        public AssemblyTestLogTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void ForAssembly_ReturnsSameInstanceForSameAssembly()
+        {
+            Assert.Same(
+                AssemblyTestLog.ForAssembly(ThisAssembly),
+                AssemblyTestLog.ForAssembly(ThisAssembly));
+        }
+
+        [Fact]
+        public void TestLogWritesToITestOutputHelper()
+        {
+            var output = new TestTestOutputHelper();
+            var assemblyLog = AssemblyTestLog.Create("NonExistant.Test.Assembly", baseDirectory: null);
+
+            using (assemblyLog.StartTestLog(output, "NonExistant.Test.Class", out var loggerFactory))
+            {
+                var logger = loggerFactory.CreateLogger("TestLogger");
+                logger.LogInformation("Information!");
+            }
+
+            Assert.Equal(@"| TestLifetime Information: Starting test TestLogWritesToITestOutputHelper
+| TestLogger Information: Information!
+| TestLifetime Information: Finished test TestLogWritesToITestOutputHelper in DURATION
+", MakeConsistent(output.Output));
+        }
+
+        [Fact]
+        public void TestLogWritesToGlobalLogFile()
+        {
+            // Because this test writes to a file, it is a functional test and should be logged
+            // but it's also testing the test logging facility. So this is pretty meta ;)
+            using (StartLog(out var loggerFactory))
+            {
+                var logger = loggerFactory.CreateLogger("Test");
+
+                var tempDir = Path.Combine(Path.GetTempPath(), $"TestLogging_{Guid.NewGuid().ToString("N")}");
+                using (var testAssemblyLog = AssemblyTestLog.Create("FakeTestAssembly", tempDir))
+                {
+                    logger.LogInformation("Created test log in {baseDirectory}", tempDir);
+
+                    using (testAssemblyLog.StartTestLog(output: null, className: "FakeTestAssembly.FakeTestClass", loggerFactory: out var testLoggerFactory, testName: "FakeTestName"))
+                    {
+                        var testLogger = testLoggerFactory.CreateLogger("TestLogger");
+                        testLogger.LogInformation("Information!");
+                    }
+                }
+
+                logger.LogInformation("Finished test log in {baseDirectory}", tempDir);
+
+                var globalLogPath = Path.Combine(tempDir, "FakeTestAssembly", "global.log");
+                var testLog = Path.Combine(tempDir, "FakeTestAssembly", "FakeTestClass", $"FakeTestName.log");
+
+                Assert.True(File.Exists(globalLogPath), $"Expected global log file {globalLogPath} to exist");
+                Assert.True(File.Exists(testLog), $"Expected test log file {testLog} to exist");
+
+                var globalLogContent = MakeConsistent(File.ReadAllText(globalLogPath));
+                logger.LogInformation($"Global Log Content:{Environment.NewLine}{{content}}", globalLogContent);
+                var testLogContent = MakeConsistent(File.ReadAllText(testLog));
+                logger.LogInformation($"Test Log Content:{Environment.NewLine}{{content}}", testLogContent);
+
+                Assert.Equal(@"[GlobalTestLog] [Information] Global Test Logging initialized. Set the 'ASPNETCORE_TEST_LOG_DIR' Environment Variable in order to create log files on disk.
+[GlobalTestLog] [Information] Starting test ""FakeTestName""
+[GlobalTestLog] [Information] Finished test ""FakeTestName"" in DURATION
+", globalLogContent);
+                Assert.Equal(@"[TestLifetime] [Information] Starting test ""FakeTestName""
+[TestLogger] [Information] Information!
+[TestLifetime] [Information] Finished test ""FakeTestName"" in DURATION
+", testLogContent);
+            }
+        }
+
+        private static readonly Regex DurationRegex = new Regex(@"\d+\.\d+E?-?\d*s");
+        private static string MakeConsistent(string input)
+        {
+            return string.Join(Environment.NewLine, input.Split(new[] { Environment.NewLine }, StringSplitOptions.None)
+                .Select(line => DurationRegex.Replace(line.IndexOf("[") >= 0 ? line.Substring(line.IndexOf("[")) : line, "DURATION")));
+        }
+    }
+}

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/TestTestOutputHelper.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/TestTestOutputHelper.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using Xunit.Abstractions;
+
+namespace Microsoft.Extensions.Logging.Testing.Tests
+{
+    public class TestTestOutputHelper : ITestOutputHelper
+    {
+        private StringBuilder _output = new StringBuilder();
+
+        public bool Throw { get; set; }
+
+        public string Output => _output.ToString();
+
+        public void WriteLine(string message)
+        {
+            if (Throw)
+            {
+                throw new Exception("Boom!");
+            }
+            _output.AppendLine(message);
+        }
+
+        public void WriteLine(string format, params object[] args)
+        {
+            if (Throw)
+            {
+                throw new Exception("Boom!");
+            }
+            _output.AppendLine(string.Format(format, args));
+        }
+    }
+}

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/XunitLoggerProviderTest.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/XunitLoggerProviderTest.cs
@@ -2,13 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Text;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.Extensions.Logging.Testing.Tests
 {
-    public class XunitLoggerProviderTest
+    public partial class XunitLoggerProviderTest
     {
         [Fact]
         public void LoggerProviderWritesToTestOutputHelper()
@@ -72,33 +70,6 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
             logger.LogInformation("This is a" + Environment.NewLine + "multi-line" + Environment.NewLine + "message");
 
             Assert.Equal(0, testTestOutputHelper.Output.Length);
-        }
-
-        private class TestTestOutputHelper : ITestOutputHelper
-        {
-            private StringBuilder _output = new StringBuilder();
-
-            public bool Throw { get; set; }
-
-            public string Output => _output.ToString();
-
-            public void WriteLine(string message)
-            {
-                if (Throw)
-                {
-                    throw new Exception("Boom!");
-                }
-                _output.AppendLine(message);
-            }
-
-            public void WriteLine(string format, params object[] args)
-            {
-                if (Throw)
-                {
-                    throw new Exception("Boom!");
-                }
-                _output.AppendLine(string.Format(format, args));
-            }
         }
     }
 }

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/XunitLoggerProviderTest.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/XunitLoggerProviderTest.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Microsoft.Extensions.Logging.Testing.Tests
 {
-    public partial class XunitLoggerProviderTest
+    public class XunitLoggerProviderTest
     {
         [Fact]
         public void LoggerProviderWritesToTestOutputHelper()


### PR DESCRIPTION
@davidfowl really wanted this available as low as possible, so I've moved it from IntegrationTesting to here, Logging.Testing. This is a noship package already.

@Eilon The Serilog dependency is moving once again, from Hosting to here. Once this is merged, I'll be converting the IntegrationTesting package to use it and removing the dependency there.

I also restructured this to allow me to write some tests for it.