### PR TITLE
Implement file logging with default xunit tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,7 @@ environment:
   global:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    ASPNETCORE_TEST_LOG_DIR: "$APPVEYOR_BUILD_FOLDER\\artifacts\\logs"
 test: 'off'
 deploy: 'off'
 os: Visual Studio 2017

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   global:
   - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   - DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  - ASPNETCORE_TEST_LOG_DIR: "$APPVEYOR_BUILD_FOLDER\\artifacts\\logs"
 mono: none
 os:
 - linux

--- a/NuGetPackageVerifier.json
+++ b/NuGetPackageVerifier.json
@@ -2,6 +2,15 @@
     "Default": {
         "rules": [
             "DefaultCompositeRule"
-        ]
+        ],
+        "packages": {
+            "Microsoft.Extensions.Logging.Testing": {
+                "Exclusions": {
+                    "BUILD_ITEMS_FRAMEWORK": {
+                        "*": "Props file intentionally targets any framework since the content is the same for both netstandard2.0 and net461."
+                    }
+                }
+            }
+        }
     }
 }

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,31 +4,32 @@
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
     <InternalAspNetCoreSdkPackageVersion>2.1.0-preview3-17004</InternalAspNetCoreSdkPackageVersion>
-    <MicrosoftAspNetCoreTestingPackageVersion>2.1.0-preview3-32176</MicrosoftAspNetCoreTestingPackageVersion>
+    <MicrosoftAspNetCoreTestingPackageVersion>2.1.0-preview3-32192</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>2.6.1</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
-    <MicrosoftExtensionsConfigurationBinderPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsConfigurationBinderPackageVersion>
-    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
-    <MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>
-    <MicrosoftExtensionsConfigurationJsonPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsConfigurationJsonPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsDependencyInjectionPackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>2.1.0-preview2-26403-06</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
-    <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
-    <MicrosoftExtensionsOptionsPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsOptionsPackageVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.1.0-preview3-32192</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
+    <MicrosoftExtensionsConfigurationBinderPackageVersion>2.1.0-preview3-32192</MicrosoftExtensionsConfigurationBinderPackageVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.1.0-preview3-32192</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
+    <MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>2.1.0-preview3-32192</MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>
+    <MicrosoftExtensionsConfigurationJsonPackageVersion>2.1.0-preview3-32192</MicrosoftExtensionsConfigurationJsonPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>2.1.0-preview3-32192</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionPackageVersion>2.1.0-preview3-32192</MicrosoftExtensionsDependencyInjectionPackageVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>2.1.0-preview2-26406-04</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>2.1.0-preview3-32192</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
+    <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>2.1.0-preview3-32192</MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
+    <MicrosoftExtensionsOptionsPackageVersion>2.1.0-preview3-32192</MicrosoftExtensionsOptionsPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
-    <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview2-26403-06</MicrosoftNETCoreApp21PackageVersion>
+    <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview2-26406-04</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.7.49</MoqPackageVersion>
     <NewtonsoftJsonPackageVersion>11.0.2</NewtonsoftJsonPackageVersion>
     <SerilogExtensionsLoggingPackageVersion>1.4.0</SerilogExtensionsLoggingPackageVersion>
     <SerilogSinksFilePackageVersion>3.2.0</SerilogSinksFilePackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>4.5.0-preview2-26403-05</SystemDiagnosticsEventLogPackageVersion>
-    <SystemReflectionMetadataPackageVersion>1.6.0-preview2-26403-05</SystemReflectionMetadataPackageVersion>
-    <SystemValueTuplePackageVersion>4.5.0-preview2-26403-05</SystemValueTuplePackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>4.5.0-preview2-26406-04</SystemDiagnosticsEventLogPackageVersion>
+    <SystemReflectionMetadataPackageVersion>1.6.0-preview2-26406-04</SystemReflectionMetadataPackageVersion>
+    <SystemValueTuplePackageVersion>4.5.0-preview2-26406-04</SystemValueTuplePackageVersion>
     <XunitAbstractionsPackageVersion>2.0.1</XunitAbstractionsPackageVersion>
     <XunitAssertPackageVersion>2.3.1</XunitAssertPackageVersion>
+    <XunitExtensibilityExecutionPackageVersion>2.3.1</XunitExtensibilityExecutionPackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.4.0-beta.1.build3945</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>

--- a/src/Microsoft.Extensions.Logging.Testing/LoggedTest.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/LoggedTest.cs
@@ -4,24 +4,50 @@
 using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 
 namespace Microsoft.Extensions.Logging.Testing
 {
     public abstract class LoggedTest
     {
-        private readonly ITestOutputHelper _output;
+        private ILoggerFactory _loggerFactory;
 
-        public LoggedTest(ITestOutputHelper output)
+        // Obsolete but keeping for back compat
+        public LoggedTest(ITestOutputHelper output = null)
         {
-            _output = output;
+            TestOutputHelper = output;
         }
+
+        // Internal for testing
+        internal string TestMethodTestName { get; set; }
+
+        public ILogger Logger { get; set; }
+
+        public ILoggerFactory LoggerFactory
+        {
+            get
+            {
+                return _loggerFactory;
+            }
+            set
+            {
+                _loggerFactory = value;
+                AddTestLogging = services => services.AddSingleton(_loggerFactory);
+            }
+        }
+
+        public ITestOutputHelper TestOutputHelper { get; set; }
+
+        public ITestSink TestSink { get; set; }
+
+        public Action<IServiceCollection> AddTestLogging { get; private set; } = services => { };
 
         public IDisposable StartLog(out ILoggerFactory loggerFactory, [CallerMemberName] string testName = null) => StartLog(out loggerFactory, LogLevel.Information, testName);
 
         public IDisposable StartLog(out ILoggerFactory loggerFactory, LogLevel minLogLevel, [CallerMemberName] string testName = null)
         {
-            return AssemblyTestLog.ForAssembly(GetType().GetTypeInfo().Assembly).StartTestLog(_output, GetType().FullName, out loggerFactory, minLogLevel, testName);
+            return AssemblyTestLog.ForAssembly(GetType().GetTypeInfo().Assembly).StartTestLog(TestOutputHelper, GetType().FullName, out loggerFactory, minLogLevel, testName);
         }
     }
 }

