### PR TITLE
Upgrade test framework versions and fix test issues

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -10,9 +10,9 @@
     <SerilogPeriodicBatchingVersion>2.1.0</SerilogPeriodicBatchingVersion>
     <SerilogRollingFileVersion>3.3.0</SerilogRollingFileVersion>
     <SerilogFileSinkVersion>3.2.0</SerilogFileSinkVersion>
-    <TestSdkVersion>15.0.0</TestSdkVersion>
+    <TestSdkVersion>15.3.0-*</TestSdkVersion>
     <WindowsAzureStorageVersion>8.1.1</WindowsAzureStorageVersion>
-    <XunitVersion>2.2.0</XunitVersion>
+    <XunitVersion>2.3.0-beta2-*</XunitVersion>
     <XunitAbstractionsVersion>2.0.1</XunitAbstractionsVersion>
   </PropertyGroup>
 </Project>

--- a/test/Microsoft.Extensions.Logging.AzureAppServices.Test/AzureBlobSinkTests.cs
+++ b/test/Microsoft.Extensions.Logging.AzureAppServices.Test/AzureBlobSinkTests.cs
@@ -38,12 +38,12 @@ namespace Microsoft.Extensions.Logging.AzureAppServices.Test
             await sink.DoEmitBatchInternalAsync(events.ToArray());
 
             Assert.Equal(1, buffers.Count);
-            Assert.Equal(Encoding.UTF8.GetString(buffers[0]), @"Information Text 0
+            Assert.Equal(@"Information Text 0
 Information Text 1
 Information Text 2
 Information Text 3
 Information Text 4
-");
+", Encoding.UTF8.GetString(buffers[0]));
         }
 
         [Fact]
@@ -104,7 +104,7 @@ Information Text 4
             await sink.DoEmitBatchInternalAsync(new[] {CreateEvent(DateTime.Now, "Text")});
 
             Assert.Equal(1, buffers.Count);
-            Assert.Equal(true, created);
+            Assert.True(created);
         }
 
         private static LogEvent CreateEvent(DateTime addHours, string text)

--- a/test/Microsoft.Extensions.Logging.AzureAppServices.Test/Microsoft.Extensions.Logging.AzureAppServices.Test.csproj
+++ b/test/Microsoft.Extensions.Logging.AzureAppServices.Test/Microsoft.Extensions.Logging.AzureAppServices.Test.csproj
@@ -19,8 +19,4 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.Extensions.Logging.EventSource.Test/Microsoft.Extensions.Logging.EventSource.Test.csproj
+++ b/test/Microsoft.Extensions.Logging.EventSource.Test/Microsoft.Extensions.Logging.EventSource.Test.csproj
@@ -18,8 +18,4 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.Extensions.Logging.Test/LoggerExtensionsTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/LoggerExtensionsTest.cs
@@ -46,37 +46,37 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(LogLevel.Trace, trace.LogLevel);
             Assert.Equal(_state, trace.State.ToString());
             Assert.Equal(0, trace.EventId);
-            Assert.Equal(null, trace.Exception);
+            Assert.Null(trace.Exception);
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
             Assert.Equal(_state, information.State.ToString());
             Assert.Equal(0, information.EventId);
-            Assert.Equal(null, information.Exception);
+            Assert.Null(information.Exception);
 
             var warning = sink.Writes[2];
             Assert.Equal(LogLevel.Warning, warning.LogLevel);
             Assert.Equal(_state, warning.State.ToString());
             Assert.Equal(0, warning.EventId);
-            Assert.Equal(null, warning.Exception);
+            Assert.Null(warning.Exception);
 
             var error = sink.Writes[3];
             Assert.Equal(LogLevel.Error, error.LogLevel);
             Assert.Equal(_state, error.State.ToString());
             Assert.Equal(0, error.EventId);
