### PR TITLE
Expand log level extension

### DIFF
--- a/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs
@@ -28,12 +28,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogDebug(0, exception, "Error while processing request from {Address}", address)</example>
         public static void LogDebug(this ILogger logger, EventId eventId, Exception exception, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Debug, eventId, new FormattedLogValues(message, args), exception, _messageFormatter);
+            logger.Log(LogLevel.Debug, eventId, exception, message, args);
         }
 
         /// <summary>
@@ -46,12 +41,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogDebug(0, "Processing request from {Address}", address)</example>
         public static void LogDebug(this ILogger logger, EventId eventId, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Debug, eventId, new FormattedLogValues(message, args), null, _messageFormatter);
+            logger.Log(LogLevel.Debug, eventId, message, args);
         }
 
         /// <summary>
@@ -64,12 +54,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogDebug(exception, "Error while processing request from {Address}", address)</example>
         public static void LogDebug(this ILogger logger, Exception exception, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Debug, 0, new FormattedLogValues(message, args), exception, _messageFormatter);
+            logger.Log(LogLevel.Debug, exception, message, args);
         }
 
         /// <summary>
@@ -81,12 +66,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogDebug("Processing request from {Address}", address)</example>
         public static void LogDebug(this ILogger logger, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Debug, 0, new FormattedLogValues(message, args), null, _messageFormatter);
+            logger.Log(LogLevel.Debug, message, args);
         }
 
         //------------------------------------------TRACE------------------------------------------//
@@ -102,12 +82,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogTrace(0, exception, "Error while processing request from {Address}", address)</example>
         public static void LogTrace(this ILogger logger, EventId eventId, Exception exception, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Trace, eventId, new FormattedLogValues(message, args), exception, _messageFormatter);
+            logger.Log(LogLevel.Trace, eventId, exception, message, args);
         }
 
         /// <summary>
@@ -120,12 +95,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogTrace(0, "Processing request from {Address}", address)</example>
         public static void LogTrace(this ILogger logger, EventId eventId, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Trace, eventId, new FormattedLogValues(message, args), null, _messageFormatter);
+            logger.Log(LogLevel.Trace, eventId, message, args);
         }
 
         /// <summary>
@@ -138,12 +108,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogTrace(exception, "Error while processing request from {Address}", address)</example>
         public static void LogTrace(this ILogger logger, Exception exception, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Trace, 0, new FormattedLogValues(message, args), exception, _messageFormatter);
+            logger.Log(LogLevel.Trace, exception, message, args);
         }
 
         /// <summary>
@@ -155,12 +120,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogTrace("Processing request from {Address}", address)</example>
         public static void LogTrace(this ILogger logger, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Trace, 0, new FormattedLogValues(message, args), null, _messageFormatter);
+            logger.Log(LogLevel.Trace, message, args);
         }
 
         //------------------------------------------INFORMATION------------------------------------------//
@@ -176,12 +136,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogInformation(0, exception, "Error while processing request from {Address}", address)</example>
         public static void LogInformation(this ILogger logger, EventId eventId, Exception exception, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Information, eventId, new FormattedLogValues(message, args), exception, _messageFormatter);
+            logger.Log(LogLevel.Information, eventId, exception, message, args);
         }
 
         /// <summary>
@@ -194,12 +149,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogInformation(0, "Processing request from {Address}", address)</example>
         public static void LogInformation(this ILogger logger, EventId eventId, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Information, eventId, new FormattedLogValues(message, args), null, _messageFormatter);
+            logger.Log(LogLevel.Information, eventId, message, args);
         }
 
         /// <summary>
@@ -212,12 +162,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogInformation(exception, "Error while processing request from {Address}", address)</example>
         public static void LogInformation(this ILogger logger, Exception exception, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Information, 0, new FormattedLogValues(message, args), exception, _messageFormatter);
+            logger.Log(LogLevel.Information, exception, message, args);
         }
 
         /// <summary>
@@ -229,12 +174,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogInformation("Processing request from {Address}", address)</example>
         public static void LogInformation(this ILogger logger, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Information, 0, new FormattedLogValues(message, args), null, _messageFormatter);
+            logger.Log(LogLevel.Information, message, args);
         }
 
         //------------------------------------------WARNING------------------------------------------//
@@ -250,12 +190,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogWarning(0, exception, "Error while processing request from {Address}", address)</example>
         public static void LogWarning(this ILogger logger, EventId eventId, Exception exception, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Warning, eventId, new FormattedLogValues(message, args), exception, _messageFormatter);
+            logger.Log(LogLevel.Warning, eventId, exception, message, args);
         }
 
         /// <summary>
@@ -268,12 +203,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogWarning(0, "Processing request from {Address}", address)</example>
         public static void LogWarning(this ILogger logger, EventId eventId, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Warning, eventId, new FormattedLogValues(message, args), null, _messageFormatter);
+            logger.Log(LogLevel.Warning, eventId, message, args);
         }
 
         /// <summary>
@@ -286,12 +216,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogWarning(exception, "Error while processing request from {Address}", address)</example>
         public static void LogWarning(this ILogger logger, Exception exception, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Warning, 0, new FormattedLogValues(message, args), exception, _messageFormatter);
+            logger.Log(LogLevel.Warning, exception, message, args);
         }
 
         /// <summary>
@@ -303,12 +228,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogWarning("Processing request from {Address}", address)</example>
         public static void LogWarning(this ILogger logger, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Warning, 0, new FormattedLogValues(message, args), null, _messageFormatter);
+            logger.Log(LogLevel.Warning, message, args);
         }
 
         //------------------------------------------ERROR------------------------------------------//
@@ -324,12 +244,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogError(0, exception, "Error while processing request from {Address}", address)</example>
         public static void LogError(this ILogger logger, EventId eventId, Exception exception, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Error, eventId, new FormattedLogValues(message, args), exception, _messageFormatter);
+            logger.Log(LogLevel.Error, eventId, exception, message, args);
         }
 
         /// <summary>
@@ -342,12 +257,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogError(0, "Processing request from {Address}", address)</example>
         public static void LogError(this ILogger logger, EventId eventId, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Error, eventId, new FormattedLogValues(message, args), null, _messageFormatter);
+            logger.Log(LogLevel.Error, eventId, message, args);
         }
 
         /// <summary>
@@ -360,12 +270,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogError(exception, "Error while processing request from {Address}", address)</example>
         public static void LogError(this ILogger logger, Exception exception, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Error, 0, new FormattedLogValues(message, args), exception, _messageFormatter);
+            logger.Log(LogLevel.Error, exception, message, args);
         }
 
         /// <summary>
@@ -377,12 +282,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogError("Processing request from {Address}", address)</example>
         public static void LogError(this ILogger logger, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Error, 0, new FormattedLogValues(message, args), null, _messageFormatter);
+            logger.Log(LogLevel.Error, message, args);
         }
 
         //------------------------------------------CRITICAL------------------------------------------//
@@ -398,12 +298,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogCritical(0, exception, "Error while processing request from {Address}", address)</example>
         public static void LogCritical(this ILogger logger, EventId eventId, Exception exception, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Critical, eventId, new FormattedLogValues(message, args), exception, _messageFormatter);
+            logger.Log(LogLevel.Critical, eventId, exception, message, args);
         }
 
         /// <summary>
@@ -416,12 +311,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogCritical(0, "Processing request from {Address}", address)</example>
         public static void LogCritical(this ILogger logger, EventId eventId, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Critical, eventId, new FormattedLogValues(message, args), null, _messageFormatter);
+            logger.Log(LogLevel.Critical, eventId, message, args);
         }
 
         /// <summary>
@@ -434,12 +324,7 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogCritical(exception, "Error while processing request from {Address}", address)</example>
         public static void LogCritical(this ILogger logger, Exception exception, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Critical, 0, new FormattedLogValues(message, args), exception, _messageFormatter);
+            logger.Log(LogLevel.Critical, exception, message, args);
         }
 
         /// <summary>
@@ -451,17 +336,11 @@ namespace Microsoft.Extensions.Logging
         /// <example>logger.LogCritical("Processing request from {Address}", address)</example>
         public static void LogCritical(this ILogger logger, string message, params object[] args)
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            logger.Log(LogLevel.Critical, 0, new FormattedLogValues(message, args), null, _messageFormatter);
+            logger.Log(LogLevel.Critical, message, args);
         }
 
