### PR TITLE
Mark Logging.Abstractions as CLSCompliant

### DIFF
--- a/src/Microsoft.Extensions.Logging.Abstractions/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/Properties/AssemblyInfo.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Runtime.CompilerServices;
+
+[assembly: CLSCompliant(true)]
 
 [assembly: InternalsVisibleTo("Microsoft.Extensions.Logging.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]


### PR DESCRIPTION
Only change is to mark Logging.Abstractions assembly as CLSCompliant.

Background:
We have some .NET Framework projects that we want to port to .NET Standard. All these projects are marked as CLSCompliant. So this change would help a lot to make a step-by-step migration much easier.

This resolve issue #500 