### PR TITLE
Split test log out directory by framework the test ran under

### DIFF
--- a/src/Microsoft.Extensions.Logging.Testing/AssemblyTestLog.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/AssemblyTestLog.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Extensions.Logging.Testing
             SerilogLoggerProvider serilogLoggerProvider = null;
             if (!string.IsNullOrEmpty(_baseDirectory))
             {
-                var testOutputFile = Path.Combine(_baseDirectory, _assemblyName, RuntimeInformation.FrameworkDescription, className, $"{testName}.log");
+                var testOutputFile = Path.Combine(_baseDirectory, _assemblyName, RuntimeInformation.FrameworkDescription.TrimStart('.'), className, $"{testName}.log");
 
                 serilogLoggerProvider = ConfigureFileLogging(testOutputFile);
             }
@@ -114,7 +114,7 @@ namespace Microsoft.Extensions.Logging.Testing
             SerilogLoggerProvider serilogLoggerProvider = null;
             if (!string.IsNullOrEmpty(baseDirectory))
             {
-                var globalLogFileName = Path.Combine(baseDirectory, assemblyName, RuntimeInformation.FrameworkDescription, "global.log");
+                var globalLogFileName = Path.Combine(baseDirectory, assemblyName, RuntimeInformation.FrameworkDescription.TrimStart('.'), "global.log");
                 serilogLoggerProvider = ConfigureFileLogging(globalLogFileName);
             }
 

--- a/src/Microsoft.Extensions.Logging.Testing/AssemblyTestLog.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/AssemblyTestLog.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 using Serilog.Extensions.Logging;
@@ -83,7 +84,7 @@ namespace Microsoft.Extensions.Logging.Testing
             SerilogLoggerProvider serilogLoggerProvider = null;
             if (!string.IsNullOrEmpty(_baseDirectory))
             {
-                var testOutputFile = Path.Combine(_baseDirectory, _assemblyName, className, $"{testName}.log");
+                var testOutputFile = Path.Combine(_baseDirectory, _assemblyName, RuntimeInformation.FrameworkDescription, className, $"{testName}.log");
 
                 serilogLoggerProvider = ConfigureFileLogging(testOutputFile);
             }
@@ -113,7 +114,7 @@ namespace Microsoft.Extensions.Logging.Testing
             SerilogLoggerProvider serilogLoggerProvider = null;
             if (!string.IsNullOrEmpty(baseDirectory))
             {
-                var globalLogFileName = Path.Combine(baseDirectory, assemblyName, "global.log");
+                var globalLogFileName = Path.Combine(baseDirectory, assemblyName, RuntimeInformation.FrameworkDescription, "global.log");
                 serilogLoggerProvider = ConfigureFileLogging(globalLogFileName);
             }
 

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
@@ -76,8 +76,8 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
                     logger.LogInformation("Finished test log in {baseDirectory}", tempDir);
                 }
 
-                var globalLogPath = Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription, "global.log");
-                var testLog = Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription, "FakeTestClass", $"FakeTestName.log");
+                var globalLogPath = Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription.TrimStart('.'), "global.log");
+                var testLog = Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription.TrimStart('.'), "FakeTestClass", $"FakeTestName.log");
 
                 Assert.True(File.Exists(globalLogPath), $"Expected global log file {globalLogPath} to exist");
                 Assert.True(File.Exists(testLog), $"Expected test log file {testLog} to exist");

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Xunit;
 using Xunit.Abstractions;
@@ -75,8 +76,8 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
                     logger.LogInformation("Finished test log in {baseDirectory}", tempDir);
                 }
 
-                var globalLogPath = Path.Combine(tempDir, "FakeTestAssembly", "global.log");
-                var testLog = Path.Combine(tempDir, "FakeTestAssembly", "FakeTestClass", $"FakeTestName.log");
+                var globalLogPath = Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription, "global.log");
+                var testLog = Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription, "FakeTestClass", $"FakeTestName.log");
 
                 Assert.True(File.Exists(globalLogPath), $"Expected global log file {globalLogPath} to exist");
                 Assert.True(File.Exists(testLog), $"Expected test log file {testLog} to exist");


### PR DESCRIPTION
`NET Core 4.6.26020.03` for 2.0
`NET Core 4.6.26130.05` for 2.1
`NET Framework 4.7.2117.0` for Full Framework