### PR TITLE
Corrected documentation spelling, typos, formatting. 

### DIFF
--- a/src/Microsoft.Extensions.Logging.EventSource/LoggingEventSource.cs
+++ b/src/Microsoft.Extensions.Logging.EventSource/LoggingEventSource.cs
@@ -6,29 +6,33 @@ using System.Diagnostics.Tracing;
 namespace Microsoft.Extensions.Logging.EventSource
 {
     /// <summary>
-    /// The LoggingEventSource is the bridge form all <see cref="ILogger"/>-based logging to EventSource/EventListener logging.
-    ///
-    /// You turn this logging on by enabling the EventSource called <c>Microsoft-Extensions-Logging</c>
-    ///
-    /// When you enabled the EventSource, the EventLevel you set is translated in the obvious way to the level
-    /// associated with the ILogger (thus Debug = verbose, Informational = Informational ... Critical = Critical)
-    ///
+    /// <para>
+    /// The LoggingEventSource is the bridge from all <see cref="ILogger"/>-based logging to EventSource/EventListener logging.
+    /// </para>
+    /// <para>
+    /// Turn on this logging by enabling the EventSource called 'Microsoft-Extensions-Logging'
+    /// </para>
+    /// <para>
+    /// When you enable the EventSource, the EventLevel you set is translated to the corresponding level
+    /// associated with the ILogger, so that Debug = Verbose, Informational = Informational, Critical = Critical, etc.
     /// This allows you to filter by event level in a straighforward way.
-    ///
-    /// For finer control you can specify an EventSource argument called 'FilterSpecs'
-    ///
-    /// The FilterSpecs argument is a semicolon-separated list of specifications, where each specification is
-    ///
+    /// </para>
+    /// <para>
+    /// For finer control you can specify an EventSource argument called 'FilterSpecs'. 
+    /// The FilterSpecs argument is a semicolon-separated list of specifications, where each specification is:
+    /// </para>
     /// <code>
-    ///     SPEC =                          // empty spec, same as *
-    ///          | NAME                     // Just a name the level is the default level
-    ///          | NAME : LEVEL             // specifies level for a particular logger (can have a * suffix).
+    ///     SPEC =                          // Empty spec; same as *
+    ///          | NAME                     // Just a name. The level is the default level.
+    ///          | NAME : LEVEL             // Specifies level for a particular logger (can have a * suffix).
     /// </code>
-    ///
+    /// <para>
     /// 'NAME' is the name of a ILogger (case matters), Name can have a * which acts as a wildcard
     /// *as a suffix*. Thus, 'Net*' will match any loggers that start with the string 'Net'.
-    ///
-    /// 'LEVEL' is a number or a LogLevel string. 
+    /// </para>
+    /// <para>
+    /// 'LEVEL' is a number or a LogLevel string:
+    /// </para>
     /// <code>
     ///     0 = Trace
     ///     1 = Debug
@@ -37,27 +41,26 @@ namespace Microsoft.Extensions.Logging.EventSource
     ///     4 = Error
     ///     5 = Critical
     /// </code>
-    /// 
+    /// <para>
     /// This specifies the level for the associated pattern. If the number is not specified, (first form
     /// of the specification) it is the default level for the EventSource.
-    ///
-    /// First match is used if a particular name matches more than one pattern.
-    ///
-    /// In addition the level and 'FilterSpec' argument, you can also set 'EventSource' Keywords. See the Keywords
-    /// definition below, but basically you get to decide if you wish to have:
-    ///
+    /// The First match is used if a particular name matches more than one pattern.
+    /// </para>
+    /// <para>
+    /// In addition the level and 'FilterSpec' argument, you can also set 'EventSource' Keywords. (See the Keywords
+    /// definition below.) Your options are:
+    /// </para>
+    /// <para>
     ///   * Keywords.Message - You get the event with the data in parsed form.
     ///   * Keywords.JsonMessage - you get an event with the data in parse form but as a JSON blob (not broken up by argument ...)
     ///   * Keywords.FormattedMessage - you get an event with the data formatted as a string
-    ///
-    /// It is expected that you will turn only one of these keywords on at a time, but you can turn them all on (and get
+    /// </para>
+    /// <para>
+    /// Typically, you will turn only one of these keywords on at a time. However, you can turn them all on and get
     /// the same data logged three different ways.
-    ///
+    /// </para>
     /// <example>
-    /// Example Usage
-    ///
     /// This example shows how to use an EventListener to get ILogging information
-    ///
     /// <code>
     /// class MyEventListener : EventListener {
     ///     protected override void OnEventSourceCreated(EventSource eventSource) {

--- a/src/Microsoft.Extensions.Logging.EventSource/LoggingEventSource.cs
+++ b/src/Microsoft.Extensions.Logging.EventSource/LoggingEventSource.cs
@@ -6,38 +6,34 @@ using System.Diagnostics.Tracing;
 namespace Microsoft.Extensions.Logging.EventSource
 {
     /// <summary>
-    /// The LoggingEventSource is the bridge form all ILogger based logging to EventSource/EventListener logging.
+    /// The LoggingEventSource is the bridge form all `ILogger`-based logging to EventSource/EventListener logging.
     ///
-    /// You turn this logging on by enabling the EvenSource called
-    ///
-    ///      Microsoft-Extensions-Logging
+    /// You turn this logging on by enabling the EventSource called `Microsoft-Extensions-Logging`
     ///
     /// When you enabled the EventSource, the EventLevel you set is translated in the obvious way to the level
-    /// associated with the ILogger (thus Debug = verbose, Informational = Informational ... Critical == Critical)
+    /// associated with the ILogger (thus Debug = verbose, Informational = Informational ... Critical = Critical)
     ///
     /// This allows you to filter by event level in a straighforward way.
     ///
-    /// For finer control you can specify a EventSource Argument called
+    /// For finer control you can specify an EventSource argument called `FilterSpecs`
     ///
-    /// FilterSpecs
+    /// The FilterSpecs argument is a semicolon-separated list of specifications, where each specification is
     ///
-    /// The FilterSpecs argument is a semicolon separated list of specifications.   Where each specification is
+    ///     SPEC =                          // empty spec, same as *
+    ///          | NAME                     // Just a name the level is the default level
+    ///          | NAME : LEVEL             // specifies level for a particular logger (can have a * suffix).
     ///
-    /// SPEC =                          // empty spec, same as *
-    ///      | NAME                     // Just a name the level is the default level
-    ///      | NAME : LEVEL            // specifies level for a particular logger (can have a * suffix).
+    /// **NAME** is the name of a ILogger (case matters), Name can have a * which acts as a wildcard
+    /// *as a suffix*. Thus, `Net*` will match any loggers that start with the string 'Net'.
     ///
-    /// Where Name is the name of a ILoggger (case matters), Name can have a * which acts as a wildcard
-    /// AS A SUFFIX.   Thus Net* will match any loggers that start with the 'Net'.
-    ///
-    /// The LEVEL is a number or a LogLevel string. 0=Trace, 1=Debug, 2=Information, 3=Warning,  4=Error, Critical=5
-    /// This speicifies the level for the associated pattern.  If the number is not specified, (first form
+    /// **LEVEL** is a number or a LogLevel string. 0=Trace, 1=Debug, 2=Information, 3=Warning,  4=Error, Critical=5
+    /// This specifies the level for the associated pattern. If the number is not specified, (first form
     /// of the specification) it is the default level for the EventSource.
     ///
-    /// First match is used if a partciular name matches more than one pattern.
+    /// First match is used if a particular name matches more than one pattern.
     ///
-    /// In addition the level and FilterSpec argument, you can also set EventSource Keywords.  See the Keywords
-    /// definition below, but basically you get to decide if you wish to have
+    /// In addition the level and `FilterSpec` argument, you can also set `EventSource` Keywords.  See the Keywords
+    /// definition below, but basically you get to decide if you wish to have:
     ///
     ///   * Keywords.Message - You get the event with the data in parsed form.
     ///   * Keywords.JsonMessage - you get an event with the data in parse form but as a JSON blob (not broken up by argument ...)
@@ -48,8 +44,9 @@ namespace Microsoft.Extensions.Logging.EventSource
     ///
     /// Example Usage
     ///
-    /// This example shows how to use an EventListener to get ILogging information
+    /// This example shows how to use an `EventListener` to get `ILogging` information
     ///
+    /// ```csharp
     /// class MyEventListener : EventListener {
     ///     protected override void OnEventSourceCreated(EventSource eventSource) {
     ///         if (eventSource.Name == "Microsoft-Extensions-Logging") {
@@ -67,36 +64,37 @@ namespace Microsoft.Extensions.Logging.EventSource
     ///             Console.WriteLine("Logger {0}: {1}", eventData.Payload[2], eventData.Payload[4]);
     ///     }
     /// }
+    /// ```
     /// </summary>
     [EventSource(Name = "Microsoft-Extensions-Logging")]
     internal class LoggingEventSource : System.Diagnostics.Tracing.EventSource
     {
         /// <summary>
-        /// This is public from an EventSource consumer point of view, but since these defintions
+        /// This is public from an `EventSource` consumer point of view. These definitions
         /// are not needed outside this class
         /// </summary>
         public class Keywords
         {
             /// <summary>
-            /// Meta events are evnets about the LoggingEventSource itself (that is they did not come from ILogger
+            /// Meta events are events about the `LoggingEventSource` itself (that is, they did not come from `ILogger`)
             /// </summary>
             public const EventKeywords Meta = (EventKeywords)1;
             /// <summary>
-            /// Turns on the 'Message' event when ILogger.Log() is called.   It gives the information in a programatic (not formatted) way
+            /// Turns on the `Message` event when `ILogger.Log()` is called.   It gives the information in a programmatic (not formatted) way
             /// </summary>
             public const EventKeywords Message = (EventKeywords)2;
             /// <summary>
-            /// Turns on the 'FormatMessage' event when ILogger.Log() is called.  It gives the formatted string version of the information.
+            /// Turns on the `FormatMessage` event when `ILogger.Log()` is called.  It gives the formatted string version of the information.
             /// </summary>
             public const EventKeywords FormattedMessage = (EventKeywords)4;
             /// <summary>
-            /// Turns on the 'MessageJson' event when ILogger.Log() is called.   It gives  JSON representation of the Arguments.
+            /// Turns on the `MessageJson` event when `ILogger.Log()` is called.   It gives  JSON representation of the arguments.
             /// </summary>
             public const EventKeywords JsonMessage = (EventKeywords)8;
         }
 
         /// <summary>
-        ///  The one and only instance of the LoggingEventSource.
+        ///  The one and only instance of the `LoggingEventSource`.
         /// </summary>
         internal static readonly LoggingEventSource Instance = new LoggingEventSource();
 
@@ -127,8 +125,8 @@ namespace Microsoft.Extensions.Logging.EventSource
         private LoggingEventSource() : base(EventSourceSettings.EtwSelfDescribingEventFormat) { }
 
         /// <summary>
-        /// FormattedMessage() is called when ILogger.Log() is called. and the FormattedMessage keyword is active
-        /// This only gives you the human reasable formatted message.
+        /// `FormattedMessage()` is called when `ILogger.Log()` is called, and the `FormattedMessage` keyword is active.
+        /// This only gives you the human readable formatted message.
         /// </summary>
         [Event(1, Keywords = Keywords.FormattedMessage, Level = EventLevel.LogAlways)]
         internal void FormattedMessage(LogLevel Level, int FactoryID, string LoggerName, string EventId, string FormattedMessage)
@@ -137,8 +135,8 @@ namespace Microsoft.Extensions.Logging.EventSource
         }
 
         /// <summary>
-        /// Message() is called when ILogger.Log() is called. and the Message keyword is active
-        /// This gives you the logged information in a programatic format (arguments are key-value pairs)
+        /// `Message()` is called when `ILogger.Log()` is called. and the `Message` keyword is active.
+        /// This gives you the logged information in a programmatic format (arguments are key-value pairs)
         /// </summary>
         [Event(2, Keywords = Keywords.Message, Level = EventLevel.LogAlways)]
         internal void Message(LogLevel Level, int FactoryID, string LoggerName, string EventId, ExceptionInfo Exception, IEnumerable<KeyValuePair<string, string>> Arguments)
@@ -147,7 +145,7 @@ namespace Microsoft.Extensions.Logging.EventSource
         }
 
         /// <summary>
-        /// ActivityStart is called when ILogger.BeginScope() is called
+        /// `ActivityStart` is called when `ILogger.BeginScope()` is called
         /// </summary>
         [Event(3, Keywords = Keywords.Message | Keywords.FormattedMessage, Level = EventLevel.LogAlways, ActivityOptions = EventActivityOptions.Recursive)]
         internal void ActivityStart(int ID, int FactoryID, string LoggerName, IEnumerable<KeyValuePair<string, string>> Arguments)
@@ -202,7 +200,7 @@ namespace Microsoft.Extensions.Logging.EventSource
         }
 
         /// <summary>