-
         /// <summary>
-        /// Formats and writes a log message on specified log level.
+        /// Formats and writes a log message at the specified log level.
         /// </summary>
         /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
         /// <param name="logLevel">Entry will be written on this level.</param>
@@ -469,12 +348,52 @@ namespace Microsoft.Extensions.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void Log(this ILogger logger, LogLevel logLevel, string message, params object[] args)
         {
+            logger.Log(logLevel, 0, null, message, args);
+        }
+
+        /// <summary>
+        /// Formats and writes a log message at the specified log level.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+        /// <param name="logLevel">Entry will be written on this level.</param>
+        /// <param name="eventId">The event id associated with the log.</param>
+        /// <param name="message">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void Log(this ILogger logger, LogLevel logLevel, EventId eventId, string message, params object[] args)
+        {
+            logger.Log(logLevel, eventId, null, message, args);
+        }
+
+        /// <summary>
+        /// Formats and writes a log message at the specified log level.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+        /// <param name="logLevel">Entry will be written on this level.</param>
+        /// <param name="exception">The exception to log.</param>
+        /// <param name="message">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void Log(this ILogger logger, LogLevel logLevel, Exception exception, string message, params object[] args)
+        {
+            logger.Log(logLevel, 0, exception, message, args);
+        }
+
+        /// <summary>
+        /// Formats and writes a log message at the specified log level.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger"/> to write to.</param>
+        /// <param name="logLevel">Entry will be written on this level.</param>
+        /// <param name="eventId">The event id associated with the log.</param>
+        /// <param name="exception">The exception to log.</param>
+        /// <param name="message">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void Log(this ILogger logger, LogLevel logLevel, EventId eventId, Exception exception, string message, params object[] args)
+        {
             if (logger == null)
             {
                 throw new ArgumentNullException(nameof(logger));
             }
 
-            logger.Log(logLevel, 0, new FormattedLogValues(message, args), null, _messageFormatter);
+            logger.Log(logLevel, eventId, new FormattedLogValues(message, args), exception, _messageFormatter);
         }
 
         //------------------------------------------Scope------------------------------------------//

--- a/test/Microsoft.Extensions.Logging.Test/LoggerExtensionsTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/LoggerExtensionsTest.cs
@@ -623,338 +623,158 @@ namespace Microsoft.Extensions.Logging.Test
                 debug.Formatter(debug.State, debug.Exception));
         }
 
-        [Fact]
-        public void LogLevel_MessageOnly_LogsCorrectValues()
+        [Theory]
+        [InlineData(LogLevel.Trace)]
+        [InlineData(LogLevel.Information)]
+        [InlineData(LogLevel.Warning)]
+        [InlineData(LogLevel.Error)]
+        [InlineData(LogLevel.Critical)]
+        [InlineData(LogLevel.Debug)]
+        public void LogLevel_MessageOnly_LogsCorrectValues(LogLevel logLevel)
         {
             // Arrange
             var sink = new TestSink();
             var logger = SetUp(sink);
 
             // Act
-            logger.Log(LogLevel.Trace, _state);
-            logger.Log(LogLevel.Information, _state);
-            logger.Log(LogLevel.Warning, _state);
-            logger.Log(LogLevel.Error, _state);
-            logger.Log(LogLevel.Critical, _state);
-            logger.Log(LogLevel.Debug, _state);
+            logger.Log(logLevel, _state);
 
             // Assert
-            Assert.Equal(6, sink.Writes.Count);
-
-            Assert.True(sink.Writes.TryTake(out var trace));
-            Assert.Equal(LogLevel.Trace, trace.LogLevel);
-            Assert.Equal(_state, trace.State.ToString());
-            Assert.Equal(0, trace.EventId);
-            Assert.Null(trace.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var information));
-            Assert.Equal(LogLevel.Information, information.LogLevel);
-            Assert.Equal(_state, information.State.ToString());
-            Assert.Equal(0, information.EventId);
-            Assert.Null(information.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var warning));
-            Assert.Equal(LogLevel.Warning, warning.LogLevel);
-            Assert.Equal(_state, warning.State.ToString());
-            Assert.Equal(0, warning.EventId);
-            Assert.Null(warning.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var error));
-            Assert.Equal(LogLevel.Error, error.LogLevel);
-            Assert.Equal(_state, error.State.ToString());
-            Assert.Equal(0, error.EventId);
-            Assert.Null(error.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var critical));
-            Assert.Equal(LogLevel.Critical, critical.LogLevel);
-            Assert.Equal(_state, critical.State.ToString());
-            Assert.Equal(0, critical.EventId);
-            Assert.Null(critical.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var debug));
-            Assert.Equal(LogLevel.Debug, debug.LogLevel);
-            Assert.Equal(_state, debug.State.ToString());
-            Assert.Equal(0, debug.EventId);
-            Assert.Null(debug.Exception);
+            Assert.True(sink.Writes.TryTake(out var write));
+            Assert.Equal(logLevel, write.LogLevel);
+            Assert.Equal(_state, write.State.ToString());
+            Assert.Equal(0, write.EventId);
+            Assert.Null(write.Exception);
         }
 
-        [Fact]
-        public void LogLevel_FormatMessage_LogsCorrectValues()
+        [Theory]
+        [InlineData(LogLevel.Trace)]
+        [InlineData(LogLevel.Information)]
+        [InlineData(LogLevel.Warning)]
+        [InlineData(LogLevel.Error)]
+        [InlineData(LogLevel.Critical)]
+        [InlineData(LogLevel.Debug)]
+        public void LogLevel_FormatMessage_LogsCorrectValues(LogLevel logLevel)
         {
             // Arrange
             var sink = new TestSink();
             var logger = SetUp(sink);
 
             // Act
-            logger.Log(LogLevel.Trace, _format, "test1", "test2");
-            logger.Log(LogLevel.Information, _format, "test1", "test2");
-            logger.Log(LogLevel.Warning, _format, "test1", "test2");
-            logger.Log(LogLevel.Error, _format, "test1", "test2");
-            logger.Log(LogLevel.Critical, _format, "test1", "test2");
-            logger.Log(LogLevel.Debug, _format, "test1", "test2");
+            logger.Log(logLevel, _format, "test1", "test2");
 
             // Assert
-            Assert.Equal(6, sink.Writes.Count);
-
-            Assert.True(sink.Writes.TryTake(out var trace));
-            Assert.Equal(LogLevel.Trace, trace.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), trace.State?.ToString());
-            Assert.Equal(0, trace.EventId);
-            Assert.Null(trace.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var information));
-            Assert.Equal(LogLevel.Information, information.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), information.State?.ToString());
-            Assert.Equal(0, information.EventId);
-            Assert.Null(information.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var warning));
-            Assert.Equal(LogLevel.Warning, warning.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), warning.State?.ToString());
-            Assert.Equal(0, warning.EventId);
-            Assert.Null(warning.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var error));
-            Assert.Equal(LogLevel.Error, error.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), error.State?.ToString());
-            Assert.Equal(0, error.EventId);
-            Assert.Null(error.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var critical));
-            Assert.Equal(LogLevel.Critical, critical.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), critical.State?.ToString());
-            Assert.Equal(0, critical.EventId);
-            Assert.Null(critical.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var debug));
-            Assert.Equal(LogLevel.Debug, debug.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), debug.State?.ToString());
-            Assert.Equal(0, debug.EventId);
-            Assert.Null(debug.Exception);
+            Assert.True(sink.Writes.TryTake(out var write));
+            Assert.Equal(logLevel, write.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), write.State?.ToString());
+            Assert.Equal(0, write.EventId);
+            Assert.Null(write.Exception);
         }
 
