### PR TITLE
Use TryAddEnumerable to prevernt adding logger provider multiple times

### DIFF
--- a/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesLoggerFactoryExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging.AzureAppServices;
 using Microsoft.Extensions.Logging.AzureAppServices.Internal;
 using Microsoft.Extensions.Options;
@@ -29,25 +30,25 @@ namespace Microsoft.Extensions.Logging
 
             var config = SiteConfigurationProvider.GetAzureLoggingConfiguration(context);
 
-            builder.Services.AddSingleton<IConfigureOptions<LoggerFilterOptions>>(CreateFileFilterConfigureOptions(config));
-            builder.Services.AddSingleton<IConfigureOptions<LoggerFilterOptions>>(CreateBlobFilterConfigureOptions(config));
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<LoggerFilterOptions>>(CreateFileFilterConfigureOptions(config)));
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<LoggerFilterOptions>>(CreateBlobFilterConfigureOptions(config)));
 
-            builder.Services.AddSingleton<IOptionsChangeTokenSource<LoggerFilterOptions>>(
-                new ConfigurationChangeTokenSource<LoggerFilterOptions>(config));
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IOptionsChangeTokenSource<LoggerFilterOptions>>(
+                    new ConfigurationChangeTokenSource<LoggerFilterOptions>(config)));
 
-            builder.Services.AddSingleton<IConfigureOptions<AzureBlobLoggerOptions>>(new BlobLoggerConfigureOptions(config, context));
-            builder.Services.AddSingleton<IOptionsChangeTokenSource<AzureBlobLoggerOptions>>(
-                new ConfigurationChangeTokenSource<AzureBlobLoggerOptions>(config));
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<AzureBlobLoggerOptions>>(new BlobLoggerConfigureOptions(config, context)));
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IOptionsChangeTokenSource<AzureBlobLoggerOptions>>(
+                new ConfigurationChangeTokenSource<AzureBlobLoggerOptions>(config)));
 
-            builder.Services.AddSingleton<IConfigureOptions<AzureFileLoggerOptions>>(new FileLoggerConfigureOptions(config, context));
-            builder.Services.AddSingleton<IOptionsChangeTokenSource<AzureFileLoggerOptions>>(
-                new ConfigurationChangeTokenSource<AzureFileLoggerOptions>(config));
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<AzureFileLoggerOptions>>(new FileLoggerConfigureOptions(config, context)));
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IOptionsChangeTokenSource<AzureFileLoggerOptions>>(
+                new ConfigurationChangeTokenSource<AzureFileLoggerOptions>(config)));
 
-            builder.Services.AddSingleton<IWebAppContext>(context);
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebAppContext>(context));
 
             // Only add the provider if we're in Azure WebApp. That cannot change once the apps started
-            builder.Services.AddSingleton<ILoggerProvider, FileLoggerProvider>();
-            builder.Services.AddSingleton<ILoggerProvider, BlobLoggerProvider>();
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, FileLoggerProvider>());
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, BlobLoggerProvider>());
 
             return builder;
         }

--- a/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesLoggerFactoryExtensions.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging.AzureAppServices;
 using Microsoft.Extensions.Logging.AzureAppServices.Internal;
 using Microsoft.Extensions.Options;
+using static Microsoft.Extensions.DependencyInjection.ServiceDescriptor;
 
 namespace Microsoft.Extensions.Logging
 {
@@ -29,26 +28,28 @@ namespace Microsoft.Extensions.Logging
             }
 
             var config = SiteConfigurationProvider.GetAzureLoggingConfiguration(context);