-            Assert.Equal(null, error.Exception);
+            Assert.Null(error.Exception);
 
             var critical = sink.Writes[4];
             Assert.Equal(LogLevel.Critical, critical.LogLevel);
             Assert.Equal(_state, critical.State.ToString());
             Assert.Equal(0, critical.EventId);
-            Assert.Equal(null, critical.Exception);
+            Assert.Null(critical.Exception);
 
             var debug = sink.Writes[5];
             Assert.Equal(LogLevel.Debug, debug.LogLevel);
             Assert.Equal(_state, debug.State.ToString());
             Assert.Equal(0, debug.EventId);
-            Assert.Equal(null, debug.Exception);
+            Assert.Null(debug.Exception);
         }
 
         [Fact]
@@ -101,37 +101,37 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(LogLevel.Trace, trace.LogLevel);
             Assert.Equal(string.Format(_format, "test1", "test2"), trace.State?.ToString());
             Assert.Equal(0, trace.EventId);
-            Assert.Equal(null, trace.Exception);
+            Assert.Null(trace.Exception);
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
             Assert.Equal(string.Format(_format, "test1", "test2"), information.State?.ToString());
             Assert.Equal(0, information.EventId);
-            Assert.Equal(null, information.Exception);
+            Assert.Null(information.Exception);
 
             var warning = sink.Writes[2];
             Assert.Equal(LogLevel.Warning, warning.LogLevel);
             Assert.Equal(string.Format(_format, "test1", "test2"), warning.State?.ToString());
             Assert.Equal(0, warning.EventId);
-            Assert.Equal(null, warning.Exception);
+            Assert.Null(warning.Exception);
 
             var error = sink.Writes[3];
             Assert.Equal(LogLevel.Error, error.LogLevel);
             Assert.Equal(string.Format(_format, "test1", "test2"), error.State?.ToString());
             Assert.Equal(0, error.EventId);
-            Assert.Equal(null, error.Exception);
+            Assert.Null(error.Exception);
 
             var critical = sink.Writes[4];
             Assert.Equal(LogLevel.Critical, critical.LogLevel);
             Assert.Equal(string.Format(_format, "test1", "test2"), critical.State?.ToString());
             Assert.Equal(0, critical.EventId);
-            Assert.Equal(null, critical.Exception);
+            Assert.Null(critical.Exception);
 
             var debug = sink.Writes[5];
             Assert.Equal(LogLevel.Debug, debug.LogLevel);
             Assert.Equal(string.Format(_format, "test1", "test2"), debug.State?.ToString());
             Assert.Equal(0, debug.EventId);
-            Assert.Equal(null, debug.Exception);
+            Assert.Null(debug.Exception);
         }
 
         [Fact]
@@ -156,37 +156,37 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(LogLevel.Trace, trace.LogLevel);
             Assert.Equal(_state, trace.State.ToString());
             Assert.Equal(1, trace.EventId);
-            Assert.Equal(null, trace.Exception);
+            Assert.Null(trace.Exception);
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
             Assert.Equal(_state, information.State.ToString());
             Assert.Equal(2, information.EventId);
-            Assert.Equal(null, information.Exception);
+            Assert.Null(information.Exception);
 
             var warning = sink.Writes[2];
             Assert.Equal(LogLevel.Warning, warning.LogLevel);
             Assert.Equal(_state, warning.State.ToString());
             Assert.Equal(3, warning.EventId);
-            Assert.Equal(null, warning.Exception);
+            Assert.Null(warning.Exception);
 
             var error = sink.Writes[3];
             Assert.Equal(LogLevel.Error, error.LogLevel);
             Assert.Equal(_state, error.State.ToString());
             Assert.Equal(4, error.EventId);
-            Assert.Equal(null, error.Exception);
+            Assert.Null(error.Exception);
 
             var critical = sink.Writes[4];
             Assert.Equal(LogLevel.Critical, critical.LogLevel);
             Assert.Equal(_state, critical.State.ToString());
             Assert.Equal(5, critical.EventId);