-        [Fact]
-        public void LogLevel_MessageAndEventId_LogsCorrectValues()
+        [Theory]
+        [InlineData(LogLevel.Trace, 1)]
+        [InlineData(LogLevel.Information, 2)]
+        [InlineData(LogLevel.Warning, 3)]
+        [InlineData(LogLevel.Error, 4)]
+        [InlineData(LogLevel.Critical, 5)]
+        [InlineData(LogLevel.Debug, 6)]
+        public void LogLevel_MessageAndEventId_LogsCorrectValues(LogLevel logLevel, int eventId)
         {
             // Arrange
             var sink = new TestSink();
             var logger = SetUp(sink);
 
             // Act
-            logger.Log(LogLevel.Trace, 1, _state);
-            logger.Log(LogLevel.Information, 2, _state);
-            logger.Log(LogLevel.Warning, 3, _state);
-            logger.Log(LogLevel.Error, 4, _state);
-            logger.Log(LogLevel.Critical, 5, _state);
-            logger.Log(LogLevel.Debug, 6, _state);
+            logger.Log(logLevel, eventId, _state);
 
             // Assert
-            Assert.Equal(6, sink.Writes.Count);
-
-            Assert.True(sink.Writes.TryTake(out var trace));
-            Assert.Equal(LogLevel.Trace, trace.LogLevel);
-            Assert.Equal(_state, trace.State.ToString());
-            Assert.Equal(1, trace.EventId);
-            Assert.Null(trace.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var information));
-            Assert.Equal(LogLevel.Information, information.LogLevel);
-            Assert.Equal(_state, information.State.ToString());
-            Assert.Equal(2, information.EventId);
-            Assert.Null(information.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var warning));
-            Assert.Equal(LogLevel.Warning, warning.LogLevel);
-            Assert.Equal(_state, warning.State.ToString());
-            Assert.Equal(3, warning.EventId);
-            Assert.Null(warning.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var error));
-            Assert.Equal(LogLevel.Error, error.LogLevel);
-            Assert.Equal(_state, error.State.ToString());
-            Assert.Equal(4, error.EventId);
-            Assert.Null(error.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var critical));
-            Assert.Equal(LogLevel.Critical, critical.LogLevel);
-            Assert.Equal(_state, critical.State.ToString());
-            Assert.Equal(5, critical.EventId);
-            Assert.Null(critical.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var debug));
-            Assert.Equal(LogLevel.Debug, debug.LogLevel);
-            Assert.Equal(_state, debug.State.ToString());
-            Assert.Equal(6, debug.EventId);
-            Assert.Null(debug.Exception);
+            Assert.True(sink.Writes.TryTake(out var write));
+            Assert.Equal(logLevel, write.LogLevel);
+            Assert.Equal(_state, write.State.ToString());
+            Assert.Equal(eventId, write.EventId);
+            Assert.Null(write.Exception);
         }
 
-        [Fact]
-        public void LogLevel_FormatMessageAndEventId_LogsCorrectValues()
+        [Theory]
+        [InlineData(LogLevel.Trace, 1)]
+        [InlineData(LogLevel.Information, 2)]
+        [InlineData(LogLevel.Warning, 3)]
+        [InlineData(LogLevel.Error, 4)]
+        [InlineData(LogLevel.Critical, 5)]
+        [InlineData(LogLevel.Debug, 6)]
+        public void LogLevel_FormatMessageAndEventId_LogsCorrectValues(LogLevel logLevel, int eventId)
         {
             // Arrange
             var sink = new TestSink();
             var logger = SetUp(sink);
 
             // Act
-            logger.Log(LogLevel.Trace, 1, _format, "test1", "test2");
-            logger.Log(LogLevel.Information, 2, _format, "test1", "test2");
-            logger.Log(LogLevel.Warning, 3, _format, "test1", "test2");
-            logger.Log(LogLevel.Error, 4, _format, "test1", "test2");
-            logger.Log(LogLevel.Critical, 5, _format, "test1", "test2");
-            logger.Log(LogLevel.Debug, 6, _format, "test1", "test2");
+            logger.Log(logLevel, eventId, _format, "test1", "test2");
 
             // Assert
-            Assert.Equal(6, sink.Writes.Count);
-
-            Assert.True(sink.Writes.TryTake(out var trace));
-            Assert.Equal(LogLevel.Trace, trace.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), trace.State?.ToString());
-            Assert.Equal(1, trace.EventId);
-            Assert.Null(trace.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var information));
-            Assert.Equal(LogLevel.Information, information.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), information.State?.ToString());
-            Assert.Equal(2, information.EventId);
-            Assert.Null(information.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var warning));
-            Assert.Equal(LogLevel.Warning, warning.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), warning.State?.ToString());
-            Assert.Equal(3, warning.EventId);
-            Assert.Null(warning.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var error));
-            Assert.Equal(LogLevel.Error, error.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), error.State?.ToString());
-            Assert.Equal(4, error.EventId);
-            Assert.Null(error.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var critical));
-            Assert.Equal(LogLevel.Critical, critical.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), critical.State?.ToString());
-            Assert.Equal(5, critical.EventId);
-            Assert.Null(critical.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var debug));
-            Assert.Equal(LogLevel.Debug, debug.LogLevel);
-            Assert.Equal(string.Format(_format, "test1", "test2"), debug.State?.ToString());
-            Assert.Equal(6, debug.EventId);
-            Assert.Null(debug.Exception);
+            Assert.True(sink.Writes.TryTake(out var write));
+            Assert.Equal(logLevel, write.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), write.State?.ToString());
+            Assert.Equal(eventId, write.EventId);
+            Assert.Null(write.Exception);
         }
 
-        [Fact]
-        public void LogLevel_MessageAndError_LogsCorrectValues()
+        [Theory]
+        [InlineData(LogLevel.Trace)]
+        [InlineData(LogLevel.Information)]
+        [InlineData(LogLevel.Warning)]
+        [InlineData(LogLevel.Error)]
+        [InlineData(LogLevel.Critical)]
+        [InlineData(LogLevel.Debug)]
+        public void LogLevel_MessageAndError_LogsCorrectValues(LogLevel logLevel)
         {
             // Arrange
             var sink = new TestSink();
             var logger = SetUp(sink);
 
             // Act
-            logger.Log(LogLevel.Trace, _exception, _state);
-            logger.Log(LogLevel.Information, _exception, _state);
-            logger.Log(LogLevel.Warning, _exception, _state);
-            logger.Log(LogLevel.Error, _exception, _state);
-            logger.Log(LogLevel.Critical, _exception, _state);
-            logger.Log(LogLevel.Debug, _exception, _state);
+            logger.Log(logLevel, _exception, _state);
 
             // Assert
-            Assert.Equal(6, sink.Writes.Count);
-
-            Assert.True(sink.Writes.TryTake(out var trace));
-            Assert.Equal(LogLevel.Trace, trace.LogLevel);
-            Assert.Equal(_state, trace.State.ToString());
-            Assert.Equal(0, trace.EventId);
-            Assert.Equal(_exception, trace.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var information));
-            Assert.Equal(LogLevel.Information, information.LogLevel);
-            Assert.Equal(_state, information.State.ToString());
-            Assert.Equal(0, information.EventId);
-            Assert.Equal(_exception, information.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var warning));
-            Assert.Equal(LogLevel.Warning, warning.LogLevel);
-            Assert.Equal(_state, warning.State.ToString());
-            Assert.Equal(0, warning.EventId);
-            Assert.Equal(_exception, warning.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var error));
-            Assert.Equal(LogLevel.Error, error.LogLevel);
-            Assert.Equal(_state, error.State.ToString());
-            Assert.Equal(0, error.EventId);
-            Assert.Equal(_exception, error.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var critical));
-            Assert.Equal(LogLevel.Critical, critical.LogLevel);
-            Assert.Equal(_state, critical.State.ToString());
-            Assert.Equal(0, critical.EventId);
-            Assert.Equal(_exception, critical.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var debug));
-            Assert.Equal(LogLevel.Debug, debug.LogLevel);
-            Assert.Equal(_state, debug.State.ToString());
-            Assert.Equal(0, debug.EventId);
-            Assert.Equal(_exception, debug.Exception);
+            Assert.True(sink.Writes.TryTake(out var write));
+            Assert.Equal(logLevel, write.LogLevel);
+            Assert.Equal(_state, write.State.ToString());
+            Assert.Equal(0, write.EventId);
+            Assert.Equal(_exception, write.Exception);
         }
 