+            var services = builder.Services;
 
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<LoggerFilterOptions>>(CreateFileFilterConfigureOptions(config)));
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<LoggerFilterOptions>>(CreateBlobFilterConfigureOptions(config)));
+            services.TryAddEnumerable(Singleton<IConfigureOptions<LoggerFilterOptions>>(CreateFileFilterConfigureOptions(config)));
+            services.TryAddEnumerable(Singleton<IConfigureOptions<LoggerFilterOptions>>(CreateBlobFilterConfigureOptions(config)));
 
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IOptionsChangeTokenSource<LoggerFilterOptions>>(
+            services.TryAddEnumerable(Singleton<IOptionsChangeTokenSource<LoggerFilterOptions>>(
                     new ConfigurationChangeTokenSource<LoggerFilterOptions>(config)));
 
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<AzureBlobLoggerOptions>>(new BlobLoggerConfigureOptions(config, context)));
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IOptionsChangeTokenSource<AzureBlobLoggerOptions>>(
+            services.TryAddEnumerable(Singleton<IConfigureOptions<AzureBlobLoggerOptions>>(
+                new BlobLoggerConfigureOptions(config, context)));
+            services.TryAddEnumerable(Singleton<IOptionsChangeTokenSource<AzureBlobLoggerOptions>>(
                 new ConfigurationChangeTokenSource<AzureBlobLoggerOptions>(config)));
 
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<AzureFileLoggerOptions>>(new FileLoggerConfigureOptions(config, context)));
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IOptionsChangeTokenSource<AzureFileLoggerOptions>>(
+            services.TryAddEnumerable(Singleton<IConfigureOptions<AzureFileLoggerOptions>>(new FileLoggerConfigureOptions(config, context)));
+            services.TryAddEnumerable(Singleton<IOptionsChangeTokenSource<AzureFileLoggerOptions>>(
                 new ConfigurationChangeTokenSource<AzureFileLoggerOptions>(config)));
 
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebAppContext>(context));
+            services.TryAddEnumerable(Singleton<IWebAppContext>(context));
 
             // Only add the provider if we're in Azure WebApp. That cannot change once the apps started
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, FileLoggerProvider>());
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, BlobLoggerProvider>());
+            services.TryAddEnumerable(Singleton<ILoggerProvider, FileLoggerProvider>());
+            services.TryAddEnumerable(Singleton<ILoggerProvider, BlobLoggerProvider>());
 
             return builder;
         }

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerFactoryExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Options;
@@ -20,9 +21,9 @@ namespace Microsoft.Extensions.Logging
         {
             builder.AddConfiguration();
 
-            builder.Services.AddSingleton<ILoggerProvider, ConsoleLoggerProvider>();
-            builder.Services.AddSingleton<IConfigureOptions<ConsoleLoggerOptions>, ConsoleLoggerOptionsSetup>();
-            builder.Services.AddSingleton<IOptionsChangeTokenSource<ConsoleLoggerOptions>, LoggerProviderOptionsChangeTokenSource<ConsoleLoggerOptions, ConsoleLoggerProvider>>();
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, ConsoleLoggerProvider>());
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<ConsoleLoggerOptions>, ConsoleLoggerOptionsSetup>());
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IOptionsChangeTokenSource<ConsoleLoggerOptions>, LoggerProviderOptionsChangeTokenSource<ConsoleLoggerOptions, ConsoleLoggerProvider>>());
             return builder;
         }
 

--- a/src/Microsoft.Extensions.Logging.Debug/DebugLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Debug/DebugLoggerFactoryExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging.Debug;
 
 namespace Microsoft.Extensions.Logging
@@ -18,7 +19,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="builder">The extension method argument.</param>
         public static ILoggingBuilder AddDebug(this ILoggingBuilder builder)
         {
-            builder.Services.AddSingleton<ILoggerProvider, DebugLoggerProvider>();
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, DebugLoggerProvider>());
 
             return builder;
         }

--- a/src/Microsoft.Extensions.Logging.EventLog/EventLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/EventLoggerFactoryExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging.EventLog;
 
 namespace Microsoft.Extensions.Logging
@@ -23,7 +24,7 @@ namespace Microsoft.Extensions.Logging
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            builder.Services.AddSingleton<ILoggerProvider, EventLogLoggerProvider>();
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, EventLogLoggerProvider>());
 
             return builder;
         }
@@ -45,7 +46,7 @@ namespace Microsoft.Extensions.Logging
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            builder.Services.AddSingleton<ILoggerProvider>(new EventLogLoggerProvider(settings));
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider>(new EventLogLoggerProvider(settings)));
 
             return builder;
         }

--- a/src/Microsoft.Extensions.Logging.EventSource/EventSourceLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.EventSource/EventSourceLoggerFactoryExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging.EventSource;
 
 namespace Microsoft.Extensions.Logging
@@ -24,7 +25,7 @@ namespace Microsoft.Extensions.Logging
             }
 
             var loggerProvider = LoggingEventSource.Instance.CreateLoggerProvider();
-            builder.Services.AddSingleton<ILoggerProvider>(loggerProvider);
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider>(loggerProvider));
 
             return builder;
         }

--- a/src/Microsoft.Extensions.Logging.Testing/XunitLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/XunitLoggerFactoryExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit.Abstractions;
 
@@ -12,13 +13,13 @@ namespace Microsoft.Extensions.Logging
     {
         public static ILoggingBuilder AddXunit(this ILoggingBuilder builder, ITestOutputHelper output)
         {
-            builder.Services.AddSingleton<ILoggerProvider>(new XunitLoggerProvider(output));
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider>(new XunitLoggerProvider(output)));
             return builder;
         }
 
         public static ILoggingBuilder AddXunit(this ILoggingBuilder builder, ITestOutputHelper output, LogLevel minLevel)
         {
-            builder.Services.AddSingleton<ILoggerProvider>(new XunitLoggerProvider(output, minLevel));
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider>(new XunitLoggerProvider(output, minLevel)));
             return builder;
         }
 

--- a/src/Microsoft.Extensions.Logging.Testing/XunitLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/XunitLoggerFactoryExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit.Abstractions;
 
