### PR TITLE
Add azure logging change token source unconditionally

### DIFF
--- a/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesLoggerFactoryExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging.AzureAppServices;
 using Microsoft.Extensions.Logging.AzureAppServices.Internal;
@@ -22,6 +23,13 @@ namespace Microsoft.Extensions.Logging
         public static ILoggingBuilder AddAzureWebAppDiagnostics(this ILoggingBuilder builder)
         {
             var context = WebAppContext.Default;
+
+            // Only add the provider if we're in Azure WebApp. That cannot change once the apps started
+            return AddAzureWebAppDiagnostics(builder, context);
+        }
+
+        internal static ILoggingBuilder AddAzureWebAppDiagnostics(this ILoggingBuilder builder, IWebAppContext context)
+        {
             if (!context.IsRunningInAzureWebApp)
             {
                 return builder;
@@ -30,28 +38,40 @@ namespace Microsoft.Extensions.Logging
             var config = SiteConfigurationProvider.GetAzureLoggingConfiguration(context);
             var services = builder.Services;
 
-            services.TryAddEnumerable(Singleton<IConfigureOptions<LoggerFilterOptions>>(CreateFileFilterConfigureOptions(config)));
-            services.TryAddEnumerable(Singleton<IConfigureOptions<LoggerFilterOptions>>(CreateBlobFilterConfigureOptions(config)));
+            var addedFileLogger = TryAddEnumerableSucceeded(services, Singleton<ILoggerProvider, FileLoggerProvider>());
+            var addedBlobLogger = TryAddEnumerableSucceeded(services, Singleton<ILoggerProvider, BlobLoggerProvider>());
 
-            services.TryAddEnumerable(Singleton<IOptionsChangeTokenSource<LoggerFilterOptions>>(
-                    new ConfigurationChangeTokenSource<LoggerFilterOptions>(config)));
+            if (addedFileLogger || addedBlobLogger)
+            {
+                services.AddSingleton(context);
+                services.AddSingleton<IOptionsChangeTokenSource<LoggerFilterOptions>>(
+                    new ConfigurationChangeTokenSource<LoggerFilterOptions>(config));
+            }
 
-            services.TryAddEnumerable(Singleton<IConfigureOptions<AzureBlobLoggerOptions>>(
-                new BlobLoggerConfigureOptions(config, context)));
-            services.TryAddEnumerable(Singleton<IOptionsChangeTokenSource<AzureBlobLoggerOptions>>(
-                new ConfigurationChangeTokenSource<AzureBlobLoggerOptions>(config)));
+            if (addedFileLogger)
+            {
+                services.AddSingleton<IConfigureOptions<LoggerFilterOptions>>(CreateFileFilterConfigureOptions(config));
+                services.AddSingleton<IConfigureOptions<AzureBlobLoggerOptions>>(new BlobLoggerConfigureOptions(config, context));
+                services.AddSingleton<IOptionsChangeTokenSource<AzureBlobLoggerOptions>>(
+                    new ConfigurationChangeTokenSource<AzureBlobLoggerOptions>(config));
+            }
 
-            services.TryAddEnumerable(Singleton<IConfigureOptions<AzureFileLoggerOptions>>(new FileLoggerConfigureOptions(config, context)));
-            services.TryAddEnumerable(Singleton<IOptionsChangeTokenSource<AzureFileLoggerOptions>>(
-                new ConfigurationChangeTokenSource<AzureFileLoggerOptions>(config)));
-
-            services.TryAddEnumerable(Singleton<IWebAppContext>(context));
-
-            // Only add the provider if we're in Azure WebApp. That cannot change once the apps started
-            services.TryAddEnumerable(Singleton<ILoggerProvider, FileLoggerProvider>());
-            services.TryAddEnumerable(Singleton<ILoggerProvider, BlobLoggerProvider>());
+            if (addedBlobLogger)
+            {
+                services.AddSingleton<IConfigureOptions<LoggerFilterOptions>>(CreateBlobFilterConfigureOptions(config));
+                services.AddSingleton<IConfigureOptions<AzureFileLoggerOptions>>(new FileLoggerConfigureOptions(config, context));
+                services.AddSingleton<IOptionsChangeTokenSource<AzureFileLoggerOptions>>(
+                    new ConfigurationChangeTokenSource<AzureFileLoggerOptions>(config));
+            }
 
             return builder;
+        }
+
+        private static bool TryAddEnumerableSucceeded(IServiceCollection collection, ServiceDescriptor descriptor)
+        {
+            var beforeCount = collection.Count;
+            collection.TryAddEnumerable(descriptor);
+            return beforeCount != collection.Count;
         }
 
         private static ConfigurationBasedLevelSwitcher CreateBlobFilterConfigureOptions(IConfiguration config)

--- a/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesLoggerFactoryExtensions.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Extensions.Logging
             var config = SiteConfigurationProvider.GetAzureLoggingConfiguration(context);
             var services = builder.Services;
 
-            var addedFileLogger = TryAddEnumerableSucceeded(services, Singleton<ILoggerProvider, FileLoggerProvider>());
-            var addedBlobLogger = TryAddEnumerableSucceeded(services, Singleton<ILoggerProvider, BlobLoggerProvider>());
+            var addedFileLogger = TryAddEnumerable(services, Singleton<ILoggerProvider, FileLoggerProvider>());
+            var addedBlobLogger = TryAddEnumerable(services, Singleton<ILoggerProvider, BlobLoggerProvider>());
 
             if (addedFileLogger || addedBlobLogger)
             {
@@ -51,23 +51,23 @@ namespace Microsoft.Extensions.Logging
             if (addedFileLogger)
             {
                 services.AddSingleton<IConfigureOptions<LoggerFilterOptions>>(CreateFileFilterConfigureOptions(config));
-                services.AddSingleton<IConfigureOptions<AzureBlobLoggerOptions>>(new BlobLoggerConfigureOptions(config, context));
-                services.AddSingleton<IOptionsChangeTokenSource<AzureBlobLoggerOptions>>(
-                    new ConfigurationChangeTokenSource<AzureBlobLoggerOptions>(config));
-            }
-
-            if (addedBlobLogger)
-            {
-                services.AddSingleton<IConfigureOptions<LoggerFilterOptions>>(CreateBlobFilterConfigureOptions(config));
                 services.AddSingleton<IConfigureOptions<AzureFileLoggerOptions>>(new FileLoggerConfigureOptions(config, context));
                 services.AddSingleton<IOptionsChangeTokenSource<AzureFileLoggerOptions>>(
                     new ConfigurationChangeTokenSource<AzureFileLoggerOptions>(config));
             }
 
+            if (addedBlobLogger)
+            {
+                services.AddSingleton<IConfigureOptions<LoggerFilterOptions>>(CreateBlobFilterConfigureOptions(config));
+                services.AddSingleton<IConfigureOptions<AzureBlobLoggerOptions>>(new BlobLoggerConfigureOptions(config, context));
+                services.AddSingleton<IOptionsChangeTokenSource<AzureBlobLoggerOptions>>(
+                    new ConfigurationChangeTokenSource<AzureBlobLoggerOptions>(config));
+            }
+
             return builder;
         }
 
-        private static bool TryAddEnumerableSucceeded(IServiceCollection collection, ServiceDescriptor descriptor)
+        private static bool TryAddEnumerable(IServiceCollection collection, ServiceDescriptor descriptor)
         {
             var beforeCount = collection.Count;
             collection.TryAddEnumerable(descriptor);

--- a/test/Microsoft.Extensions.Logging.AzureAppServices.Test/LoggerBuilderExtensionsTests.cs
+++ b/test/Microsoft.Extensions.Logging.AzureAppServices.Test/LoggerBuilderExtensionsTests.cs
@@ -1,22 +1,69 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.AzureAppServices.Internal;
+using Microsoft.Extensions.Options;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Extensions.Logging.AzureAppServices.Test
 {
     public class LoggerBuilderExtensionsTests
-{
+    {
+        private IWebAppContext _appContext;
+
+        public LoggerBuilderExtensionsTests()
+        {
+            var contextMock = new Mock<IWebAppContext>();
+            contextMock.SetupGet(c => c.IsRunningInAzureWebApp).Returns(true);
+            contextMock.SetupGet(c => c.HomeFolder).Returns(".");
+            _appContext = contextMock.Object;
+        }
+
         [Fact]
         public void BuilderExtensionAddsSingleSetOfServicesWhenCalledTwice()
         {
             var serviceCollection = new ServiceCollection();
-            serviceCollection.AddLogging(builder => builder.AddAzureWebAppDiagnostics());
+            serviceCollection.AddLogging(builder => builder.AddAzureWebAppDiagnostics(_appContext));
             var count = serviceCollection.Count;
-            serviceCollection.AddLogging(builder => builder.AddAzureWebAppDiagnostics());
+
+            Assert.NotEqual(0, count);
+
+            serviceCollection.AddLogging(builder => builder.AddAzureWebAppDiagnostics(_appContext));
 
             Assert.Equal(count, serviceCollection.Count);
+        }
+
+        [Fact]
+        public void BuilderExtensionAddsConfigurationChangeTokenSource()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddLogging(builder => builder.AddConfiguration(new ConfigurationBuilder().Build()));
+
+            // Tracking for main configuration
+            Assert.Equal(1, serviceCollection.Count(d => d.ServiceType == typeof(IOptionsChangeTokenSource<LoggerFilterOptions>)));
+
+            serviceCollection.AddLogging(builder => builder.AddAzureWebAppDiagnostics(_appContext));
+
+            // Make sure we add another config change token for azure diagnostic configuration
+            Assert.Equal(2, serviceCollection.Count(d => d.ServiceType == typeof(IOptionsChangeTokenSource<LoggerFilterOptions>)));
+        }
+
+        [Fact]
+        public void BuilderExtensionAddsIConfigureOptions()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddLogging(builder => builder.AddConfiguration(new ConfigurationBuilder().Build()));
+
+            // Tracking for main configuration
+            Assert.Equal(2, serviceCollection.Count(d => d.ServiceType == typeof(IConfigureOptions<LoggerFilterOptions>)));
+
+            serviceCollection.AddLogging(builder => builder.AddAzureWebAppDiagnostics(_appContext));
+
+            Assert.Equal(4, serviceCollection.Count(d => d.ServiceType == typeof(IConfigureOptions<LoggerFilterOptions>)));
         }
     }
 }


### PR DESCRIPTION
https://github.com/aspnet/AzureIntegration/issues/177

It was regressed by https://github.com/aspnet/Logging/pull/719, `loggerBuilder.AddConfiguration` adds some services that we call `TryAddEnumerable` on afterwards. It causes us not to add required configuration change token source.