-        [Fact]
-        public void LogLevel_MessageEventIdAndError_LogsCorrectValues()
+        [Theory]
+        [InlineData(LogLevel.Trace, 1)]
+        [InlineData(LogLevel.Information, 2)]
+        [InlineData(LogLevel.Warning, 3)]
+        [InlineData(LogLevel.Error, 4)]
+        [InlineData(LogLevel.Critical, 5)]
+        [InlineData(LogLevel.Debug, 6)]
+        public void LogLevel_MessageEventIdAndError_LogsCorrectValues(LogLevel logLevel, int eventId)
         {
             // Arrange
             var sink = new TestSink();
             var logger = SetUp(sink);
 
             // Act
-            logger.Log(LogLevel.Trace, 1, _exception, _state);
-            logger.Log(LogLevel.Information, 2, _exception, _state);
-            logger.Log(LogLevel.Warning, 3, _exception, _state);
-            logger.Log(LogLevel.Error, 4, _exception, _state);
-            logger.Log(LogLevel.Critical, 5, _exception, _state);
-            logger.Log(LogLevel.Debug, 6, _exception, _state);
+            logger.Log(logLevel, eventId, _exception, _state);
 
             // Assert
-            Assert.Equal(6, sink.Writes.Count());
-
-            Assert.True(sink.Writes.TryTake(out var trace));
-            Assert.Equal(LogLevel.Trace, trace.LogLevel);
-            Assert.Equal(_state, trace.State.ToString());
-            Assert.Equal(1, trace.EventId);
-            Assert.Equal(_exception, trace.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var information));
-            Assert.Equal(LogLevel.Information, information.LogLevel);
-            Assert.Equal(_state, information.State.ToString());
-            Assert.Equal(2, information.EventId);
-            Assert.Equal(_exception, information.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var warning));
-            Assert.Equal(LogLevel.Warning, warning.LogLevel);
-            Assert.Equal(_state, warning.State.ToString());
-            Assert.Equal(3, warning.EventId);
-            Assert.Equal(_exception, warning.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var error));
-            Assert.Equal(LogLevel.Error, error.LogLevel);
-            Assert.Equal(_state, error.State.ToString());
-            Assert.Equal(4, error.EventId);
-            Assert.Equal(_exception, error.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var critical));
-            Assert.Equal(LogLevel.Critical, critical.LogLevel);
-            Assert.Equal(_state, critical.State.ToString());
-            Assert.Equal(5, critical.EventId);
-            Assert.Equal(_exception, critical.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var debug));
-            Assert.Equal(LogLevel.Debug, debug.LogLevel);
-            Assert.Equal(_state, debug.State.ToString());
-            Assert.Equal(6, debug.EventId);
-            Assert.Equal(_exception, debug.Exception);
+            Assert.True(sink.Writes.TryTake(out var write));
+            Assert.Equal(logLevel, write.LogLevel);
+            Assert.Equal(_state, write.State.ToString());
+            Assert.Equal(eventId, write.EventId);
+            Assert.Equal(_exception, write.Exception);
         }
 
-        [Fact]
-        public void LogLevel_LogValues_LogsCorrectValues()
+        [Theory]
+        [InlineData(LogLevel.Trace)]
+        [InlineData(LogLevel.Information)]
+        [InlineData(LogLevel.Warning)]
+        [InlineData(LogLevel.Error)]
+        [InlineData(LogLevel.Critical)]
+        [InlineData(LogLevel.Debug)]
+        public void LogLevel_LogValues_LogsCorrectValues(LogLevel logLevel)
         {
             // Arrange
             var sink = new TestSink();
@@ -965,55 +785,24 @@ namespace Microsoft.Extensions.Logging.Test
             };
 
             // Act
-            logger.Log(LogLevel.Trace, 0, testLogValues.ToString());
-            logger.Log(LogLevel.Information, 0, testLogValues.ToString());
-            logger.Log(LogLevel.Warning, 0, testLogValues.ToString());
-            logger.Log(LogLevel.Error, 0, testLogValues.ToString());
-            logger.Log(LogLevel.Critical, 0, testLogValues.ToString());
-            logger.Log(LogLevel.Debug, 0, testLogValues.ToString());
+            logger.Log(logLevel, 0, testLogValues.ToString());
 
             // Assert
-            Assert.Equal(6, sink.Writes.Count());
-
-            Assert.True(sink.Writes.TryTake(out var trace));
-            Assert.Equal(LogLevel.Trace, trace.LogLevel);
-            Assert.Equal(0, trace.EventId);
-            Assert.Null(trace.Exception);
-            Assert.Equal("Test 1", trace.Formatter(trace.State, trace.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var information));
-            Assert.Equal(LogLevel.Information, information.LogLevel);
-            Assert.Equal(0, information.EventId);
-            Assert.Null(information.Exception);
-            Assert.Equal("Test 1", information.Formatter(information.State, information.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var warning));
-            Assert.Equal(LogLevel.Warning, warning.LogLevel);
-            Assert.Equal(0, warning.EventId);
-            Assert.Null(warning.Exception);
-            Assert.Equal("Test 1", warning.Formatter(warning.State, warning.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var error));
-            Assert.Equal(LogLevel.Error, error.LogLevel);
-            Assert.Equal(0, error.EventId);
-            Assert.Null(error.Exception);
-            Assert.Equal("Test 1", error.Formatter(error.State, error.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var critical));
-            Assert.Equal(LogLevel.Critical, critical.LogLevel);
-            Assert.Equal(0, critical.EventId);
-            Assert.Null(critical.Exception);
-            Assert.Equal("Test 1", critical.Formatter(critical.State, critical.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var debug));
-            Assert.Equal(LogLevel.Debug, debug.LogLevel);
-            Assert.Equal(0, debug.EventId);
-            Assert.Null(debug.Exception);
-            Assert.Equal("Test 1", debug.Formatter(debug.State, debug.Exception));
+            Assert.True(sink.Writes.TryTake(out var write));
+            Assert.Equal(logLevel, write.LogLevel);
+            Assert.Equal(0, write.EventId);
+            Assert.Null(write.Exception);
+            Assert.Equal("Test 1", write.Formatter(write.State, write.Exception));
         }
 
-        [Fact]
-        public void LogLevel_LogValuesAndEventId_LogsCorrectValues()
+        [Theory]
+        [InlineData(LogLevel.Trace, 1)]
+        [InlineData(LogLevel.Information, 2)]
+        [InlineData(LogLevel.Warning, 3)]
+        [InlineData(LogLevel.Error, 4)]
+        [InlineData(LogLevel.Critical, 5)]
+        [InlineData(LogLevel.Debug, 6)]
+        public void LogLevel_LogValuesAndEventId_LogsCorrectValues(LogLevel logLevel, int eventId)
         {
             // Arrange
             var sink = new TestSink();
@@ -1024,55 +813,24 @@ namespace Microsoft.Extensions.Logging.Test
             };
 
             // Act
-            logger.Log(LogLevel.Trace, 1, testLogValues.ToString());
-            logger.Log(LogLevel.Information, 2, testLogValues.ToString());
-            logger.Log(LogLevel.Warning, 3, testLogValues.ToString());
-            logger.Log(LogLevel.Error, 4, testLogValues.ToString());
-            logger.Log(LogLevel.Critical, 5, testLogValues.ToString());
-            logger.Log(LogLevel.Debug, 6, testLogValues.ToString());
+            logger.Log(logLevel, eventId, testLogValues.ToString());
 
             // Assert
-            Assert.Equal(6, sink.Writes.Count());
-
-            Assert.True(sink.Writes.TryTake(out var trace));
-            Assert.Equal(LogLevel.Trace, trace.LogLevel);
-            Assert.Equal(1, trace.EventId);
-            Assert.Null(trace.Exception);
-            Assert.Equal("Test 1", trace.Formatter(trace.State, trace.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var information));
-            Assert.Equal(LogLevel.Information, information.LogLevel);
-            Assert.Equal(2, information.EventId);
-            Assert.Null(information.Exception);
-            Assert.Equal("Test 1", information.Formatter(information.State, information.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var warning));
-            Assert.Equal(LogLevel.Warning, warning.LogLevel);
-            Assert.Equal(3, warning.EventId);
-            Assert.Null(warning.Exception);
-            Assert.Equal("Test 1", warning.Formatter(warning.State, warning.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var error));
-            Assert.Equal(LogLevel.Error, error.LogLevel);
-            Assert.Equal(4, error.EventId);
-            Assert.Null(error.Exception);
-            Assert.Equal("Test 1", error.Formatter(error.State, error.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var critical));
-            Assert.Equal(LogLevel.Critical, critical.LogLevel);
-            Assert.Equal(5, critical.EventId);
-            Assert.Null(critical.Exception);
-            Assert.Equal("Test 1", critical.Formatter(critical.State, critical.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var debug));
-            Assert.Equal(LogLevel.Debug, debug.LogLevel);
-            Assert.Equal(6, debug.EventId);
-            Assert.Null(debug.Exception);
-            Assert.Equal("Test 1", debug.Formatter(debug.State, debug.Exception));
+            Assert.True(sink.Writes.TryTake(out var write));
+            Assert.Equal(logLevel, write.LogLevel);
+            Assert.Equal(eventId, write.EventId);
+            Assert.Null(write.Exception);
+            Assert.Equal("Test 1", write.Formatter(write.State, write.Exception));
         }
 
