### PR TITLE
[Logging.Testing] Drop test logging level down to Trace

### DIFF
--- a/src/Microsoft.Extensions.Logging.Testing/LoggedTest.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/LoggedTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -17,9 +17,11 @@ namespace Microsoft.Extensions.Logging.Testing
             _output = output;
         }
 
-        public IDisposable StartLog(out ILoggerFactory loggerFactory, [CallerMemberName] string testName = null)
+        public IDisposable StartLog(out ILoggerFactory loggerFactory, [CallerMemberName] string testName = null) => StartLog(out loggerFactory, LogLevel.Information, testName);
+
+        public IDisposable StartLog(out ILoggerFactory loggerFactory, LogLevel minLogLevel, [CallerMemberName] string testName = null)
         {
-            return AssemblyTestLog.ForAssembly(GetType().GetTypeInfo().Assembly).StartTestLog(_output, GetType().FullName, out loggerFactory, testName);
+            return AssemblyTestLog.ForAssembly(GetType().GetTypeInfo().Assembly).StartTestLog(_output, GetType().FullName, out loggerFactory, minLogLevel, testName);
         }
     }
 }

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
@@ -2,10 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -72,28 +74,26 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
                     }
 
                     logger.LogInformation("Finished test log in {baseDirectory}", tempDir);
+                }
 
-                    var globalLogPath = Path.Combine(tempDir, "FakeTestAssembly", "global.log");
-                    var testLog = Path.Combine(tempDir, "FakeTestAssembly", "FakeTestClass", $"FakeTestName.log");
+                var globalLogPath = Path.Combine(tempDir, "FakeTestAssembly", "global.log");
+                var testLog = Path.Combine(tempDir, "FakeTestAssembly", "FakeTestClass", $"FakeTestName.log");
 
-                    Assert.True(File.Exists(globalLogPath), $"Expected global log file {globalLogPath} to exist");
-                    Assert.True(File.Exists(testLog), $"Expected test log file {testLog} to exist");
+                Assert.True(File.Exists(globalLogPath), $"Expected global log file {globalLogPath} to exist");
+                Assert.True(File.Exists(testLog), $"Expected test log file {testLog} to exist");
 
-                    var globalLogContent = MakeConsistent(File.ReadAllText(globalLogPath));
-                    logger.LogInformation($"Global Log Content:{Environment.NewLine}{{content}}", globalLogContent);
-                    var testLogContent = MakeConsistent(File.ReadAllText(testLog));
-                    logger.LogInformation($"Test Log Content:{Environment.NewLine}{{content}}", testLogContent);
+                var globalLogContent = MakeConsistent(File.ReadAllText(globalLogPath));
+                var testLogContent = MakeConsistent(File.ReadAllText(testLog));
 
-                    Assert.Equal(@"[GlobalTestLog] [Information] Global Test Logging initialized. Set the 'ASPNETCORE_TEST_LOG_DIR' Environment Variable in order to create log files on disk.
+                Assert.Equal(@"[GlobalTestLog] [Information] Global Test Logging initialized. Set the 'ASPNETCORE_TEST_LOG_DIR' Environment Variable in order to create log files on disk.
 [GlobalTestLog] [Information] Starting test ""FakeTestName""
 [GlobalTestLog] [Information] Finished test ""FakeTestName"" in DURATION
 ", globalLogContent, ignoreLineEndingDifferences: true);
-                    Assert.Equal(@"[TestLifetime] [Information] Starting test ""FakeTestName""
+                Assert.Equal(@"[TestLifetime] [Information] Starting test ""FakeTestName""
 [TestLogger] [Information] Information!
-[TestLogger] [Trace] Trace!
+[TestLogger] [Verbose] Trace!
 [TestLifetime] [Information] Finished test ""FakeTestName"" in DURATION
 ", testLogContent, ignoreLineEndingDifferences: true);
-                }
             }
             finally
             {

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -39,12 +37,13 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
             {
                 var logger = loggerFactory.CreateLogger("TestLogger");
                 logger.LogInformation("Information!");
+
+                // Trace is disabled by default
                 logger.LogTrace("Trace!");
             }
 
             Assert.Equal(@"| TestLifetime Information: Starting test TestLogWritesToITestOutputHelper
 | TestLogger Information: Information!
-| TestLogger Trace: Trace!
 | TestLifetime Information: Finished test TestLogWritesToITestOutputHelper in DURATION
 ", MakeConsistent(output.Output), ignoreLineEndingDifferences: true);
         }
@@ -65,7 +64,7 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
                     {
                         logger.LogInformation("Created test log in {baseDirectory}", tempDir);
 
-                        using (testAssemblyLog.StartTestLog(output: null, className: "FakeTestAssembly.FakeTestClass", loggerFactory: out var testLoggerFactory, testName: "FakeTestName"))
+                        using (testAssemblyLog.StartTestLog(output: null, className: "FakeTestAssembly.FakeTestClass", loggerFactory: out var testLoggerFactory, minLogLevel: LogLevel.Trace, testName: "FakeTestName"))
                         {
                             var testLogger = testLoggerFactory.CreateLogger("TestLogger");
                             testLogger.LogInformation("Information!");


### PR DESCRIPTION
Also, the tests were leaving directories and files around in Temp. That ended up requiring some changes to how objects are disposed because they were keeping the test files locked.