### PR TITLE
Removed indirection in starting the consumer in ConsoleLoggerProcessor

### DIFF
--- a/src/Microsoft.Extensions.Logging.Console/Internal/ConsoleLoggerProcessor.cs
+++ b/src/Microsoft.Extensions.Logging.Console/Internal/ConsoleLoggerProcessor.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Extensions.Logging.Console.Internal
             // Start Console message queue processor
             _outputTask = Task.Factory.StartNew(
                 ProcessLogQueue,
-                this,
                 TaskCreationOptions.LongRunning);
         }
 
@@ -59,13 +58,6 @@ namespace Microsoft.Extensions.Logging.Console.Internal
             {
                 WriteMessage(message);
             }
-        }
-
-        private static void ProcessLogQueue(object state)
-        {
-            var consoleLogger = (ConsoleLoggerProcessor)state;
-
-            consoleLogger.ProcessLogQueue();
         }
 
         public void Dispose()


### PR DESCRIPTION
I see no need for the indirection to the static method, which in turn only calls the instance method.

```c#
public ConsoleLoggerProcessor()
{
	// Start Console message queue processor
	_outputTask = Task.Factory.StartNew(
		ProcessLogQueue,
		this,
		TaskCreationOptions.LongRunning);
}

private void ProcessLogQueue()
{
	foreach (var message in _messageQueue.GetConsumingEnumerable())
	{
		WriteMessage(message);
	}
}

private static void ProcessLogQueue(object state)
{
	var consoleLogger = (ConsoleLoggerProcessor)state;

	consoleLogger.ProcessLogQueue();
}
```

The (little) change uses the instance method directly in the `Task.Factory.StartNew` method.