-            Assert.Equal(null, critical.Exception);
+            Assert.Null(critical.Exception);
 
             var debug = sink.Writes[5];
             Assert.Equal(LogLevel.Debug, debug.LogLevel);
             Assert.Equal(_state, debug.State.ToString());
             Assert.Equal(6, debug.EventId);
-            Assert.Equal(null, debug.Exception);
+            Assert.Null(debug.Exception);
         }
 
         [Fact]
@@ -211,37 +211,37 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(LogLevel.Trace, trace.LogLevel);
             Assert.Equal(string.Format(_format, "test1", "test2"), trace.State?.ToString());
             Assert.Equal(1, trace.EventId);
-            Assert.Equal(null, trace.Exception);
+            Assert.Null(trace.Exception);
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
             Assert.Equal(string.Format(_format, "test1", "test2"), information.State?.ToString());
             Assert.Equal(2, information.EventId);
-            Assert.Equal(null, information.Exception);
+            Assert.Null(information.Exception);
 
             var warning = sink.Writes[2];
             Assert.Equal(LogLevel.Warning, warning.LogLevel);
             Assert.Equal(string.Format(_format, "test1", "test2"), warning.State?.ToString());
             Assert.Equal(3, warning.EventId);
-            Assert.Equal(null, warning.Exception);
+            Assert.Null(warning.Exception);
 
             var error = sink.Writes[3];
             Assert.Equal(LogLevel.Error, error.LogLevel);
             Assert.Equal(string.Format(_format, "test1", "test2"), error.State?.ToString());
             Assert.Equal(4, error.EventId);
-            Assert.Equal(null, error.Exception);
+            Assert.Null(error.Exception);
 
             var critical = sink.Writes[4];
             Assert.Equal(LogLevel.Critical, critical.LogLevel);
             Assert.Equal(string.Format(_format, "test1", "test2"), critical.State?.ToString());
             Assert.Equal(5, critical.EventId);
-            Assert.Equal(null, critical.Exception);
+            Assert.Null(critical.Exception);
 
             var debug = sink.Writes[5];
             Assert.Equal(LogLevel.Debug, debug.LogLevel);
             Assert.Equal(string.Format(_format, "test1", "test2"), debug.State?.ToString());
             Assert.Equal(6, debug.EventId);
-            Assert.Equal(null, debug.Exception);
+            Assert.Null(debug.Exception);
         }
 
         [Fact]
@@ -379,37 +379,37 @@ namespace Microsoft.Extensions.Logging.Test
             var trace = sink.Writes[0];
             Assert.Equal(LogLevel.Trace, trace.LogLevel);
             Assert.Equal(0, trace.EventId);
-            Assert.Equal(null, trace.Exception);
+            Assert.Null(trace.Exception);
             Assert.Equal("Test 1", trace.Formatter(trace.State, trace.Exception));
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
             Assert.Equal(0, information.EventId);
-            Assert.Equal(null, information.Exception);
+            Assert.Null(information.Exception);
             Assert.Equal("Test 1", information.Formatter(information.State, information.Exception));
 
             var warning = sink.Writes[2];
             Assert.Equal(LogLevel.Warning, warning.LogLevel);
             Assert.Equal(0, warning.EventId);
-            Assert.Equal(null, warning.Exception);
+            Assert.Null(warning.Exception);
             Assert.Equal("Test 1", warning.Formatter(warning.State, warning.Exception));
 
             var error = sink.Writes[3];
             Assert.Equal(LogLevel.Error, error.LogLevel);
             Assert.Equal(0, error.EventId);
-            Assert.Equal(null, error.Exception);
+            Assert.Null(error.Exception);
             Assert.Equal("Test 1", error.Formatter(error.State, error.Exception));
 
             var critical = sink.Writes[4];
             Assert.Equal(LogLevel.Critical, critical.LogLevel);
             Assert.Equal(0, critical.EventId);
