### PR TITLE
Add Sharpbrake to the list of community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Community projects adapt _Microsoft.Extensions.Logging_ for use with different b
  * [Loggr](https://github.com/imobile3/Loggr.Extensions.Logging) - provider for the Loggr service
  * [NLog](https://github.com/NLog/NLog.Extensions.Logging) - provider for the NLog library
  * [Graylog](https://github.com/mattwcole/gelf-extensions-logging) - provider for the Graylog service
+ * [Sharpbrake](https://github.com/airbrake/sharpbrake#microsoftextensionslogging-integration) - provider for the Airbrake notifier
 
 ## Building from source
 


### PR DESCRIPTION
Sharpbrake is a C# notifier library for [Airbrake](https://airbrake.io/) - an online tool that provides error tracking for applications. The [Sharpbrake.Extensions.Logging](https://www.nuget.org/packages/Sharpbrake.Extensions.Logging) provider notifies the Airbrake dashboard of an error with the help of the Microsoft.Extensions.Logging API.