### PR TITLE
Fix #656 - issue parsing format string w/ group separator

### DIFF
--- a/src/Microsoft.Extensions.Logging.Abstractions/Internal/LogValuesFormatter.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/Internal/LogValuesFormatter.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Extensions.Logging.Internal
     {
         private const string NullValue = "(null)";
         private static readonly object[] EmptyArray = new object[0];
+        private static readonly char[] FormatDelimiters = {',', ':'};
         private readonly string _format;
         private readonly List<string> _valueNames = new List<string>();
 
@@ -34,11 +35,7 @@ namespace Microsoft.Extensions.Logging.Internal
                 var closeBraceIndex = FindBraceIndex(format, '}', openBraceIndex, endIndex);
 
                 // Format item syntax : { index[,alignment][ :formatString] }.
-                var formatDelimiterIndex = FindIndexOf(format, ',', openBraceIndex, closeBraceIndex);
-                if (formatDelimiterIndex == closeBraceIndex)
-                {
-                    formatDelimiterIndex = FindIndexOf(format, ':', openBraceIndex, closeBraceIndex);
-                }
+                var formatDelimiterIndex = FindIndexOfAny(format, FormatDelimiters, openBraceIndex, closeBraceIndex);
 
                 if (closeBraceIndex == endIndex)
                 {
@@ -110,9 +107,9 @@ namespace Microsoft.Extensions.Logging.Internal
             return braceIndex;
         }
 
-        private static int FindIndexOf(string format, char ch, int startIndex, int endIndex)
+        private static int FindIndexOfAny(string format, char[] chars, int startIndex, int endIndex)
         {
-            var findIndex = format.IndexOf(ch, startIndex, endIndex - startIndex);
+            var findIndex = format.IndexOfAny(chars, startIndex, endIndex - startIndex);
             return findIndex == -1 ? endIndex : findIndex;
         }
 

--- a/test/Microsoft.Extensions.Logging.Test/FormattedLogValuesTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/FormattedLogValuesTest.cs
@@ -61,6 +61,18 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Theory]
+        [InlineData("8,765", "{Number:#,#}")]
+        public void LogValues_With_CustomNumericFormat(string expected, string format)
+        {
+            var number = 8765.4321;
+            var logValues = new FormattedLogValues(format, new object[] { number, number });
+            Assert.Equal(expected, logValues.ToString());
+
+            // Original format is expected to be returned from GetValues.
+            Assert.Equal(format, logValues.First(v => v.Key == "{OriginalFormat}").Value);
+        }
+
+        [Theory]
         [InlineData("{{", "{{", null)]
         [InlineData("'{{'", "'{{'", null)]
         [InlineData("'{{}}'", "'{{}}'", null)]

--- a/test/Microsoft.Extensions.Logging.Test/FormattedLogValuesTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/FormattedLogValuesTest.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Extensions.Logging.Test
         [InlineData("arg1 arg2", "{Start} {End}", new object[] { "arg1", "arg2" })]
         [InlineData("arg1     arg2", "{Start,-6} {End,6}", new object[] { "arg1", "arg2" })]
         [InlineData("0064", "{Hex:X4}", new object[] { 100 })]
+        [InlineData("8,765", "{Number:#,#}", new object[] {8765.4321})]
         public void LogValues_With_Basic_Types(string expected, string format, object[] args)
         {
             var logValues = new FormattedLogValues(format, args);
@@ -54,18 +55,6 @@ namespace Microsoft.Extensions.Logging.Test
         {
             var dateTime = new DateTime(2015, 1, 1, 1, 1, 1);
             var logValues = new FormattedLogValues(format, new object[] { dateTime, dateTime });
-            Assert.Equal(expected, logValues.ToString());
-
-            // Original format is expected to be returned from GetValues.
-            Assert.Equal(format, logValues.First(v => v.Key == "{OriginalFormat}").Value);
-        }
-
-        [Theory]
-        [InlineData("8,765", "{Number:#,#}")]
-        public void LogValues_With_CustomNumericFormat(string expected, string format)
-        {
-            var number = 8765.4321;
-            var logValues = new FormattedLogValues(format, new object[] { number, number });
             Assert.Equal(expected, logValues.ToString());
 
             // Original format is expected to be returned from GetValues.

--- a/test/Microsoft.Extensions.Logging.Test/FormattedLogValuesTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/FormattedLogValuesTest.cs
@@ -17,7 +17,8 @@ namespace Microsoft.Extensions.Logging.Test
         [InlineData("arg1 arg2", "{Start} {End}", new object[] { "arg1", "arg2" })]
         [InlineData("arg1     arg2", "{Start,-6} {End,6}", new object[] { "arg1", "arg2" })]
         [InlineData("0064", "{Hex:X4}", new object[] { 100 })]
-        [InlineData("8,765", "{Number:#,#}", new object[] {8765.4321})]
+        [InlineData("8,765", "{Number:#,#}", new object[] { 8765.4321 })]
+        [InlineData(" 8,765", "{Number,6:#,#}", new object[] { 8765.4321 })]
         public void LogValues_With_Basic_Types(string expected, string format, object[] args)
         {
             var logValues = new FormattedLogValues(format, args);


### PR DESCRIPTION
Fixes #656

Fix issue parsing log message format strings with placeholders containing a format string with a comma ",", such as "{setupTime:#,#}" which uses a custom numeric format string with a group separator. This fix uses the index of the first first comma "," or colon ":" found as the delimiter instead of ignoring the colon ":" if a comma "," was found.