-            Assert.Equal(null, critical.Exception);
+            Assert.Null(critical.Exception);
             Assert.Equal("Test 1", critical.Formatter(critical.State, critical.Exception));
 
             var debug = sink.Writes[5];
             Assert.Equal(LogLevel.Debug, debug.LogLevel);
             Assert.Equal(0, debug.EventId);
-            Assert.Equal(null, debug.Exception);
+            Assert.Null(debug.Exception);
             Assert.Equal("Test 1", debug.Formatter(debug.State, debug.Exception));
         }
 
@@ -438,37 +438,37 @@ namespace Microsoft.Extensions.Logging.Test
             var trace = sink.Writes[0];
             Assert.Equal(LogLevel.Trace, trace.LogLevel);
             Assert.Equal(1, trace.EventId);
-            Assert.Equal(null, trace.Exception);
+            Assert.Null(trace.Exception);
             Assert.Equal("Test 1", trace.Formatter(trace.State, trace.Exception));
 
             var information = sink.Writes[1];
             Assert.Equal(LogLevel.Information, information.LogLevel);
             Assert.Equal(2, information.EventId);
-            Assert.Equal(null, information.Exception);
+            Assert.Null(information.Exception);
             Assert.Equal("Test 1", information.Formatter(information.State, information.Exception));
 
             var warning = sink.Writes[2];
             Assert.Equal(LogLevel.Warning, warning.LogLevel);
             Assert.Equal(3, warning.EventId);
-            Assert.Equal(null, warning.Exception);
+            Assert.Null(warning.Exception);
             Assert.Equal("Test 1", warning.Formatter(warning.State, warning.Exception));
 
             var error = sink.Writes[3];
             Assert.Equal(LogLevel.Error, error.LogLevel);
             Assert.Equal(4, error.EventId);
-            Assert.Equal(null, error.Exception);
+            Assert.Null(error.Exception);
             Assert.Equal("Test 1", error.Formatter(error.State, error.Exception));
 
             var critical = sink.Writes[4];
             Assert.Equal(LogLevel.Critical, critical.LogLevel);
             Assert.Equal(5, critical.EventId);
-            Assert.Equal(null, critical.Exception);
+            Assert.Null(critical.Exception);
             Assert.Equal("Test 1", critical.Formatter(critical.State, critical.Exception));
 
             var debug = sink.Writes[5];
             Assert.Equal(LogLevel.Debug, debug.LogLevel);
             Assert.Equal(6, debug.EventId);
-            Assert.Equal(null, debug.Exception);
+            Assert.Null(debug.Exception);
             Assert.Equal("Test 1", debug.Formatter(debug.State, debug.Exception));
         }
 
@@ -625,7 +625,7 @@ namespace Microsoft.Extensions.Logging.Test
         {
             // Arrange
             var testSink = new TestSink(
-                writeEnabled: (writeContext) => true, 
+                writeEnabled: (writeContext) => true,
                 beginEnabled: (beginScopeContext) => true);
             var logger = new TestLogger("TestLogger", testSink, enabled: true);
             var actionName = "App.Controllers.Home.Index";

--- a/test/Microsoft.Extensions.Logging.Test/Microsoft.Extensions.Logging.Test.csproj
+++ b/test/Microsoft.Extensions.Logging.Test/Microsoft.Extensions.Logging.Test.csproj
@@ -5,8 +5,6 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,10 +26,6 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <ProjectReference Include="..\..\src\Microsoft.Extensions.Logging.EventLog\Microsoft.Extensions.Logging.EventLog.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/Microsoft.Extensions.Logging.Testing.Tests.csproj
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/Microsoft.Extensions.Logging.Testing.Tests.csproj
@@ -18,8 +18,4 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Upgrade to xunit2.3 and test SDK 15.3.

:watch: blocked on https://github.com/aspnet/KestrelHttpServer/pull/1834 which has a down-stream dependency on Logging.Testing. This can't merge until Kestrel has also updated to xunit 2.3.