### PR TITLE
Alter the dependency of Console to Abstractions rather than Microsoft.Extensions.Logging

### DIFF
--- a/src/Microsoft.Extensions.Logging.Console/Microsoft.Extensions.Logging.Console.csproj
+++ b/src/Microsoft.Extensions.Logging.Console/Microsoft.Extensions.Logging.Console.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.Extensions.Logging\Microsoft.Extensions.Logging.csproj" />
+    <ProjectReference Include="..\Microsoft.Extensions.Logging.Abstractions\Microsoft.Extensions.Logging.Abstractions.csproj" />
     <ProjectReference Include="..\Microsoft.Extensions.Logging.Configuration\Microsoft.Extensions.Logging.Configuration.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Currently, `Microsoft.Extensions.Logging.Console` depends on `Microsoft.Extensions.Logging` - but this is unecessary, as only interfaces from `Microsoft.Extensions.Logging.Abstractions` are actually used. This will reduce the referenced assemblies by approximately 2 MB (`System.Linq.Expressions` alone is 1.4 MB alone, and isn't needed if you don't need `Microsoft.Extensions.Logging`)

I've tried altering the other sink implementations, but they depend on stuff from Logging directly, such as `ILoggingBuilder`.