-        /// Set the filtering specifcation.  null means turn off all loggers.   Empty string is turn on all providers.
+        /// Set the filtering specifcation. Use `null` to turn off all loggers. Use an empty string to turn on all providers.
         /// </summary>
         /// <param name="filterSpec"></param>
         [NonEvent]

--- a/src/Microsoft.Extensions.Logging.EventSource/LoggingEventSource.cs
+++ b/src/Microsoft.Extensions.Logging.EventSource/LoggingEventSource.cs
@@ -6,33 +6,44 @@ using System.Diagnostics.Tracing;
 namespace Microsoft.Extensions.Logging.EventSource
 {
     /// <summary>
-    /// The LoggingEventSource is the bridge form all `ILogger`-based logging to EventSource/EventListener logging.
+    /// The LoggingEventSource is the bridge form all <see cref="ILogger"/>-based logging to EventSource/EventListener logging.
     ///
-    /// You turn this logging on by enabling the EventSource called `Microsoft-Extensions-Logging`
+    /// You turn this logging on by enabling the EventSource called <c>Microsoft-Extensions-Logging</c>
     ///
     /// When you enabled the EventSource, the EventLevel you set is translated in the obvious way to the level
     /// associated with the ILogger (thus Debug = verbose, Informational = Informational ... Critical = Critical)
     ///
     /// This allows you to filter by event level in a straighforward way.
     ///
-    /// For finer control you can specify an EventSource argument called `FilterSpecs`
+    /// For finer control you can specify an EventSource argument called 'FilterSpecs'
     ///
     /// The FilterSpecs argument is a semicolon-separated list of specifications, where each specification is
     ///
+    /// <code>
     ///     SPEC =                          // empty spec, same as *
     ///          | NAME                     // Just a name the level is the default level
     ///          | NAME : LEVEL             // specifies level for a particular logger (can have a * suffix).
+    /// </code>
     ///
-    /// **NAME** is the name of a ILogger (case matters), Name can have a * which acts as a wildcard
-    /// *as a suffix*. Thus, `Net*` will match any loggers that start with the string 'Net'.
+    /// 'NAME' is the name of a ILogger (case matters), Name can have a * which acts as a wildcard
+    /// *as a suffix*. Thus, 'Net*' will match any loggers that start with the string 'Net'.
     ///
-    /// **LEVEL** is a number or a LogLevel string. 0=Trace, 1=Debug, 2=Information, 3=Warning,  4=Error, Critical=5
+    /// 'LEVEL' is a number or a LogLevel string. 
+    /// <code>
+    ///     0 = Trace
+    ///     1 = Debug
+    ///     2 = Information
+    ///     3 = Warning
+    ///     4 = Error
+    ///     5 = Critical
+    /// </code>
+    /// 
     /// This specifies the level for the associated pattern. If the number is not specified, (first form
     /// of the specification) it is the default level for the EventSource.
     ///
     /// First match is used if a particular name matches more than one pattern.
     ///
-    /// In addition the level and `FilterSpec` argument, you can also set `EventSource` Keywords.  See the Keywords
+    /// In addition the level and 'FilterSpec' argument, you can also set 'EventSource' Keywords. See the Keywords
     /// definition below, but basically you get to decide if you wish to have:
     ///
     ///   * Keywords.Message - You get the event with the data in parsed form.
@@ -42,11 +53,12 @@ namespace Microsoft.Extensions.Logging.EventSource
     /// It is expected that you will turn only one of these keywords on at a time, but you can turn them all on (and get
     /// the same data logged three different ways.
     ///
+    /// <example>
     /// Example Usage
     ///
-    /// This example shows how to use an `EventListener` to get `ILogging` information
+    /// This example shows how to use an EventListener to get ILogging information
     ///
-    /// ```csharp
+    /// <code>
     /// class MyEventListener : EventListener {
     ///     protected override void OnEventSourceCreated(EventSource eventSource) {
     ///         if (eventSource.Name == "Microsoft-Extensions-Logging") {
@@ -64,7 +76,8 @@ namespace Microsoft.Extensions.Logging.EventSource
     ///             Console.WriteLine("Logger {0}: {1}", eventData.Payload[2], eventData.Payload[4]);
     ///     }
     /// }
-    /// ```
+    /// </code>
+    /// </example>
     /// </summary>
     [EventSource(Name = "Microsoft-Extensions-Logging")]
     internal class LoggingEventSource : System.Diagnostics.Tracing.EventSource


### PR DESCRIPTION
Very minor revisions for clarity. No code change.