-        [Fact]
-        public void LogLevel_LogValuesAndError_LogsCorrectValues()
+        [Theory]
+        [InlineData(LogLevel.Trace)]
+        [InlineData(LogLevel.Information)]
+        [InlineData(LogLevel.Warning)]
+        [InlineData(LogLevel.Error)]
+        [InlineData(LogLevel.Critical)]
+        [InlineData(LogLevel.Debug)]
+        public void LogLevel_LogValuesAndError_LogsCorrectValues(LogLevel logLevel)
         {
             // Arrange
             var sink = new TestSink();
@@ -1083,67 +841,26 @@ namespace Microsoft.Extensions.Logging.Test
             };
 
             // Act
-            logger.Log(LogLevel.Trace, 0, _exception, testLogValues.ToString());
-            logger.Log(LogLevel.Information, 0, _exception, testLogValues.ToString());
-            logger.Log(LogLevel.Warning, 0, _exception, testLogValues.ToString());
-            logger.Log(LogLevel.Error, 0, _exception, testLogValues.ToString());
-            logger.Log(LogLevel.Critical, 0, _exception, testLogValues.ToString());
-            logger.Log(LogLevel.Debug, 0, _exception, testLogValues.ToString());
+            logger.Log(logLevel, 0, _exception, testLogValues.ToString());
 
             // Assert
-            Assert.Equal(6, sink.Writes.Count());
-
-            Assert.True(sink.Writes.TryTake(out var trace));
-            Assert.Equal(LogLevel.Trace, trace.LogLevel);
-            Assert.Equal(0, trace.EventId);
-            Assert.Equal(_exception, trace.Exception);
+            Assert.True(sink.Writes.TryTake(out var write));
+            Assert.Equal(logLevel, write.LogLevel);
+            Assert.Equal(0, write.EventId);
+            Assert.Equal(_exception, write.Exception);
             Assert.Equal(
                 "Test 1",
-                trace.Formatter(trace.State, trace.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var information));
-            Assert.Equal(LogLevel.Information, information.LogLevel);
-            Assert.Equal(0, information.EventId);
-            Assert.Equal(_exception, information.Exception);
-            Assert.Equal(
-                "Test 1",
-                information.Formatter(information.State, information.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var warning));
-            Assert.Equal(LogLevel.Warning, warning.LogLevel);
-            Assert.Equal(0, warning.EventId);
-            Assert.Equal(_exception, warning.Exception);
-            Assert.Equal(
-                "Test 1",
-                warning.Formatter(warning.State, warning.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var error));
-            Assert.Equal(LogLevel.Error, error.LogLevel);
-            Assert.Equal(0, error.EventId);
-            Assert.Equal(_exception, error.Exception);
-            Assert.Equal(
-                "Test 1",
-                error.Formatter(error.State, error.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var critical));
-            Assert.Equal(LogLevel.Critical, critical.LogLevel);
-            Assert.Equal(0, critical.EventId);
-            Assert.Equal(_exception, critical.Exception);
-            Assert.Equal(
-                "Test 1",
-                critical.Formatter(critical.State, critical.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var debug));
-            Assert.Equal(LogLevel.Debug, debug.LogLevel);
-            Assert.Equal(0, debug.EventId);
-            Assert.Equal(_exception, debug.Exception);
-            Assert.Equal(
-                "Test 1",
-                debug.Formatter(debug.State, debug.Exception));
+                write.Formatter(write.State, write.Exception));
         }
 
-        [Fact]
-        public void LogLevel_LogValuesEventIdAndError_LogsCorrectValues()
+        [Theory]
+        [InlineData(LogLevel.Trace, 1)]
+        [InlineData(LogLevel.Information, 2)]
+        [InlineData(LogLevel.Warning, 3)]
+        [InlineData(LogLevel.Error, 4)]
+        [InlineData(LogLevel.Critical, 5)]
+        [InlineData(LogLevel.Debug, 6)]
+        public void LogLevel_LogValuesEventIdAndError_LogsCorrectValues(LogLevel logLevel, int eventId)
         {
             // Arrange
             var sink = new TestSink();
@@ -1154,69 +871,17 @@ namespace Microsoft.Extensions.Logging.Test
             };
 
             // Act
-            logger.Log(LogLevel.Trace, 1, _exception, testLogValues.ToString());
-            logger.Log(LogLevel.Information, 2, _exception, testLogValues.ToString());
-            logger.Log(LogLevel.Warning, 3, _exception, testLogValues.ToString());
-            logger.Log(LogLevel.Error, 4, _exception, testLogValues.ToString());
-            logger.Log(LogLevel.Critical, 5, _exception, testLogValues.ToString());
-            logger.Log(LogLevel.Debug, 6, _exception, testLogValues.ToString());
+            logger.Log(logLevel, eventId, _exception, testLogValues.ToString());
 
             // Assert
-            Assert.Equal(6, sink.Writes.Count());
-
-            Assert.True(sink.Writes.TryTake(out var trace));
-            Assert.Equal(LogLevel.Trace, trace.LogLevel);
-            Assert.Equal(testLogValues.ToString(), trace.State.ToString());
-            Assert.Equal(1, trace.EventId);
-            Assert.Equal(_exception, trace.Exception);
+            Assert.True(sink.Writes.TryTake(out var write));
+            Assert.Equal(logLevel, write.LogLevel);
+            Assert.Equal(testLogValues.ToString(), write.State.ToString());
+            Assert.Equal(eventId, write.EventId);
+            Assert.Equal(_exception, write.Exception);
             Assert.Equal(
                 "Test 1",
-                trace.Formatter(trace.State, trace.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var information));
-            Assert.Equal(LogLevel.Information, information.LogLevel);
-            Assert.Equal(testLogValues.ToString(), information.State.ToString());
-            Assert.Equal(2, information.EventId);
-            Assert.Equal(_exception, information.Exception);
-            Assert.Equal(
-                "Test 1",
-                information.Formatter(information.State, information.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var warning));
-            Assert.Equal(LogLevel.Warning, warning.LogLevel);
-            Assert.Equal(testLogValues.ToString(), warning.State.ToString());
-            Assert.Equal(3, warning.EventId);
-            Assert.Equal(_exception, warning.Exception);
-            Assert.Equal(
-                "Test 1",
-                warning.Formatter(warning.State, warning.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var error));
-            Assert.Equal(LogLevel.Error, error.LogLevel);
-            Assert.Equal(testLogValues.ToString(), error.State.ToString());
-            Assert.Equal(4, error.EventId);
-            Assert.Equal(_exception, error.Exception);
-            Assert.Equal(
-                "Test 1",
-                error.Formatter(error.State, error.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var critical));
-            Assert.Equal(LogLevel.Critical, critical.LogLevel);
-            Assert.Equal(testLogValues.ToString(), critical.State.ToString());
-            Assert.Equal(5, critical.EventId);
-            Assert.Equal(_exception, critical.Exception);
-            Assert.Equal(
-                "Test 1",
-                critical.Formatter(critical.State, critical.Exception));
-
-            Assert.True(sink.Writes.TryTake(out var debug));
-            Assert.Equal(LogLevel.Debug, debug.LogLevel);
-            Assert.Equal(testLogValues.ToString(), debug.State.ToString());
-            Assert.Equal(6, debug.EventId);
-            Assert.Equal(_exception, debug.Exception);
-            Assert.Equal(
-                "Test 1",
-                debug.Formatter(debug.State, debug.Exception));
+                write.Formatter(write.State, write.Exception));
         }
 
         [Fact]

--- a/test/Microsoft.Extensions.Logging.Test/LoggerExtensionsTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/LoggerExtensionsTest.cs
@@ -39,10 +39,9 @@ namespace Microsoft.Extensions.Logging.Test
             logger.LogError(_state);
             logger.LogCritical(_state);
             logger.LogDebug(_state);
