### PR TITLE
Harden logging tests

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,30 +3,30 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
-    <InternalAspNetCoreSdkPackageVersion>2.1.0-preview3-17002</InternalAspNetCoreSdkPackageVersion>
-    <MicrosoftAspNetCoreTestingPackageVersion>2.1.0-preview3-32110</MicrosoftAspNetCoreTestingPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>2.1.0-preview3-17004</InternalAspNetCoreSdkPackageVersion>
+    <MicrosoftAspNetCoreTestingPackageVersion>2.1.0-preview3-32176</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>2.6.1</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.1.0-preview3-32110</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
-    <MicrosoftExtensionsConfigurationBinderPackageVersion>2.1.0-preview3-32110</MicrosoftExtensionsConfigurationBinderPackageVersion>
-    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.1.0-preview3-32110</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
-    <MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>2.1.0-preview3-32110</MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>
-    <MicrosoftExtensionsConfigurationJsonPackageVersion>2.1.0-preview3-32110</MicrosoftExtensionsConfigurationJsonPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>2.1.0-preview3-32110</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionPackageVersion>2.1.0-preview3-32110</MicrosoftExtensionsDependencyInjectionPackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>2.1.0-preview3-26331-01</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>2.1.0-preview3-32110</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
-    <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>2.1.0-preview3-32110</MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
-    <MicrosoftExtensionsOptionsPackageVersion>2.1.0-preview3-32110</MicrosoftExtensionsOptionsPackageVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
+    <MicrosoftExtensionsConfigurationBinderPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsConfigurationBinderPackageVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
+    <MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>
+    <MicrosoftExtensionsConfigurationJsonPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsConfigurationJsonPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsDependencyInjectionPackageVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>2.1.0-preview2-26403-06</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
+    <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
+    <MicrosoftExtensionsOptionsPackageVersion>2.1.0-preview3-32176</MicrosoftExtensionsOptionsPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
-    <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview3-26331-01</MicrosoftNETCoreApp21PackageVersion>
+    <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview2-26403-06</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
     <MoqPackageVersion>4.7.49</MoqPackageVersion>
     <NewtonsoftJsonPackageVersion>11.0.2</NewtonsoftJsonPackageVersion>
     <SerilogExtensionsLoggingPackageVersion>1.4.0</SerilogExtensionsLoggingPackageVersion>
     <SerilogSinksFilePackageVersion>3.2.0</SerilogSinksFilePackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>4.5.0-preview3-26331-02</SystemDiagnosticsEventLogPackageVersion>
-    <SystemReflectionMetadataPackageVersion>1.6.0-preview3-26331-02</SystemReflectionMetadataPackageVersion>
-    <SystemValueTuplePackageVersion>4.5.0-preview3-26331-02</SystemValueTuplePackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>4.5.0-preview2-26403-05</SystemDiagnosticsEventLogPackageVersion>
+    <SystemReflectionMetadataPackageVersion>1.6.0-preview2-26403-05</SystemReflectionMetadataPackageVersion>
+    <SystemValueTuplePackageVersion>4.5.0-preview2-26403-05</SystemValueTuplePackageVersion>
     <XunitAbstractionsPackageVersion>2.0.1</XunitAbstractionsPackageVersion>
     <XunitAssertPackageVersion>2.3.1</XunitAssertPackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-preview3-17002
-commithash:b8e4e6ab104adc94c0719bb74229870e9b584a7f
+version:2.1.0-preview3-17004
+commithash:0e523ad57cf84e546a50ab15df544e6ded8688a4

--- a/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -763,7 +765,18 @@ namespace Microsoft.Extensions.Logging.Test
             var cancellationTokenSource = settings.Cancel;
             settings.Cancel = new CancellationTokenSource();
 
-            cancellationTokenSource.Cancel();
+            var oldConsole = System.Console.Out;
+            var consoleOutput = new StringBuilder();
+            try
+            {
+                var stringWriter = new StringWriter(consoleOutput);
+                System.Console.SetOut(stringWriter);
+                cancellationTokenSource.Cancel();
+            }
+            finally
+            {
+                System.Console.SetOut(oldConsole);
+            }
 
             Assert.False(logger.IsEnabled(LogLevel.Trace));
 
@@ -776,6 +789,7 @@ namespace Microsoft.Extensions.Logging.Test
             cancellationTokenSource.Cancel();
 
             Assert.True(logger.IsEnabled(LogLevel.Trace));
+            Assert.Contains("Failed to parse LogLevel", consoleOutput.ToString());
         }
 
         [Fact]

--- a/test/Microsoft.Extensions.Logging.Test/TraceSourceLoggerProviderTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/TraceSourceLoggerProviderTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #if NET461
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging.TraceSource;
 using Xunit;
@@ -29,16 +31,33 @@ namespace Microsoft.Extensions.Logging.Test
 
             // Assert
             Assert.Equal(1, listener.FlushCount);
+            Assert.Equal(new []
+            {
+                "FirstLogger Error: 0 : ",
+                "message1" + Environment.NewLine,
+                "SecondLogger Error: 0 : ",
+                "message2" + Environment.NewLine
+            }, listener.Messages);
         }
 
-        private class BufferedConsoleTraceListener : ConsoleTraceListener
+        private class BufferedConsoleTraceListener : TraceListener
         {
             public int FlushCount { get; set; }
+            public List<string> Messages { get; } = new List<string>();
 
             public override void Flush()
             {
                 FlushCount++;
-                base.Flush();
+            }
+
+            public override void Write(string message)
+            {
+                Messages.Add(message);
+            }
+
+            public override void WriteLine(string message)
+            {
+                Messages.Add(message + Environment.NewLine);
             }
         }
     }


### PR DESCRIPTION
Recent logging failures were caused by tests logging to TraceSource so I fixed that.

While investigating failures I thought it was caused by an error being logged to console so redirected console output too.