### PR TITLE
Fix config loading to be case insensitive

### DIFF
--- a/src/Microsoft.Extensions.Logging.Configuration/LoggerFilterConfigureOptions.cs
+++ b/src/Microsoft.Extensions.Logging.Configuration/LoggerFilterConfigureOptions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.Logging
 {
     internal class LoggerFilterConfigureOptions : IConfigureOptions<LoggerFilterOptions>
     {
+        private const string LOGLEVEL_KEY = "LogLevel";
         private readonly IConfiguration _configuration;
 
         public LoggerFilterConfigureOptions(IConfiguration configuration)
@@ -27,18 +28,17 @@ namespace Microsoft.Extensions.Logging
             {
                 return;
             }
-            
-            const string logLevelKey = "LogLevel";            
+
             foreach (var configurationSection in _configuration.GetChildren())
             {
-                if (configurationSection.Key.Equals(logLevelKey, StringComparison.OrdinalIgnoreCase))
+                if (configurationSection.Key.Equals(LOGLEVEL_KEY, StringComparison.OrdinalIgnoreCase))
                 {
                     // Load global category defaults
                     LoadRules(options, configurationSection, null);
                 }
                 else
                 {
-                    var logLevelSection = configurationSection.GetSection(logLevelKey);
+                    var logLevelSection = configurationSection.GetSection(LOGLEVEL_KEY);
                     if (logLevelSection != null)
                     {
                         // Load logger specific rules

--- a/src/Microsoft.Extensions.Logging.Configuration/LoggerFilterConfigureOptions.cs
+++ b/src/Microsoft.Extensions.Logging.Configuration/LoggerFilterConfigureOptions.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Extensions.Logging
     internal class LoggerFilterConfigureOptions : IConfigureOptions<LoggerFilterOptions>
     {
         private const string LOGLEVEL_KEY = "LogLevel";
+        private const string DEFAULT_CATEGORY = "Default";
         private readonly IConfiguration _configuration;
 
         public LoggerFilterConfigureOptions(IConfiguration configuration)
@@ -56,7 +57,7 @@ namespace Microsoft.Extensions.Logging
                 if (TryGetSwitch(section.Value, out var level))
                 {
                     var category = section.Key;
-                    if (category.Equals("Default", StringComparison.OrdinalIgnoreCase))
+                    if (category.Equals(DEFAULT_CATEGORY, StringComparison.OrdinalIgnoreCase))
                     {
                         category = null;
                     }

--- a/src/Microsoft.Extensions.Logging.Configuration/LoggerFilterConfigureOptions.cs
+++ b/src/Microsoft.Extensions.Logging.Configuration/LoggerFilterConfigureOptions.cs
@@ -27,17 +27,18 @@ namespace Microsoft.Extensions.Logging
             {
                 return;
             }
-
+            
+            const string logLevelKey = "LogLevel";            
             foreach (var configurationSection in _configuration.GetChildren())
             {
-                if (configurationSection.Key == "LogLevel")
+                if (configurationSection.Key.Equals(logLevelKey, StringComparison.OrdinalIgnoreCase))
                 {
                     // Load global category defaults
                     LoadRules(options, configurationSection, null);
                 }
                 else
                 {
-                    var logLevelSection = configurationSection.GetSection("LogLevel");
+                    var logLevelSection = configurationSection.GetSection(logLevelKey);
                     if (logLevelSection != null)
                     {
                         // Load logger specific rules
@@ -55,7 +56,7 @@ namespace Microsoft.Extensions.Logging
                 if (TryGetSwitch(section.Value, out var level))
                 {
                     var category = section.Key;
-                    if (category == "Default")
+                    if (category.Equals("Default", StringComparison.OrdinalIgnoreCase))
                     {
                         category = null;
                     }

--- a/src/Microsoft.Extensions.Logging.Configuration/LoggerFilterConfigureOptions.cs
+++ b/src/Microsoft.Extensions.Logging.Configuration/LoggerFilterConfigureOptions.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Extensions.Logging
 {
     internal class LoggerFilterConfigureOptions : IConfigureOptions<LoggerFilterOptions>
     {
-        private const string LOGLEVEL_KEY = "LogLevel";
-        private const string DEFAULT_CATEGORY = "Default";
+        private const string LogLevelKey = "LogLevel";
+        private const string DefaultCategory = "Default";
         private readonly IConfiguration _configuration;
 
         public LoggerFilterConfigureOptions(IConfiguration configuration)
@@ -32,14 +32,14 @@ namespace Microsoft.Extensions.Logging
 
             foreach (var configurationSection in _configuration.GetChildren())
             {
-                if (configurationSection.Key.Equals(LOGLEVEL_KEY, StringComparison.OrdinalIgnoreCase))
+                if (configurationSection.Key.Equals(LogLevelKey, StringComparison.OrdinalIgnoreCase))
                 {
                     // Load global category defaults
                     LoadRules(options, configurationSection, null);
                 }
                 else
                 {
-                    var logLevelSection = configurationSection.GetSection(LOGLEVEL_KEY);
+                    var logLevelSection = configurationSection.GetSection(LogLevelKey);
                     if (logLevelSection != null)
                     {
                         // Load logger specific rules
@@ -57,7 +57,7 @@ namespace Microsoft.Extensions.Logging
                 if (TryGetSwitch(section.Value, out var level))
                 {
                     var category = section.Key;
-                    if (category.Equals(DEFAULT_CATEGORY, StringComparison.OrdinalIgnoreCase))
+                    if (category.Equals(DefaultCategory, StringComparison.OrdinalIgnoreCase))
                     {
                         category = null;
                     }

--- a/test/Microsoft.Extensions.Logging.Test/LoggerFilterTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/LoggerFilterTest.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Microsoft.Extensions.Logging.Test
@@ -396,6 +398,42 @@ namespace Microsoft.Extensions.Logging.Test
             logger.LogWarning("Message");
 
             Assert.Single(writes);
+        }
+
+        [Fact]
+        public void LogLevelKeyIsCaseInsensitive()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddLogging(
+                    builder => builder.AddConfiguration(new ConfigurationBuilder()
+                                                            .AddInMemoryCollection(new[] {new KeyValuePair<string, string>("logLevel:Default", "Error")})
+                                                            .Build())
+                )
+                .BuildServiceProvider();
+            var filterOptions = new LoggerFilterOptions();
+            var options = serviceProvider.GetRequiredService<IConfigureOptions<LoggerFilterOptions>>();
+
+            options.Configure(filterOptions);
+
+            Assert.Equal(LogLevel.Error, filterOptions.Rules.Single().LogLevel);
+        }
+
+        [Fact]
+        public void DefaultCategoryIsCaseInsensitive()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddLogging(
+                    builder => builder.AddConfiguration(new ConfigurationBuilder()
+                                                            .AddInMemoryCollection(new[] {new KeyValuePair<string, string>("LogLevel:default", "Error")})
+                                                            .Build())
+                )
+                .BuildServiceProvider();
+            var filterOptions = new LoggerFilterOptions();
+            var options = serviceProvider.GetRequiredService<IConfigureOptions<LoggerFilterOptions>>();
+
+            options.Configure(filterOptions);
+
+            Assert.Null(filterOptions.Rules.Single().CategoryName);
         }
 
         [Theory]

--- a/test/Microsoft.Extensions.Logging.Test/LoggerFilterTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/LoggerFilterTest.cs
@@ -410,12 +410,10 @@ namespace Microsoft.Extensions.Logging.Test
                                                             .Build())
                 )
                 .BuildServiceProvider();
-            var filterOptions = new LoggerFilterOptions();
-            var options = serviceProvider.GetRequiredService<IConfigureOptions<LoggerFilterOptions>>();
 
-            options.Configure(filterOptions);
+            var options = serviceProvider.GetRequiredService<IOptions<LoggerFilterOptions>>();
 
-            Assert.Equal(LogLevel.Error, filterOptions.Rules.Single().LogLevel);
+            Assert.Equal(LogLevel.Error, options.Value.Rules.Single().LogLevel);
         }
 
         [Fact]
@@ -428,12 +426,10 @@ namespace Microsoft.Extensions.Logging.Test
                                                             .Build())
                 )
                 .BuildServiceProvider();
-            var filterOptions = new LoggerFilterOptions();
-            var options = serviceProvider.GetRequiredService<IConfigureOptions<LoggerFilterOptions>>();
+            
+            var options = serviceProvider.GetRequiredService<IOptions<LoggerFilterOptions>>();
 
-            options.Configure(filterOptions);
-
-            Assert.Null(filterOptions.Rules.Single().CategoryName);
+            Assert.Null(options.Value.Rules.Single().CategoryName);
         }
 
         [Theory]


### PR DESCRIPTION
Hi,

this PR files an issue with loading filter configuration. The configuration section `LogLevel` and the category name as well were read case-sensitive while the Microsoft.Extensions.Configuration is case-insensitive, which leads to an unexpected behavior.

see:
https://github.com/aspnet/Logging/blob/71e619a5599af7bdf903061ac011ed2c6f62a744/src/Microsoft.Extensions.Logging.Configuration/LoggerFilterConfigureOptions.cs#L33

https://github.com/aspnet/Logging/blob/71e619a5599af7bdf903061ac011ed2c6f62a744/src/Microsoft.Extensions.Logging.Configuration/LoggerFilterConfigureOptions.cs#L58

Cheers,
 Andy