-            logger.Log(LogLevel.Information, _state);
 
             // Assert
-            Assert.Equal(7, sink.Writes.Count());
+            Assert.Equal(6, sink.Writes.Count());
 
             Assert.True(sink.Writes.TryTake(out var trace));
             Assert.Equal(LogLevel.Trace, trace.LogLevel);
@@ -79,12 +78,6 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(_state, debug.State.ToString());
             Assert.Equal(0, debug.EventId);
             Assert.Null(debug.Exception);
-
-            Assert.True(sink.Writes.TryTake(out var logInf));
-            Assert.Equal(LogLevel.Information, logInf.LogLevel);
-            Assert.Equal(_state, logInf.State.ToString());
-            Assert.Equal(0, logInf.EventId);
-            Assert.Null(logInf.Exception);
         }
 
         [Fact]
@@ -270,6 +263,8 @@ namespace Microsoft.Extensions.Logging.Test
             var writeList = sink.Writes.ToList();
 
             // Assert
+            Assert.Equal(6, sink.Writes.Count);
+
             Assert.True(sink.Writes.TryTake(out var trace));
             Assert.Equal(LogLevel.Trace, trace.LogLevel);
             Assert.Equal(_state, trace.State.ToString());
@@ -569,6 +564,602 @@ namespace Microsoft.Extensions.Logging.Test
             logger.LogError(4, _exception, testLogValues.ToString());
             logger.LogCritical(5, _exception, testLogValues.ToString());
             logger.LogDebug(6, _exception, testLogValues.ToString());
