### PR TITLE
Make NETStandard.Library PrivateAssets=All on Logging.Analyzers

### DIFF
--- a/src/Microsoft.Extensions.Logging.Analyzers/Microsoft.Extensions.Logging.Analyzers.csproj
+++ b/src/Microsoft.Extensions.Logging.Analyzers/Microsoft.Extensions.Logging.Analyzers.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="All" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
+    <PackageReference Update="NETStandard.Library" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Analyzers packages shouldn't have a dependency to NS.Library in their nuspec. This can affect the restore graph when we build aspnetcore projects because they get a transitive reference to NS.Library 1.6. 

FYI @muratg  - this package is "noship" so I consider this "infrastructure" since it only affects the way we build aspnetcore, but lmk if this shouldn't go into 2.1.



