### PR TITLE
Don't set AsyncLocal for scope if not included

### DIFF
--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
@@ -199,7 +199,14 @@ namespace Microsoft.Extensions.Logging.Console
                 throw new ArgumentNullException(nameof(state));
             }
 
-            return ConsoleLogScope.Push(Name, state);
+            if (IncludeScopes)
+            {
+                return ConsoleLogScope.Push(Name, state);
+            }
+            else
+            {
+                return NullDisposable.Instance;
+            }
         }
 
         private static string GetLogLevelString(LogLevel logLevel)
@@ -296,6 +303,16 @@ namespace Microsoft.Extensions.Logging.Console
             public void WriteLine(string message)
             {
                 System.Console.WriteLine(message);
+            }
+        }
+
+        private class NullDisposable : IDisposable
+        {
+            public static readonly NullDisposable Instance = new NullDisposable();
+
+            public void Dispose()
+            {
+                // intentionally does nothing
             }
         }
     }

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Extensions.Logging.Console
             }
         }
 
-        private class NullDisposable : IDisposable
+        internal class NullDisposable : IDisposable
         {
             public static readonly NullDisposable Instance = new NullDisposable();
 

--- a/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
@@ -615,11 +615,12 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Fact]
-        public void CallingBeginScopeOnLogger_AlwaysReturnsNewDisposableInstance()
+        public void CallingBeginScopeOnLoggerWithScopes_AlwaysReturnsNewDisposableInstance()
         {
             // Arrange
             var t = SetUp(null);
             var logger = t.Logger;
+            logger.IncludeScopes = true;
             var sink = t.Sink;
 
             // Act
@@ -630,6 +631,26 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.NotNull(disposable1);
             Assert.NotNull(disposable2);
             Assert.NotSame(disposable1, disposable2);
+        }
+
+        [Fact]
+        public void CallingBeginScopeOnLoggerWithoutScopes_AlwaysReturnsSameDisposableInstance()
+        {
+            // Arrange
+            var t = SetUp(null);
+            var logger = t.Logger;
+            logger.IncludeScopes = false;
+            var sink = t.Sink;
+
+            // Act
+            var disposable1 = logger.BeginScope("Scope1");
+            var disposable2 = logger.BeginScope("Scope2");
+
+            // Assert
+            Assert.NotNull(disposable1);
+            Assert.NotNull(disposable2);
+            Assert.Same(disposable1, disposable2);
+            Assert.Same(ConsoleLogger.NullDisposable.Instance, disposable2);
         }
 
         [Fact]


### PR DESCRIPTION
Don't disturb the `ExecutionContext` if scopes aren't being used as it wildly increases allocations

Without ConsoleLogger (no changes to AsyncLocal)
![](https://aoa.blob.core.windows.net/aspnet/tasks-action.png)

With ConsoleLogger and no scopes - but not logging anything (changes to AsyncLocal)
![](https://aoa.blob.core.windows.net/aspnet/async-local.png)

You can see the allocations of `Action` and `MoveNextRunner` disproportionately increase; prior to this change

Resolves https://github.com/aspnet/Logging/issues/714

/cc @davidfowl 

You are right @anurse, logging allocations make me sad 😢 