+
+            // Assert
+            Assert.Equal(6, sink.Writes.Count());
+
+            Assert.True(sink.Writes.TryTake(out var trace));
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Equal(testLogValues.ToString(), trace.State.ToString());
+            Assert.Equal(1, trace.EventId);
+            Assert.Equal(_exception, trace.Exception);
+            Assert.Equal(
+                "Test 1",
+                trace.Formatter(trace.State, trace.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var information));
+            Assert.Equal(LogLevel.Information, information.LogLevel);
+            Assert.Equal(testLogValues.ToString(), information.State.ToString());
+            Assert.Equal(2, information.EventId);
+            Assert.Equal(_exception, information.Exception);
+            Assert.Equal(
+                "Test 1",
+                information.Formatter(information.State, information.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var warning));
+            Assert.Equal(LogLevel.Warning, warning.LogLevel);
+            Assert.Equal(testLogValues.ToString(), warning.State.ToString());
+            Assert.Equal(3, warning.EventId);
+            Assert.Equal(_exception, warning.Exception);
+            Assert.Equal(
+                "Test 1",
+                warning.Formatter(warning.State, warning.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var error));
+            Assert.Equal(LogLevel.Error, error.LogLevel);
+            Assert.Equal(testLogValues.ToString(), error.State.ToString());
+            Assert.Equal(4, error.EventId);
+            Assert.Equal(_exception, error.Exception);
+            Assert.Equal(
+                "Test 1",
+                error.Formatter(error.State, error.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var critical));
+            Assert.Equal(LogLevel.Critical, critical.LogLevel);
+            Assert.Equal(testLogValues.ToString(), critical.State.ToString());
+            Assert.Equal(5, critical.EventId);
+            Assert.Equal(_exception, critical.Exception);
+            Assert.Equal(
+                "Test 1",
+                critical.Formatter(critical.State, critical.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var debug));
+            Assert.Equal(LogLevel.Debug, debug.LogLevel);
+            Assert.Equal(testLogValues.ToString(), debug.State.ToString());
+            Assert.Equal(6, debug.EventId);
+            Assert.Equal(_exception, debug.Exception);
+            Assert.Equal(
+                "Test 1",
+                debug.Formatter(debug.State, debug.Exception));
+        }
+
+        [Fact]
+        public void LogLevel_MessageOnly_LogsCorrectValues()
+        {
+            // Arrange
+            var sink = new TestSink();
+            var logger = SetUp(sink);
+
+            // Act
+            logger.Log(LogLevel.Trace, _state);
+            logger.Log(LogLevel.Information, _state);
+            logger.Log(LogLevel.Warning, _state);
+            logger.Log(LogLevel.Error, _state);
+            logger.Log(LogLevel.Critical, _state);
+            logger.Log(LogLevel.Debug, _state);
+
+            // Assert
+            Assert.Equal(6, sink.Writes.Count);
+
+            Assert.True(sink.Writes.TryTake(out var trace));
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Equal(_state, trace.State.ToString());
+            Assert.Equal(0, trace.EventId);
+            Assert.Null(trace.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var information));
+            Assert.Equal(LogLevel.Information, information.LogLevel);
+            Assert.Equal(_state, information.State.ToString());
+            Assert.Equal(0, information.EventId);
+            Assert.Null(information.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var warning));
+            Assert.Equal(LogLevel.Warning, warning.LogLevel);
+            Assert.Equal(_state, warning.State.ToString());
+            Assert.Equal(0, warning.EventId);
+            Assert.Null(warning.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var error));
+            Assert.Equal(LogLevel.Error, error.LogLevel);
+            Assert.Equal(_state, error.State.ToString());
+            Assert.Equal(0, error.EventId);
+            Assert.Null(error.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var critical));
+            Assert.Equal(LogLevel.Critical, critical.LogLevel);
+            Assert.Equal(_state, critical.State.ToString());
+            Assert.Equal(0, critical.EventId);
+            Assert.Null(critical.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var debug));
+            Assert.Equal(LogLevel.Debug, debug.LogLevel);
+            Assert.Equal(_state, debug.State.ToString());
+            Assert.Equal(0, debug.EventId);
+            Assert.Null(debug.Exception);
+        }
+
+        [Fact]
+        public void LogLevel_FormatMessage_LogsCorrectValues()
+        {
+            // Arrange
+            var sink = new TestSink();
+            var logger = SetUp(sink);
+
+            // Act
+            logger.Log(LogLevel.Trace, _format, "test1", "test2");
+            logger.Log(LogLevel.Information, _format, "test1", "test2");
+            logger.Log(LogLevel.Warning, _format, "test1", "test2");
+            logger.Log(LogLevel.Error, _format, "test1", "test2");
+            logger.Log(LogLevel.Critical, _format, "test1", "test2");
+            logger.Log(LogLevel.Debug, _format, "test1", "test2");
+
+            // Assert
+            Assert.Equal(6, sink.Writes.Count);
+
+            Assert.True(sink.Writes.TryTake(out var trace));
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), trace.State?.ToString());
+            Assert.Equal(0, trace.EventId);
+            Assert.Null(trace.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var information));
+            Assert.Equal(LogLevel.Information, information.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), information.State?.ToString());
+            Assert.Equal(0, information.EventId);
+            Assert.Null(information.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var warning));
+            Assert.Equal(LogLevel.Warning, warning.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), warning.State?.ToString());
+            Assert.Equal(0, warning.EventId);
+            Assert.Null(warning.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var error));
+            Assert.Equal(LogLevel.Error, error.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), error.State?.ToString());
+            Assert.Equal(0, error.EventId);
+            Assert.Null(error.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var critical));
+            Assert.Equal(LogLevel.Critical, critical.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), critical.State?.ToString());
+            Assert.Equal(0, critical.EventId);
+            Assert.Null(critical.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var debug));
+            Assert.Equal(LogLevel.Debug, debug.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), debug.State?.ToString());
+            Assert.Equal(0, debug.EventId);
+            Assert.Null(debug.Exception);
+        }
+
+        [Fact]
+        public void LogLevel_MessageAndEventId_LogsCorrectValues()
+        {
+            // Arrange
+            var sink = new TestSink();
+            var logger = SetUp(sink);
+
+            // Act
+            logger.Log(LogLevel.Trace, 1, _state);
+            logger.Log(LogLevel.Information, 2, _state);
+            logger.Log(LogLevel.Warning, 3, _state);
+            logger.Log(LogLevel.Error, 4, _state);
+            logger.Log(LogLevel.Critical, 5, _state);
+            logger.Log(LogLevel.Debug, 6, _state);
+
+            // Assert
+            Assert.Equal(6, sink.Writes.Count);
+
+            Assert.True(sink.Writes.TryTake(out var trace));
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Equal(_state, trace.State.ToString());
+            Assert.Equal(1, trace.EventId);
+            Assert.Null(trace.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var information));
+            Assert.Equal(LogLevel.Information, information.LogLevel);
+            Assert.Equal(_state, information.State.ToString());
+            Assert.Equal(2, information.EventId);
+            Assert.Null(information.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var warning));
+            Assert.Equal(LogLevel.Warning, warning.LogLevel);
+            Assert.Equal(_state, warning.State.ToString());
+            Assert.Equal(3, warning.EventId);
+            Assert.Null(warning.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var error));
+            Assert.Equal(LogLevel.Error, error.LogLevel);
+            Assert.Equal(_state, error.State.ToString());
+            Assert.Equal(4, error.EventId);
+            Assert.Null(error.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var critical));
+            Assert.Equal(LogLevel.Critical, critical.LogLevel);
+            Assert.Equal(_state, critical.State.ToString());
+            Assert.Equal(5, critical.EventId);
+            Assert.Null(critical.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var debug));
+            Assert.Equal(LogLevel.Debug, debug.LogLevel);
+            Assert.Equal(_state, debug.State.ToString());
+            Assert.Equal(6, debug.EventId);
+            Assert.Null(debug.Exception);
+        }
+
+        [Fact]
+        public void LogLevel_FormatMessageAndEventId_LogsCorrectValues()
+        {
+            // Arrange
+            var sink = new TestSink();
+            var logger = SetUp(sink);
+
+            // Act
+            logger.Log(LogLevel.Trace, 1, _format, "test1", "test2");
+            logger.Log(LogLevel.Information, 2, _format, "test1", "test2");
+            logger.Log(LogLevel.Warning, 3, _format, "test1", "test2");
+            logger.Log(LogLevel.Error, 4, _format, "test1", "test2");
+            logger.Log(LogLevel.Critical, 5, _format, "test1", "test2");
+            logger.Log(LogLevel.Debug, 6, _format, "test1", "test2");
+
+            // Assert
+            Assert.Equal(6, sink.Writes.Count);
+
+            Assert.True(sink.Writes.TryTake(out var trace));
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), trace.State?.ToString());
+            Assert.Equal(1, trace.EventId);
+            Assert.Null(trace.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var information));
+            Assert.Equal(LogLevel.Information, information.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), information.State?.ToString());
+            Assert.Equal(2, information.EventId);
+            Assert.Null(information.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var warning));
+            Assert.Equal(LogLevel.Warning, warning.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), warning.State?.ToString());
+            Assert.Equal(3, warning.EventId);
+            Assert.Null(warning.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var error));
+            Assert.Equal(LogLevel.Error, error.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), error.State?.ToString());
+            Assert.Equal(4, error.EventId);
+            Assert.Null(error.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var critical));
+            Assert.Equal(LogLevel.Critical, critical.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), critical.State?.ToString());
+            Assert.Equal(5, critical.EventId);
+            Assert.Null(critical.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var debug));
+            Assert.Equal(LogLevel.Debug, debug.LogLevel);
+            Assert.Equal(string.Format(_format, "test1", "test2"), debug.State?.ToString());
+            Assert.Equal(6, debug.EventId);
+            Assert.Null(debug.Exception);
+        }
+
+        [Fact]
+        public void LogLevel_MessageAndError_LogsCorrectValues()
+        {
+            // Arrange
+            var sink = new TestSink();
+            var logger = SetUp(sink);
+
+            // Act
+            logger.Log(LogLevel.Trace, _exception, _state);
+            logger.Log(LogLevel.Information, _exception, _state);
+            logger.Log(LogLevel.Warning, _exception, _state);
+            logger.Log(LogLevel.Error, _exception, _state);
+            logger.Log(LogLevel.Critical, _exception, _state);
+            logger.Log(LogLevel.Debug, _exception, _state);
+
+            // Assert
+            Assert.Equal(6, sink.Writes.Count);
+
+            Assert.True(sink.Writes.TryTake(out var trace));
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Equal(_state, trace.State.ToString());
+            Assert.Equal(0, trace.EventId);
+            Assert.Equal(_exception, trace.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var information));
+            Assert.Equal(LogLevel.Information, information.LogLevel);
+            Assert.Equal(_state, information.State.ToString());
+            Assert.Equal(0, information.EventId);
+            Assert.Equal(_exception, information.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var warning));
+            Assert.Equal(LogLevel.Warning, warning.LogLevel);
+            Assert.Equal(_state, warning.State.ToString());
+            Assert.Equal(0, warning.EventId);
+            Assert.Equal(_exception, warning.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var error));
+            Assert.Equal(LogLevel.Error, error.LogLevel);
+            Assert.Equal(_state, error.State.ToString());
+            Assert.Equal(0, error.EventId);
+            Assert.Equal(_exception, error.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var critical));
+            Assert.Equal(LogLevel.Critical, critical.LogLevel);
+            Assert.Equal(_state, critical.State.ToString());
+            Assert.Equal(0, critical.EventId);
+            Assert.Equal(_exception, critical.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var debug));
+            Assert.Equal(LogLevel.Debug, debug.LogLevel);
+            Assert.Equal(_state, debug.State.ToString());
+            Assert.Equal(0, debug.EventId);
+            Assert.Equal(_exception, debug.Exception);
+        }
+
+        [Fact]
+        public void LogLevel_MessageEventIdAndError_LogsCorrectValues()
+        {
+            // Arrange
+            var sink = new TestSink();
+            var logger = SetUp(sink);
+
+            // Act
+            logger.Log(LogLevel.Trace, 1, _exception, _state);
+            logger.Log(LogLevel.Information, 2, _exception, _state);
+            logger.Log(LogLevel.Warning, 3, _exception, _state);
+            logger.Log(LogLevel.Error, 4, _exception, _state);
+            logger.Log(LogLevel.Critical, 5, _exception, _state);
+            logger.Log(LogLevel.Debug, 6, _exception, _state);
+
+            // Assert
+            Assert.Equal(6, sink.Writes.Count());
+
+            Assert.True(sink.Writes.TryTake(out var trace));
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Equal(_state, trace.State.ToString());
+            Assert.Equal(1, trace.EventId);
+            Assert.Equal(_exception, trace.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var information));
+            Assert.Equal(LogLevel.Information, information.LogLevel);
+            Assert.Equal(_state, information.State.ToString());
+            Assert.Equal(2, information.EventId);
+            Assert.Equal(_exception, information.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var warning));
+            Assert.Equal(LogLevel.Warning, warning.LogLevel);
+            Assert.Equal(_state, warning.State.ToString());
+            Assert.Equal(3, warning.EventId);
+            Assert.Equal(_exception, warning.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var error));
+            Assert.Equal(LogLevel.Error, error.LogLevel);
+            Assert.Equal(_state, error.State.ToString());
+            Assert.Equal(4, error.EventId);
+            Assert.Equal(_exception, error.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var critical));
+            Assert.Equal(LogLevel.Critical, critical.LogLevel);
+            Assert.Equal(_state, critical.State.ToString());
+            Assert.Equal(5, critical.EventId);
+            Assert.Equal(_exception, critical.Exception);
+
+            Assert.True(sink.Writes.TryTake(out var debug));
+            Assert.Equal(LogLevel.Debug, debug.LogLevel);
+            Assert.Equal(_state, debug.State.ToString());
+            Assert.Equal(6, debug.EventId);
+            Assert.Equal(_exception, debug.Exception);
+        }
+
+        [Fact]
+        public void LogLevel_LogValues_LogsCorrectValues()
+        {
+            // Arrange
+            var sink = new TestSink();
+            var logger = SetUp(sink);
+            var testLogValues = new TestLogValues()
+            {
+                Value = 1
+            };
+
+            // Act
+            logger.Log(LogLevel.Trace, 0, testLogValues.ToString());
+            logger.Log(LogLevel.Information, 0, testLogValues.ToString());
+            logger.Log(LogLevel.Warning, 0, testLogValues.ToString());
+            logger.Log(LogLevel.Error, 0, testLogValues.ToString());
+            logger.Log(LogLevel.Critical, 0, testLogValues.ToString());
+            logger.Log(LogLevel.Debug, 0, testLogValues.ToString());
+
+            // Assert
+            Assert.Equal(6, sink.Writes.Count());
+
+            Assert.True(sink.Writes.TryTake(out var trace));
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Equal(0, trace.EventId);
+            Assert.Null(trace.Exception);
+            Assert.Equal("Test 1", trace.Formatter(trace.State, trace.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var information));
+            Assert.Equal(LogLevel.Information, information.LogLevel);
+            Assert.Equal(0, information.EventId);
+            Assert.Null(information.Exception);
+            Assert.Equal("Test 1", information.Formatter(information.State, information.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var warning));
+            Assert.Equal(LogLevel.Warning, warning.LogLevel);
+            Assert.Equal(0, warning.EventId);
+            Assert.Null(warning.Exception);
+            Assert.Equal("Test 1", warning.Formatter(warning.State, warning.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var error));
+            Assert.Equal(LogLevel.Error, error.LogLevel);
+            Assert.Equal(0, error.EventId);
+            Assert.Null(error.Exception);
+            Assert.Equal("Test 1", error.Formatter(error.State, error.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var critical));
+            Assert.Equal(LogLevel.Critical, critical.LogLevel);
+            Assert.Equal(0, critical.EventId);
+            Assert.Null(critical.Exception);
+            Assert.Equal("Test 1", critical.Formatter(critical.State, critical.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var debug));
+            Assert.Equal(LogLevel.Debug, debug.LogLevel);
+            Assert.Equal(0, debug.EventId);
+            Assert.Null(debug.Exception);
+            Assert.Equal("Test 1", debug.Formatter(debug.State, debug.Exception));
+        }
+
+        [Fact]
+        public void LogLevel_LogValuesAndEventId_LogsCorrectValues()
+        {
+            // Arrange
+            var sink = new TestSink();
+            var logger = SetUp(sink);
+            var testLogValues = new TestLogValues()
+            {
+                Value = 1
+            };
+
+            // Act
+            logger.Log(LogLevel.Trace, 1, testLogValues.ToString());
+            logger.Log(LogLevel.Information, 2, testLogValues.ToString());
+            logger.Log(LogLevel.Warning, 3, testLogValues.ToString());
+            logger.Log(LogLevel.Error, 4, testLogValues.ToString());
+            logger.Log(LogLevel.Critical, 5, testLogValues.ToString());
+            logger.Log(LogLevel.Debug, 6, testLogValues.ToString());
+
+            // Assert
+            Assert.Equal(6, sink.Writes.Count());
+
+            Assert.True(sink.Writes.TryTake(out var trace));
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Equal(1, trace.EventId);
+            Assert.Null(trace.Exception);
+            Assert.Equal("Test 1", trace.Formatter(trace.State, trace.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var information));
+            Assert.Equal(LogLevel.Information, information.LogLevel);
+            Assert.Equal(2, information.EventId);
+            Assert.Null(information.Exception);
+            Assert.Equal("Test 1", information.Formatter(information.State, information.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var warning));
+            Assert.Equal(LogLevel.Warning, warning.LogLevel);
+            Assert.Equal(3, warning.EventId);
+            Assert.Null(warning.Exception);
+            Assert.Equal("Test 1", warning.Formatter(warning.State, warning.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var error));
+            Assert.Equal(LogLevel.Error, error.LogLevel);
+            Assert.Equal(4, error.EventId);
+            Assert.Null(error.Exception);
+            Assert.Equal("Test 1", error.Formatter(error.State, error.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var critical));
+            Assert.Equal(LogLevel.Critical, critical.LogLevel);
+            Assert.Equal(5, critical.EventId);
+            Assert.Null(critical.Exception);
+            Assert.Equal("Test 1", critical.Formatter(critical.State, critical.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var debug));
+            Assert.Equal(LogLevel.Debug, debug.LogLevel);
+            Assert.Equal(6, debug.EventId);
+            Assert.Null(debug.Exception);
+            Assert.Equal("Test 1", debug.Formatter(debug.State, debug.Exception));
+        }
+
+        [Fact]
+        public void LogLevel_LogValuesAndError_LogsCorrectValues()
+        {
+            // Arrange
+            var sink = new TestSink();
+            var logger = SetUp(sink);
+            var testLogValues = new TestLogValues()
+            {
+                Value = 1
+            };
+
+            // Act
+            logger.Log(LogLevel.Trace, 0, _exception, testLogValues.ToString());
+            logger.Log(LogLevel.Information, 0, _exception, testLogValues.ToString());
+            logger.Log(LogLevel.Warning, 0, _exception, testLogValues.ToString());
+            logger.Log(LogLevel.Error, 0, _exception, testLogValues.ToString());
+            logger.Log(LogLevel.Critical, 0, _exception, testLogValues.ToString());
+            logger.Log(LogLevel.Debug, 0, _exception, testLogValues.ToString());
+
+            // Assert
+            Assert.Equal(6, sink.Writes.Count());
+
+            Assert.True(sink.Writes.TryTake(out var trace));
+            Assert.Equal(LogLevel.Trace, trace.LogLevel);
+            Assert.Equal(0, trace.EventId);
+            Assert.Equal(_exception, trace.Exception);
+            Assert.Equal(
+                "Test 1",
+                trace.Formatter(trace.State, trace.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var information));
+            Assert.Equal(LogLevel.Information, information.LogLevel);
+            Assert.Equal(0, information.EventId);
+            Assert.Equal(_exception, information.Exception);
+            Assert.Equal(
+                "Test 1",
+                information.Formatter(information.State, information.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var warning));
+            Assert.Equal(LogLevel.Warning, warning.LogLevel);
+            Assert.Equal(0, warning.EventId);
+            Assert.Equal(_exception, warning.Exception);
+            Assert.Equal(
+                "Test 1",
+                warning.Formatter(warning.State, warning.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var error));
+            Assert.Equal(LogLevel.Error, error.LogLevel);
+            Assert.Equal(0, error.EventId);
+            Assert.Equal(_exception, error.Exception);
+            Assert.Equal(
+                "Test 1",
+                error.Formatter(error.State, error.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var critical));
+            Assert.Equal(LogLevel.Critical, critical.LogLevel);
+            Assert.Equal(0, critical.EventId);
+            Assert.Equal(_exception, critical.Exception);
+            Assert.Equal(
+                "Test 1",
+                critical.Formatter(critical.State, critical.Exception));
+
+            Assert.True(sink.Writes.TryTake(out var debug));
+            Assert.Equal(LogLevel.Debug, debug.LogLevel);
+            Assert.Equal(0, debug.EventId);
+            Assert.Equal(_exception, debug.Exception);
+            Assert.Equal(
+                "Test 1",
+                debug.Formatter(debug.State, debug.Exception));
+        }
+
+        [Fact]
+        public void LogLevel_LogValuesEventIdAndError_LogsCorrectValues()
+        {
+            // Arrange
+            var sink = new TestSink();
+            var logger = SetUp(sink);
+            var testLogValues = new TestLogValues()
+            {
+                Value = 1
+            };
+
+            // Act
+            logger.Log(LogLevel.Trace, 1, _exception, testLogValues.ToString());
+            logger.Log(LogLevel.Information, 2, _exception, testLogValues.ToString());
+            logger.Log(LogLevel.Warning, 3, _exception, testLogValues.ToString());
+            logger.Log(LogLevel.Error, 4, _exception, testLogValues.ToString());
+            logger.Log(LogLevel.Critical, 5, _exception, testLogValues.ToString());
+            logger.Log(LogLevel.Debug, 6, _exception, testLogValues.ToString());
 
             // Assert
             Assert.Equal(6, sink.Writes.Count());


### PR DESCRIPTION
This PR expands on #629.  Changes:

* Adds a new extension method that also accepts an `EventId` and an `Exception`
* Update [the previous method](https://github.com/ChrisSimmons/Logging/blob/a4b901159255abbdd47cf979171838799f971f66/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs#L350) to use this new method
* Update all the level-specific methods (e.g. [`LogDebug()`](https://github.com/ChrisSimmons/Logging/blob/a4b901159255abbdd47cf979171838799f971f66/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs#L42) and [`LogWarning()`](https://github.com/ChrisSimmons/Logging/blob/a4b901159255abbdd47cf979171838799f971f66/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs#L191)) to use this new method
* Use the new method to [handle the null `logger` argument exception](https://github.com/ChrisSimmons/Logging/blob/a4b901159255abbdd47cf979171838799f971f66/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs#L366)
    * If this is not desirable, e.g. for stacktrace reasons, I can revert and resubmit the PR