@@ -13,13 +12,13 @@ namespace Microsoft.Extensions.Logging
     {
         public static ILoggingBuilder AddXunit(this ILoggingBuilder builder, ITestOutputHelper output)
         {
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider>(new XunitLoggerProvider(output)));
+            builder.Services.AddSingleton<ILoggerProvider>(new XunitLoggerProvider(output));
             return builder;
         }
 
         public static ILoggingBuilder AddXunit(this ILoggingBuilder builder, ITestOutputHelper output, LogLevel minLevel)
         {
-            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider>(new XunitLoggerProvider(output, minLevel)));
+            builder.Services.AddSingleton<ILoggerProvider>(new XunitLoggerProvider(output, minLevel));
             return builder;
         }
 

--- a/test/Microsoft.Extensions.Logging.Analyzer.Test/DiagnosticVerifier.cs
+++ b/test/Microsoft.Extensions.Logging.Analyzer.Test/DiagnosticVerifier.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Extensions.Logging.Analyzer.Test
         /// Given classes in the form of strings, their language, and an IDiagnosticAnalyzer to apply to it, return the diagnostics found in the string after converting it to a document.
         /// </summary>
         /// <param name="sources">Classes in the form of strings</param>
-        /// <param name="language">The language the source classes are in</param>
         /// <param name="analyzer">The analyzer to be run on the sources</param>
         /// <returns>An IEnumerable of Diagnostics that surfaced in the source code, sorted by Location</returns>
         protected static Diagnostic[] GetSortedDiagnostics(string[] sources, DiagnosticAnalyzer analyzer)
@@ -96,7 +95,6 @@ namespace Microsoft.Extensions.Logging.Analyzer.Test
         /// Given an array of strings as sources and a language, turn them into a project and return the documents and spans of it.
         /// </summary>
         /// <param name="sources">Classes in the form of strings</param>
-        /// <param name="language">The language the source code is in</param>
         /// <returns>A Tuple containing the Documents produced from the sources and their TextSpans if relevant</returns>
         private static Document[] GetDocuments(string[] sources)
         {

--- a/test/Microsoft.Extensions.Logging.AzureAppServices.Test/LoggerBuilderExtensionsTests.cs
+++ b/test/Microsoft.Extensions.Logging.AzureAppServices.Test/LoggerBuilderExtensionsTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Extensions.Logging.AzureAppServices.Test
+{
+    public class LoggerBuilderExtensionsTests
+{
+        [Fact]
+        public void BuilderExtensionAddsSingleSetOfServicesWhenCalledTwice()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddLogging(builder => builder.AddAzureWebAppDiagnostics());
+            var count = serviceCollection.Count;
+            serviceCollection.AddLogging(builder => builder.AddAzureWebAppDiagnostics());
+
+            Assert.Equal(count, serviceCollection.Count);
+        }
+    }
+}

--- a/test/Microsoft.Extensions.Logging.AzureAppServices.Test/Microsoft.Extensions.Logging.AzureAppServices.Test.csproj
+++ b/test/Microsoft.Extensions.Logging.AzureAppServices.Test/Microsoft.Extensions.Logging.AzureAppServices.Test.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Extensions.Logging.AzureAppServices\Microsoft.Extensions.Logging.AzureAppServices.csproj" />
   </ItemGroup>
 

--- a/test/Microsoft.Extensions.Logging.EventSource.Test/AzureAppServicesLoggerFactoryExtensionsTests.cs
+++ b/test/Microsoft.Extensions.Logging.EventSource.Test/AzureAppServicesLoggerFactoryExtensionsTests.cs
@@ -1,0 +1,22 @@
+﻿// // Copyright (c) .NET Foundation. All rights reserved.
+// // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Extensions.Logging.AzureAppServices.Test
+{
+    public class LoggerFactoryExtensionsTests
+{
+        [Fact]
+        public void BuilderExtensionAddsSingleSetOfServicesWhenCalledTwice()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddLogging(builder => builder.AddEventSourceLogger());
+            var count = serviceCollection.Count;
+            serviceCollection.AddLogging(builder => builder.AddEventSourceLogger());
+
+            Assert.Equal(count, serviceCollection.Count);
+        }
+    }
+}

--- a/test/Microsoft.Extensions.Logging.Test/LoggerBuilderExtensionsTests.cs
+++ b/test/Microsoft.Extensions.Logging.Test/LoggerBuilderExtensionsTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Extensions.Logging.Test
+{
+    public class LoggerBuilderExtensionsTests
+    {
+        [Fact]
+        public void AddConsole_BuilderExtensionAddsSingleSetOfServicesWhenCalledTwice()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddLogging(builder => builder.AddConsole());
+            var count = serviceCollection.Count;
+            serviceCollection.AddLogging(builder => builder.AddConsole());
+
+            Assert.Equal(count, serviceCollection.Count);
+        }
+
+        [Fact]
+        public void AddDebug_BuilderExtensionAddsSingleSetOfServicesWhenCalledTwice()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddLogging(builder => builder.AddDebug());
+            var count = serviceCollection.Count;
+            serviceCollection.AddLogging(builder => builder.AddDebug());
+
+            Assert.Equal(count, serviceCollection.Count);
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/aspnet/MetaPackages/issues/162

To prevent duplicated logs if people call `builder.Add*` multiple times

