### PR TITLE
Update for when log message is an empty string

### DIFF
--- a/src/Microsoft.Extensions.Logging.Testing/XunitLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/XunitLoggerProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Extensions.Logging.Testing
 
             var firstLinePrefix = $"| {_category} {logLevel}: ";
             var lines = formatter(state, exception).Split(NewLineChars, StringSplitOptions.RemoveEmptyEntries);
-            messageBuilder.AppendLine(firstLinePrefix + lines.First());
+            messageBuilder.AppendLine(firstLinePrefix + lines.FirstOrDefault() ?? string.Empty);
 
             var additionalLinePrefix = "|" + new string(' ', firstLinePrefix.Length - 1);
             foreach (var line in lines.Skip(1))


### PR DESCRIPTION
If logging an empty string, e.g. "", this fails to get lines.First().
This fix worked for my copy of this code.