--- a/src/Microsoft.Extensions.Logging.Testing/Microsoft.Extensions.Logging.Testing.csproj
+++ b/src/Microsoft.Extensions.Logging.Testing/Microsoft.Extensions.Logging.Testing.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Helpers for writing tests that use Microsoft.Extensions.Logging. Contains null implementations of the abstractions that do nothing, as well as test implementations that are observable.</Description>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <PackageTags>$(PackageTags);testing</PackageTags>
     <EnableApiCheck>false</EnableApiCheck>
@@ -14,11 +14,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(MicrosoftAspNetCoreTestingPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
     <PackageReference Include="xunit.abstractions" Version="$(XunitAbstractionsPackageVersion)" />
+    <PackageReference Include="xunit.extensibility.execution" Version="$(XunitExtensibilityExecutionPackageVersion)" />
     <PackageReference Include="xunit.assert" Version="$(XunitAssertPackageVersion)" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="$(SerilogExtensionsLoggingPackageVersion)" />
     <PackageReference Include="Serilog.Sinks.File" Version="$(SerilogSinksFilePackageVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="build\**\*.props" PackagePath="%(Identity)" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.Extensions.Logging.Testing/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Extensions.Logging.Testing.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/Microsoft.Extensions.Logging.Testing/TestLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/TestLoggerProvider.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class TestLoggerProvider : ILoggerProvider
+    {
+        private readonly ITestSink _sink;
+
+        public TestLoggerProvider(ITestSink sink)
+        {
+            _sink = sink;
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new TestLogger(categoryName, _sink, enabled: true);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LogLevelAttribute.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LogLevelAttribute.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class LogLevelAttribute : Attribute
+    {
+        public LogLevelAttribute(LogLevel logLevel)
+        {
+            LogLevel = logLevel;
+        }
+
+        public LogLevel LogLevel { get; }
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedConditionalFactDiscoverer.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedConditionalFactDiscoverer.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Testing.xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class LoggedConditionalFactDiscoverer : LoggedFactDiscoverer
+    {
+        private readonly IMessageSink _diagnosticMessageSink;
+
+        public LoggedConditionalFactDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink)
+        {
+            _diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        protected override IXunitTestCase CreateTestCase(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        {
+            var skipReason = testMethod.EvaluateSkipConditions();
+            return skipReason != null
+                ? new SkippedTestCase(skipReason, _diagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod)
+                : base.CreateTestCase(discoveryOptions, testMethod, factAttribute);
+        }
+
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedConditionalTheoryDiscoverer.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedConditionalTheoryDiscoverer.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Testing.xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class LoggedConditionalTheoryDiscoverer : LoggedTheoryDiscoverer
+    {
+        public LoggedConditionalTheoryDiscoverer(IMessageSink diagnosticMessageSink)
+            : base(diagnosticMessageSink)
+        {
+        }
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(
+            ITestFrameworkDiscoveryOptions discoveryOptions,
+            ITestMethod testMethod,
+            IAttributeInfo theoryAttribute)
+        {
+            var skipReason = testMethod.EvaluateSkipConditions();
+            return skipReason != null
+               ? new[] { new SkippedTestCase(skipReason, DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) }
+               : base.CreateTestCasesForTheory(discoveryOptions, testMethod, theoryAttribute);
+        }
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(
+            ITestFrameworkDiscoveryOptions discoveryOptions,
+            ITestMethod testMethod, IAttributeInfo theoryAttribute,
+            object[] dataRow)
+        {
+            var skipReason = testMethod.EvaluateSkipConditions();
+            return skipReason != null
+                ? base.CreateTestCasesForSkippedDataRow(discoveryOptions, testMethod, theoryAttribute, dataRow, skipReason)
+                : base.CreateTestCasesForDataRow(discoveryOptions, testMethod, theoryAttribute, dataRow);
+        }
+
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedFactDiscoverer.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedFactDiscoverer.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class LoggedFactDiscoverer : FactDiscoverer
+    {
+        public LoggedFactDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink)
+        {
+        }
+
+        protected override IXunitTestCase CreateTestCase(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+            => new LoggedTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod);
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestAssemblyRunner.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestAssemblyRunner.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class LoggedTestAssemblyRunner : XunitTestAssemblyRunner
+    {
+        public LoggedTestAssemblyRunner(
+            ITestAssembly testAssembly,
+            IEnumerable<IXunitTestCase> testCases,
+            IMessageSink diagnosticMessageSink,
+            IMessageSink executionMessageSink,
+            ITestFrameworkExecutionOptions executionOptions)
+            : base(testAssembly, testCases, diagnosticMessageSink, executionMessageSink, executionOptions)
+        {
+        }
+
+        protected override Task<RunSummary> RunTestCollectionAsync(
+            IMessageBus messageBus,
+            ITestCollection testCollection,
+            IEnumerable<IXunitTestCase> testCases,
+            CancellationTokenSource cancellationTokenSource)
+            => new LoggedTestCollectionRunner(testCollection, testCases, DiagnosticMessageSink, messageBus, TestCaseOrderer, new ExceptionAggregator(Aggregator), cancellationTokenSource).RunAsync();
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestCase.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestCase.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class LoggedTestCase : XunitTestCase
+    {
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public LoggedTestCase() : base()
+        {
+        }
+
+        public LoggedTestCase(
+            IMessageSink diagnosticMessageSink,
+            TestMethodDisplay defaultMethodDisplay,
+            ITestMethod testMethod,
+            object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod, testMethodArguments)
+        {
+        }
+
+        public override Task<RunSummary> RunAsync(
+            IMessageSink diagnosticMessageSink,
+            IMessageBus messageBus,
+            object[] constructorArguments,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource)
+            =>  new LoggedTestCaseRunner(this, DisplayName, SkipReason, constructorArguments, TestMethodArguments, messageBus, aggregator, cancellationTokenSource).RunAsync();
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestCaseRunner.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestCaseRunner.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class LoggedTestCaseRunner : XunitTestCaseRunner
+    {
+        public LoggedTestCaseRunner(
+            IXunitTestCase testCase,
+            string displayName,
+            string skipReason,
+            object[] constructorArguments,
+            object[] testMethodArguments,
+            IMessageBus messageBus,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource)
+            : base(testCase, displayName, skipReason, constructorArguments, testMethodArguments, messageBus, aggregator, cancellationTokenSource)
+        {
+        }
+
+        protected override XunitTestRunner CreateTestRunner(
+            ITest test,
+            IMessageBus messageBus,
+            Type testClass,
+            object[] constructorArguments,
+            MethodInfo testMethod,
+            object[] testMethodArguments,
+            string skipReason,
+            IReadOnlyList<BeforeAfterTestAttribute> beforeAfterAttributes,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource)
+                => new LoggedTestRunner(test, messageBus, testClass, constructorArguments, testMethod, testMethodArguments,
+                    skipReason, beforeAfterAttributes, new ExceptionAggregator(aggregator), cancellationTokenSource);
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestClassRunner.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestClassRunner.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class LoggedTestClassRunner : XunitTestClassRunner
+    {
+        public LoggedTestClassRunner(
+            ITestClass testClass,
+            IReflectionTypeInfo @class,
+            IEnumerable<IXunitTestCase> testCases,
+            IMessageSink diagnosticMessageSink,
+            IMessageBus messageBus,
+            ITestCaseOrderer testCaseOrderer,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource,
+            IDictionary<Type, object> collectionFixtureMappings)
+            : base(testClass, @class, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource, collectionFixtureMappings)
+        {
+        }
+
+        protected override Task<RunSummary> RunTestMethodAsync(
+            ITestMethod testMethod,
+            IReflectionMethodInfo method,
+            IEnumerable<IXunitTestCase> testCases,
+            object[] constructorArguments)
+            => new LoggedTestMethodRunner(testMethod, Class, method, testCases, DiagnosticMessageSink, MessageBus, new ExceptionAggregator(Aggregator), CancellationTokenSource, constructorArguments).RunAsync();
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestCollectionRunner.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestCollectionRunner.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class LoggedTestCollectionRunner : XunitTestCollectionRunner
+    {
+        private readonly IMessageSink _diagnosticMessageSink;
+
+        public LoggedTestCollectionRunner(
+            ITestCollection testCollection,
+            IEnumerable<IXunitTestCase> testCases,
+            IMessageSink diagnosticMessageSink,
+            IMessageBus messageBus,
+            ITestCaseOrderer testCaseOrderer,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource)
+            : base(testCollection, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource)
+        {
+            // Base class doesn't expose this, so capture it here.
+            _diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        protected override Task<RunSummary> RunTestClassAsync(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases)
+            => new LoggedTestClassRunner(testClass, @class, testCases, _diagnosticMessageSink, MessageBus, TestCaseOrderer, new ExceptionAggregator(Aggregator), CancellationTokenSource, CollectionFixtureMappings).RunAsync();
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestFramework.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestFramework.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class LoggedTestFramework : XunitTestFramework
+    {
+        public LoggedTestFramework(IMessageSink messageSink) : base(messageSink)
+        {
+        }
+
+        protected override ITestFrameworkDiscoverer CreateDiscoverer(IAssemblyInfo assemblyInfo)
+        {
+            return new LoggedTestFrameworkDiscoverer(assemblyInfo, SourceInformationProvider, DiagnosticMessageSink);
+        }
+
+        protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName)
+        {
+            return new LoggedTestFrameworkExecutor(assemblyName, SourceInformationProvider, DiagnosticMessageSink);
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestFrameworkDiscoverer.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestFrameworkDiscoverer.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Testing.xunit;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class LoggedTestFrameworkDiscoverer : XunitTestFrameworkDiscoverer
+    {
+        private IDictionary<Type, IXunitTestCaseDiscoverer> Discoverers { get; }
+
+        public LoggedTestFrameworkDiscoverer(
+            IAssemblyInfo assemblyInfo,
+            ISourceInformationProvider sourceProvider,
+            IMessageSink diagnosticMessageSink,
+            IXunitTestCollectionFactory collectionFactory = null)
+            : base(assemblyInfo, sourceProvider, diagnosticMessageSink, collectionFactory)
+        {
+            Discoverers = new Dictionary<Type, IXunitTestCaseDiscoverer>()
+            {
+                { typeof(ConditionalTheoryAttribute), new LoggedConditionalTheoryDiscoverer(diagnosticMessageSink) },
+                { typeof(ConditionalFactAttribute), new LoggedConditionalFactDiscoverer(diagnosticMessageSink) },
+                { typeof(TheoryAttribute), new LoggedTheoryDiscoverer(diagnosticMessageSink) },
+                { typeof(FactAttribute), new LoggedFactDiscoverer(diagnosticMessageSink) }
+            };
+        }
+
+        protected override bool FindTestsForMethod(
+            ITestMethod testMethod,
+            bool includeSourceInformation,
+            IMessageBus messageBus,
+            ITestFrameworkDiscoveryOptions discoveryOptions)
+        {
+            if (typeof(LoggedTest).IsAssignableFrom(testMethod.TestClass.Class.ToRuntimeType()))
+            {
+                var factAttributes = testMethod.Method.GetCustomAttributes(typeof(FactAttribute));
+                if (factAttributes.Count() > 1)
+                {
+                    var message = $"Test method '{testMethod.TestClass.Class.Name}.{testMethod.Method.Name}' has multiple [Fact]-derived attributes";
+                    var testCase = new ExecutionErrorTestCase(DiagnosticMessageSink, TestMethodDisplay.ClassAndMethod, testMethod, message);
+                    return ReportDiscoveredTestCase(testCase, includeSourceInformation, messageBus);
+                }
+
+                var factAttribute = factAttributes.FirstOrDefault();
+                if (factAttribute == null)
+                {
+                    return true;
+                }
+
+                var factAttributeType = (factAttribute as IReflectionAttributeInfo)?.Attribute.GetType();
+                if (!Discoverers.TryGetValue(factAttributeType, out var discoverer))
+                {
+                    return base.FindTestsForMethod(testMethod, includeSourceInformation, messageBus, discoveryOptions);
+                }
+                else
+                {
+                    foreach (var testCase in discoverer.Discover(discoveryOptions, testMethod, factAttribute))
+                    {
+                        if (!ReportDiscoveredTestCase(testCase, includeSourceInformation, messageBus))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+            }
+            else
+            {
+                return base.FindTestsForMethod(testMethod, includeSourceInformation, messageBus, discoveryOptions);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestFrameworkExecutor.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestFrameworkExecutor.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class LoggedTestFrameworkExecutor : XunitTestFrameworkExecutor
+    {
+        public LoggedTestFrameworkExecutor(AssemblyName assemblyName, ISourceInformationProvider sourceInformationProvider, IMessageSink diagnosticMessageSink)
+            : base(assemblyName, sourceInformationProvider, diagnosticMessageSink)
+        {
+        }
+
+        protected override async void RunTestCases(IEnumerable<IXunitTestCase> testCases, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
+        {
+            using (var assemblyRunner = new LoggedTestAssemblyRunner(TestAssembly, testCases, DiagnosticMessageSink, executionMessageSink, executionOptions))
+            {
+                await assemblyRunner.RunAsync();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestInvoker.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestInvoker.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class LoggedTestInvoker : XunitTestInvoker
+    {
+        private TestOutputHelper _output;
+
+        public LoggedTestInvoker(
+            ITest test,
+            IMessageBus messageBus,
+            Type testClass,
+            object[] constructorArguments,
+            MethodInfo testMethod,
+            object[] testMethodArguments,
+            IReadOnlyList<BeforeAfterTestAttribute> beforeAfterAttributes,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource)
+            : base(test, messageBus, testClass, constructorArguments, testMethod, testMethodArguments, beforeAfterAttributes, aggregator, cancellationTokenSource)
+        {
+        }
+
+        protected override Task BeforeTestMethodInvokedAsync()
+        {
+            if (_output != null)
+            {
+                _output.Initialize(MessageBus, Test);
+            }
+
+            return base.BeforeTestMethodInvokedAsync();
+        }
+
+        protected override async Task AfterTestMethodInvokedAsync()
+        {
+            await base.AfterTestMethodInvokedAsync();
+
+            if (_output != null)
+            {
+                _output.Uninitialize();
+            }
+        }
+
+        protected override object CreateTestClass()
+        {
+            var testClass = base.CreateTestClass();
+
+            if (testClass is LoggedTest loggedTestClass)
+            {
+                var classType = loggedTestClass.GetType();
+                var logLevelAttribute = TestMethod.GetCustomAttribute(typeof(LogLevelAttribute)) as LogLevelAttribute;
+                var testName = TestMethodArguments.Aggregate(TestMethod.Name, (a, b) => $"{a}-{(b ?? "null")}");
+
+                // Try resolving ITestOutputHelper from constructor arguments
+                loggedTestClass.TestOutputHelper = ConstructorArguments?.SingleOrDefault(a => typeof(ITestOutputHelper).IsAssignableFrom(a.GetType())) as ITestOutputHelper;
+
+                // None resolved so create a new one and retain a reference to it for initialization/uninitialization
+                if (loggedTestClass.TestOutputHelper == null)
+                {
+                    loggedTestClass.TestOutputHelper = _output = new TestOutputHelper();
+                }
+
+                AssemblyTestLog
+                    .ForAssembly(classType.GetTypeInfo().Assembly)
+                    .StartTestLog(loggedTestClass.TestOutputHelper, classType.FullName, out var loggerFactory, logLevelAttribute?.LogLevel ?? LogLevel.Debug, out var resolvedTestName, testName);
+
+                loggedTestClass.LoggerFactory = loggerFactory;
+                loggedTestClass.TestMethodTestName = resolvedTestName;
+                loggedTestClass.Logger = loggerFactory.CreateLogger(classType);
+                loggedTestClass.TestSink = new TestSink();
+                loggerFactory.AddProvider(new TestLoggerProvider(loggedTestClass.TestSink));
+            }
+
+            return testClass;
+        }
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestMethodRunner.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestMethodRunner.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class LoggedTestMethodRunner : XunitTestMethodRunner
+    {
+        private IMessageSink DiagnosticMessageSink { get; }
+        private object[] ConstructorArguments { get; }
+
+        public LoggedTestMethodRunner(
+            ITestMethod testMethod,
+            IReflectionTypeInfo @class,
+            IReflectionMethodInfo method,
+            IEnumerable<IXunitTestCase> testCases,
+            IMessageSink diagnosticMessageSink,
+            IMessageBus messageBus,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource,
+            object[] constructorArguments)
+            : base(testMethod, @class, method, testCases, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource, constructorArguments)
+        {
+            DiagnosticMessageSink = diagnosticMessageSink;
+            ConstructorArguments = constructorArguments;
+        }
+
+        protected override Task<RunSummary> RunTestCaseAsync(IXunitTestCase testCase)
+            => testCase.RunAsync(DiagnosticMessageSink, MessageBus, ConstructorArguments, new ExceptionAggregator(Aggregator), CancellationTokenSource);
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestRunner.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestRunner.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class LoggedTestRunner : XunitTestRunner
+    {
+        public LoggedTestRunner(
+            ITest test,
+            IMessageBus messageBus,
+            Type testClass,
+            object[] constructorArguments,
+            MethodInfo testMethod, object[]
+            testMethodArguments, string skipReason,
+            IReadOnlyList<BeforeAfterTestAttribute> beforeAfterAttributes,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource)
+            : base(test, messageBus, testClass, constructorArguments, testMethod, testMethodArguments, skipReason, beforeAfterAttributes, aggregator, cancellationTokenSource)
+        {
+        }
+
+        protected override Task<decimal> InvokeTestMethodAsync(ExceptionAggregator aggregator)
+            => new LoggedTestInvoker(Test, MessageBus, TestClass, ConstructorArguments, TestMethod, TestMethodArguments, BeforeAfterAttributes, aggregator, CancellationTokenSource).RunAsync();
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTheoryDiscoverer.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTheoryDiscoverer.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class LoggedTheoryDiscoverer : TheoryDiscoverer
+    {
+        public LoggedTheoryDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink)
+        {
+        }
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(
+            ITestFrameworkDiscoveryOptions discoveryOptions,
+            ITestMethod testMethod,
+            IAttributeInfo theoryAttribute,
+            object[] dataRow)
+            => new[] { new LoggedTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod, dataRow) };
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(
+            ITestFrameworkDiscoveryOptions discoveryOptions,
+            ITestMethod testMethod,
+            IAttributeInfo theoryAttribute)
+            => new[] { new LoggedTheoryTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), testMethod) };
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTheoryTestCase.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTheoryTestCase.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class LoggedTheoryTestCase : XunitTheoryTestCase
+    {
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public LoggedTheoryTestCase() : base()
+        {
+        }
+
+        public LoggedTheoryTestCase(
+            IMessageSink diagnosticMessageSink,
+            TestMethodDisplay defaultMethodDisplay,
+            ITestMethod testMethod)
+            : base(diagnosticMessageSink, defaultMethodDisplay, testMethod)
+        {
+        }
+
+        public override Task<RunSummary> RunAsync(
+            IMessageSink diagnosticMessageSink,
+            IMessageBus messageBus,
+            object[] constructorArguments,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource)
+            => new LoggedTheoryTestCaseRunner(this, DisplayName, SkipReason, constructorArguments, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource).RunAsync();
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTheoryTestCaseRunner.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTheoryTestCaseRunner.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class LoggedTheoryTestCaseRunner : XunitTheoryTestCaseRunner
+    {
+        public LoggedTheoryTestCaseRunner(
+            IXunitTestCase testCase,
+            string displayName,
+            string skipReason,
+            object[] constructorArguments,
+            IMessageSink diagnosticMessageSink,
+            IMessageBus messageBus,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource)
+            : base(testCase, displayName, skipReason, constructorArguments, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource)
+        {
+        }
+
+        protected override XunitTestRunner CreateTestRunner(
+            ITest test,
+            IMessageBus messageBus,
+            Type testClass,
+            object[] constructorArguments,
+            MethodInfo testMethod,
+            object[] testMethodArguments,
+            string skipReason,
+            IReadOnlyList<BeforeAfterTestAttribute> beforeAfterAttributes,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource)
+                => new LoggedTestRunner(test, messageBus, testClass, constructorArguments, testMethod, testMethodArguments, skipReason, beforeAfterAttributes, new ExceptionAggregator(aggregator), cancellationTokenSource);
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/build/Microsoft.Extensions.Logging.Testing.props
+++ b/src/Microsoft.Extensions.Logging.Testing/build/Microsoft.Extensions.Logging.Testing.props
@@ -1,0 +1,8 @@
+﻿<Project>
+  <ItemGroup>
+  	<AssemblyAttribute Include="Xunit.TestFramework">
+    	<_Parameter1>Microsoft.Extensions.Logging.Testing.LoggedTestFramework</_Parameter1>
+    	<_Parameter2>Microsoft.Extensions.Logging.Testing</_Parameter2>
+  	</AssemblyAttribute>
+	</ItemGroup>
+</Project>

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
@@ -9,18 +9,14 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.Extensions.Logging.Testing.Tests
 {
     public class AssemblyTestLogTests : LoggedTest
     {
         private static readonly Assembly ThisAssembly = typeof(AssemblyTestLog).GetTypeInfo().Assembly;
-
-        public AssemblyTestLogTests(ITestOutputHelper output) : base(output)
-        {
-        }
 
         [Fact]
         public void ForAssembly_ReturnsSameInstanceForSameAssembly()
@@ -52,37 +48,50 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
         }
 
         [Fact]
-        public Task TestLogWritesToGlobalLogFile() =>
-            RunTestLogFunctionalTest((tempDir, loggerFactory) =>
-        {
-            // Because this test writes to a file, it is a functional test and should be logged
-            // but it's also testing the test logging facility. So this is pretty meta ;)
-            var logger = loggerFactory.CreateLogger("Test");
-
-            using (var testAssemblyLog = AssemblyTestLog.Create("FakeTestAssembly", tempDir))
+        private Task TestLogEscapesIllegalFileNames() =>
+            RunTestLogFunctionalTest((tempDir) =>
             {
-                logger.LogInformation("Created test log in {baseDirectory}", tempDir);
-
-                using (testAssemblyLog.StartTestLog(output: null, className: "FakeTestAssembly.FakeTestClass", loggerFactory: out var testLoggerFactory, minLogLevel: LogLevel.Trace, testName: "FakeTestName"))
+                var illegalTestName = "Testing-https://localhost:5000";
+                var escapedTestName = "Testing-https___localhost_5000";
+                using (var testAssemblyLog = AssemblyTestLog.Create("FakeTestAssembly", baseDirectory: tempDir))
+                using (testAssemblyLog.StartTestLog(output: null, className: "FakeTestAssembly.FakeTestClass", loggerFactory: out var testLoggerFactory, minLogLevel: LogLevel.Trace, resolvedTestName: out var resolvedTestname, testName: illegalTestName))
                 {
-                    var testLogger = testLoggerFactory.CreateLogger("TestLogger");
-                    testLogger.LogInformation("Information!");
-                    testLogger.LogTrace("Trace!");
+                    Assert.Equal(escapedTestName, resolvedTestname);
                 }
-            }
+            });
 
-            logger.LogInformation("Finished test log in {baseDirectory}", tempDir);
+        [Fact]
+        public Task TestLogWritesToGlobalLogFile() =>
+            RunTestLogFunctionalTest((tempDir) =>
+            {
+                // Because this test writes to a file, it is a functional test and should be logged
+                // but it's also testing the test logging facility. So this is pretty meta ;)
+                var logger = LoggerFactory.CreateLogger("Test");
 
-            var globalLogPath = Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription.TrimStart('.'), "global.log");
-            var testLog = Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription.TrimStart('.'), "FakeTestClass", $"FakeTestName.log");
+                using (var testAssemblyLog = AssemblyTestLog.Create("FakeTestAssembly", tempDir))
+                {
+                    logger.LogInformation("Created test log in {baseDirectory}", tempDir);
 
-            Assert.True(File.Exists(globalLogPath), $"Expected global log file {globalLogPath} to exist");
-            Assert.True(File.Exists(testLog), $"Expected test log file {testLog} to exist");
+                    using (testAssemblyLog.StartTestLog(output: null, className: "FakeTestAssembly.FakeTestClass", loggerFactory: out var testLoggerFactory, minLogLevel: LogLevel.Trace, testName: "FakeTestName"))
+                    {
+                        var testLogger = testLoggerFactory.CreateLogger("TestLogger");
+                        testLogger.LogInformation("Information!");
+                        testLogger.LogTrace("Trace!");
+                    }
+                }
 
-            var globalLogContent = MakeConsistent(File.ReadAllText(globalLogPath));
-            var testLogContent = MakeConsistent(File.ReadAllText(testLog));
+                logger.LogInformation("Finished test log in {baseDirectory}", tempDir);
 
-            Assert.Equal(@"[GlobalTestLog] [Information] Global Test Logging initialized. Set the 'ASPNETCORE_TEST_LOG_DIR' Environment Variable in order to create log files on disk.
+                var globalLogPath = Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription.TrimStart('.'), "global.log");
+                var testLog = Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription.TrimStart('.'), "FakeTestClass", $"FakeTestName.log");
+
+                Assert.True(File.Exists(globalLogPath), $"Expected global log file {globalLogPath} to exist");
+                Assert.True(File.Exists(testLog), $"Expected test log file {testLog} to exist");
+
+                var globalLogContent = MakeConsistent(File.ReadAllText(globalLogPath));
+                var testLogContent = MakeConsistent(File.ReadAllText(testLog));
+
+                Assert.Equal(@"[GlobalTestLog] [Information] Global Test Logging initialized. Set the 'ASPNETCORE_TEST_LOG_DIR' Environment Variable in order to create log files on disk.
 [GlobalTestLog] [Information] Starting test ""FakeTestName""
 [GlobalTestLog] [Information] Finished test ""FakeTestName"" in DURATION
 ", globalLogContent, ignoreLineEndingDifferences: true);
@@ -91,91 +100,86 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
 [TestLogger] [Verbose] Trace!
 [TestLifetime] [Information] Finished test ""FakeTestName"" in DURATION
 ", testLogContent, ignoreLineEndingDifferences: true);
-        });
+            });
 
         [Fact]
         public Task TestLogTruncatesTestNameToAvoidLongPaths() =>
-            RunTestLogFunctionalTest((tempDir, loggerFactory) =>
-        {
-            var longTestName = new string('0', 50) + new string('1', 50) + new string('2', 50) + new string('3', 50) + new string('4', 50);
-            var logger = loggerFactory.CreateLogger("Test");
-            using (var testAssemblyLog = AssemblyTestLog.Create("FakeTestAssembly", tempDir))
+            RunTestLogFunctionalTest((tempDir) =>
             {
-                logger.LogInformation("Created test log in {baseDirectory}", tempDir);
-
-                using (testAssemblyLog.StartTestLog(output: null, className: "FakeTestAssembly.FakeTestClass", loggerFactory: out var testLoggerFactory, minLogLevel: LogLevel.Trace, testName: longTestName))
+                var longTestName = new string('0', 50) + new string('1', 50) + new string('2', 50) + new string('3', 50) + new string('4', 50);
+                var logger = LoggerFactory.CreateLogger("Test");
+                using (var testAssemblyLog = AssemblyTestLog.Create("FakeTestAssembly", tempDir))
                 {
-                    testLoggerFactory.CreateLogger("TestLogger").LogInformation("Information!");
-                }
-            }
-            logger.LogInformation("Finished test log in {baseDirectory}", tempDir);
+                    logger.LogInformation("Created test log in {baseDirectory}", tempDir);
 
-            var testLogFiles = new DirectoryInfo(Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription.TrimStart('.'), "FakeTestClass")).EnumerateFiles();
-            var testLog = Assert.Single(testLogFiles);
-            var testFileName = Path.GetFileNameWithoutExtension(testLog.Name);
-
-            // The first half of the file comes from the beginning of the test name passed to the logger
-            Assert.Equal(longTestName.Substring(0, testFileName.Length / 2), testFileName.Substring(0, testFileName.Length / 2));
-            // The last half of the file comes from the ending of the test name passed to the logger
-            Assert.Equal(longTestName.Substring(longTestName.Length - testFileName.Length / 2, testFileName.Length / 2), testFileName.Substring(testFileName.Length - testFileName.Length / 2, testFileName.Length / 2));
-
-            var testLogContent = MakeConsistent(File.ReadAllText(testLog.FullName));
-        });
-
-        [Fact]
-        public  Task TestLogEnumerateFilenamesToAvoidCollisions() =>
-            RunTestLogFunctionalTest((tempDir, loggerFactory) =>
-        {
-            var logger = loggerFactory.CreateLogger("Test");
-            using (var testAssemblyLog = AssemblyTestLog.Create("FakeTestAssembly", tempDir))
-            {
-                logger.LogInformation("Created test log in {baseDirectory}", tempDir);
-
-                for (var i = 0; i < 10; i++)
-                {
-                    using (testAssemblyLog.StartTestLog(output: null, className: "FakeTestAssembly.FakeTestClass", loggerFactory: out var testLoggerFactory, minLogLevel: LogLevel.Trace, testName: "FakeTestName"))
+                    using (testAssemblyLog.StartTestLog(output: null, className: "FakeTestAssembly.FakeTestClass", loggerFactory: out var testLoggerFactory, minLogLevel: LogLevel.Trace, testName: longTestName))
                     {
                         testLoggerFactory.CreateLogger("TestLogger").LogInformation("Information!");
                     }
                 }
-            }
-            logger.LogInformation("Finished test log in {baseDirectory}", tempDir);
+                logger.LogInformation("Finished test log in {baseDirectory}", tempDir);
 
-            // The first log file exists
-            Assert.True(File.Exists(Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription.TrimStart('.'), "FakeTestClass", $"FakeTestName.log")));
+                var testLogFiles = new DirectoryInfo(Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription.TrimStart('.'), "FakeTestClass")).EnumerateFiles();
+                var testLog = Assert.Single(testLogFiles);
+                var testFileName = Path.GetFileNameWithoutExtension(testLog.Name);
 
-            // Subsequent files exist
-            for (var i = 0; i < 9; i++)
+                // The first half of the file comes from the beginning of the test name passed to the logger
+                Assert.Equal(longTestName.Substring(0, testFileName.Length / 2), testFileName.Substring(0, testFileName.Length / 2));
+                // The last half of the file comes from the ending of the test name passed to the logger
+                Assert.Equal(longTestName.Substring(longTestName.Length - testFileName.Length / 2, testFileName.Length / 2), testFileName.Substring(testFileName.Length - testFileName.Length / 2, testFileName.Length / 2));
+            });
+
+        [Fact]
+        public  Task TestLogEnumerateFilenamesToAvoidCollisions() =>
+            RunTestLogFunctionalTest((tempDir) =>
             {
-                Assert.True(File.Exists(Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription.TrimStart('.'), "FakeTestClass", $"FakeTestName.{i}.log")));
-            }
-        });
+                var logger = LoggerFactory.CreateLogger("Test");
+                using (var testAssemblyLog = AssemblyTestLog.Create("FakeTestAssembly", tempDir))
+                {
+                    logger.LogInformation("Created test log in {baseDirectory}", tempDir);
+
+                    for (var i = 0; i < 10; i++)
+                    {
+                        using (testAssemblyLog.StartTestLog(output: null, className: "FakeTestAssembly.FakeTestClass", loggerFactory: out var testLoggerFactory, minLogLevel: LogLevel.Trace, testName: "FakeTestName"))
+                        {
+                            testLoggerFactory.CreateLogger("TestLogger").LogInformation("Information!");
+                        }
+                    }
+                }
+                logger.LogInformation("Finished test log in {baseDirectory}", tempDir);
+
+                // The first log file exists
+                Assert.True(File.Exists(Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription.TrimStart('.'), "FakeTestClass", $"FakeTestName.log")));
+
+                // Subsequent files exist
+                for (var i = 0; i < 9; i++)
+                {
+                    Assert.True(File.Exists(Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription.TrimStart('.'), "FakeTestClass", $"FakeTestName.{i}.log")));
+                }
+            });
 
         private static readonly Regex TimestampRegex = new Regex(@"\d+-\d+-\d+T\d+:\d+:\d+");
         private static readonly Regex DurationRegex = new Regex(@"[^ ]+s$");
 
-        private async Task RunTestLogFunctionalTest(Action<string, ILoggerFactory> action, [CallerMemberName] string testName = null)
+        private async Task RunTestLogFunctionalTest(Action<string> action, [CallerMemberName] string testName = null)
         {
-            using (StartLog(out var loggerFactory, testName))
+            var tempDir = Path.Combine(Path.GetTempPath(), $"TestLogging_{Guid.NewGuid().ToString("N")}");
+            try
             {
-                var tempDir = Path.Combine(Path.GetTempPath(), $"TestLogging_{Guid.NewGuid().ToString("N")}");
-                try
+                action(tempDir);
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
                 {
-                    action(tempDir, loggerFactory);
-                }
-                finally
-                {
-                    if (Directory.Exists(tempDir))
+                    try
                     {
-                        try
-                        {
-                            Directory.Delete(tempDir, recursive: true);
-                        }
-                        catch
-                        {
-                            await Task.Delay(100);
-                            Directory.Delete(tempDir, recursive: true);
-                        }
+                        Directory.Delete(tempDir, recursive: true);
+                    }
+                    catch
+                    {
+                        await Task.Delay(100);
+                        Directory.Delete(tempDir, recursive: true);
                     }
                 }
             }

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/LogValuesAssertTest.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/LogValuesAssertTest.cs
@@ -1,7 +1,6 @@
 // Copyright(c) .NET Foundation.All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/LoggedTestXunitTests.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/LoggedTestXunitTests.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Testing.xunit;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Extensions.Logging.Testing.Tests
+{
+    public class LoggedTestXunitTests : LoggedTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public LoggedTestXunitTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void LoggedTestTestOutputHelperSameInstanceAsInjectedConstructorArg()
+        {
+            Assert.Same(_output, TestOutputHelper);
+        }
+
+        [Fact]
+        public void LoggedFactInitializesLoggedTestProperties()
+        {
+            Assert.NotNull(Logger);
+            Assert.NotNull(LoggerFactory);
+            Assert.NotNull(TestSink);
+            Assert.NotNull(TestOutputHelper);
+        }
+
+        [Theory]
+        [InlineData("Hello world")]
+        public void LoggedTheoryInitializesLoggedTestProperties(string argument)
+        {
+            Assert.NotNull(Logger);
+            Assert.NotNull(LoggerFactory);
+            Assert.NotNull(TestSink);
+            Assert.NotNull(TestOutputHelper);
+            // Use the test argument
+            Assert.NotNull(argument);
+        }
+
+        [ConditionalFact]
+        public void ConditionalLoggedFactGetsInitializedLoggerFactory()
+        {
+            Assert.NotNull(Logger);
+            Assert.NotNull(LoggerFactory);
+            Assert.NotNull(TestSink);
+            Assert.NotNull(TestOutputHelper);
+        }
+
+        [ConditionalTheory]
+        [InlineData("Hello world")]
+        public void LoggedConditionalTheoryInitializesLoggedTestProperties(string argument)
+        {
+            Assert.NotNull(Logger);
+            Assert.NotNull(LoggerFactory);
+            Assert.NotNull(TestSink);
+            Assert.NotNull(TestOutputHelper);
+            // Use the test argument
+            Assert.NotNull(argument);
+        }
+
+        [Fact]
+        [LogLevel(LogLevel.Information)]
+        public void LoggedFactFilteredByLogLevel()
+        {
+            Logger.LogInformation("Information");
+            Logger.LogDebug("Debug");
+
+            var message = Assert.Single(TestSink.Writes);
+            Assert.Equal(LogLevel.Information, message.LogLevel);
+            Assert.Equal("Information", message.Formatter(message.State, null));
+        }
+
+        [Theory]
+        [InlineData("Hello world")]
+        [LogLevel(LogLevel.Information)]
+        public void LoggedTheoryFilteredByLogLevel(string argument)
+        {
+            Logger.LogInformation("Information");
+            Logger.LogDebug("Debug");
+
+            var message = Assert.Single(TestSink.Writes);
+            Assert.Equal(LogLevel.Information, message.LogLevel);
+            Assert.Equal("Information", message.Formatter(message.State, null));
+
+            // Use the test argument
+            Assert.NotNull(argument);
+        }
+
+        [Fact]
+        public void AddTestLoggingUpdatedWhenLoggerFactoryIsSet()
+        {
+            var loggerFactory = new LoggerFactory();
+            var serviceCollection = new ServiceCollection();
+
+            LoggerFactory = loggerFactory;
+            AddTestLogging(serviceCollection);
+
+            Assert.Same(loggerFactory, serviceCollection.BuildServiceProvider().GetRequiredService<ILoggerFactory>());
+        }
+
+        [ConditionalTheory]
+        [EnvironmentVariableSkipCondition("ASPNETCORE_TEST_LOG_DIR", "")] // The test name is only generated when logging is enabled via the environment variable
+        [InlineData(null)]
+        public void LoggedTheoryNullArgumentsAreEscaped(string argument)
+        {
+            Assert.NotNull(LoggerFactory);
+            Assert.Equal($"{nameof(LoggedTheoryNullArgumentsAreEscaped)}_null", TestMethodTestName);
+            // Use the test argument
+            Assert.Null(argument);
+        }
+    }
+}

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/Microsoft.Extensions.Logging.Testing.Tests.csproj
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/Microsoft.Extensions.Logging.Testing.Tests.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(MSBuildThisFileDirectory)..\..\src\Microsoft.Extensions.Logging.Testing\build\Microsoft.Extensions.Logging.Testing.props" />
 
   <PropertyGroup>
     <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
@@ -9,5 +10,4 @@
     <ProjectReference Include="..\..\src\Microsoft.Extensions.Logging\Microsoft.Extensions.Logging.csproj" />
     <ProjectReference Include="..\Microsoft.Extensions.Logging.Test\Microsoft.Extensions.Logging.Test.csproj" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This is needed for https://github.com/aspnet/KestrelHttpServer/issues/2390:

The usage is:

1. Extend base class of `LoggedTest`
```c#
    public class MyTests : LoggedTest
    {
    }
```
2. Use the properties of the base class `LoggedTest`
```c#
        [Fact]
        public void MyTest()
        {
            // using LoggerFactory
            using (var webhost = WebHost.CreateDefaultBuilder().ConfigureServices(AddTestLogging).Build())
            {
                //...
            }
            // using Logger
            Logger.LogInformation("Hello world");
            // using TestOutputHelper
           new XunitLogger(TestOutpuHelper, nameof(MyClass), LogLevel.Information);
            // using TestSink
            TestSink.Writes.ForEach(c => Assert.True(c.LogLevel >= LogLeve.Debug));
        }
```
3. The verbosity can be controlled via the LogLevelAttribute:
```c#
        [Fact]
        [LogLevel(LogLevel.Information)]
        public void MyTest()
        {
            // This will noop
            Logger.Debug("Hello world");
        }
```