### PR TITLE
make the regex for testing more consistent

### DIFF
--- a/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
             }
         }
 
-        private static readonly Regex DurationRegex = new Regex(@"\d+\.\d+E?-?\d*s");
+        private static readonly Regex DurationRegex = new Regex(@"[^ ]+s$");
         private static string MakeConsistent(string input)
         {
             return string.Join(Environment.NewLine, input.Split(new[] { Environment.NewLine }, StringSplitOptions.None)


### PR DESCRIPTION
Going to merge when I get green builds. This is causing flakiness in the CI because if the tests finish fast enough, the duration doesn't match the regex.