### PR TITLE
Late bind ProviderAlias attribute to support libraries unable to reference new logging package

### DIFF
--- a/test/Microsoft.Extensions.Logging.Test/ProviderAliasAttribute.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ProviderAliasAttribute.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.Logging
+{
+    /// <summary>
+    /// Test implementation of ProviderAliasAttribute
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class ProviderAliasAttribute : Attribute
+    {
+        public ProviderAliasAttribute(string alias)
+        {
+            Alias = alias;
+        }
+
+        public string Alias { get; }
+    }
+}

--- a/test/Microsoft.Extensions.Logging.Test/TestLoggerProvider.cs
+++ b/test/Microsoft.Extensions.Logging.Test/TestLoggerProvider.cs
@@ -6,7 +6,9 @@ using Microsoft.Extensions.Logging.Testing;
 
 namespace Microsoft.Extensions.Logging.Test
 {
+#pragma warning disable CS0436 // Type conflicts with imported type
     [ProviderAlias("TestLogger")]
+#pragma warning restore CS0436 // Type conflicts with imported type
     public class TestLoggerProvider : ILoggerProvider
     {
         private readonly Func<LogLevel, bool> _filter;


### PR DESCRIPTION
ApplicationInsights in particular 