### PR TITLE
Move AddProviderRegistration under lock

### DIFF
--- a/src/Microsoft.Extensions.Logging/LoggerFactory.cs
+++ b/src/Microsoft.Extensions.Logging/LoggerFactory.cs
@@ -89,10 +89,9 @@ namespace Microsoft.Extensions.Logging
                 throw new ObjectDisposedException(nameof(LoggerFactory));
             }
 
-            AddProviderRegistration(provider, dispose: true);
-
             lock (_sync)
             {
+                AddProviderRegistration(provider, dispose: true);
 
                 foreach (var logger in _loggers)
                 {


### PR DESCRIPTION
Resolves https://github.com/aspnet/Logging/issues/810

CreateLogger -> CreateLoggers is under lock https://github.com/aspnet/Logging/blob/073a98266684d9c643a02ac3f0f30712a35a9914/src/Microsoft.Extensions.Logging/LoggerFactory.cs#L70-L82

However... `AddProviderRegistration` in `AddProvider` isn't https://github.com/aspnet/Logging/blob/073a98266684d9c643a02ac3f0f30712a35a9914/src/Microsoft.Extensions.Logging/LoggerFactory.cs#L85-L94

Which will change the size of the `_providerRegistrations` List and cause `Index was outside the bounds of the array.` error as `_loggers` doesn't change size.

/cc @JamesNK @pakrym @davidfowl 

@muratg should this be 2.1?