### PR TITLE
Initialize ITestOutputHelper earlier

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,20 +4,20 @@
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
     <InternalAspNetCoreSdkPackageVersion>2.2.0-preview1-17042</InternalAspNetCoreSdkPackageVersion>
-    <MicrosoftAspNetCoreAnalyzerTestingPackageVersion>2.2.0-preview1-34066</MicrosoftAspNetCoreAnalyzerTestingPackageVersion>
-    <MicrosoftAspNetCoreTestingPackageVersion>2.2.0-preview1-34066</MicrosoftAspNetCoreTestingPackageVersion>
+    <MicrosoftAspNetCoreAnalyzerTestingPackageVersion>2.2.0-preview1-34074</MicrosoftAspNetCoreAnalyzerTestingPackageVersion>
+    <MicrosoftAspNetCoreTestingPackageVersion>2.2.0-preview1-34074</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>2.8.0-beta3</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.2.0-preview1-34066</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
-    <MicrosoftExtensionsConfigurationBinderPackageVersion>2.2.0-preview1-34066</MicrosoftExtensionsConfigurationBinderPackageVersion>
-    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.2.0-preview1-34066</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
-    <MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>2.2.0-preview1-34066</MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>
-    <MicrosoftExtensionsConfigurationJsonPackageVersion>2.2.0-preview1-34066</MicrosoftExtensionsConfigurationJsonPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>2.2.0-preview1-34066</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionPackageVersion>2.2.0-preview1-34066</MicrosoftExtensionsDependencyInjectionPackageVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.2.0-preview1-34074</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
+    <MicrosoftExtensionsConfigurationBinderPackageVersion>2.2.0-preview1-34074</MicrosoftExtensionsConfigurationBinderPackageVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.2.0-preview1-34074</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
+    <MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>2.2.0-preview1-34074</MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>
+    <MicrosoftExtensionsConfigurationJsonPackageVersion>2.2.0-preview1-34074</MicrosoftExtensionsConfigurationJsonPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>2.2.0-preview1-34074</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionPackageVersion>2.2.0-preview1-34074</MicrosoftExtensionsDependencyInjectionPackageVersion>
     <MicrosoftExtensionsDependencyModelPackageVersion>2.2.0-preview1-26424-04</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>2.2.0-preview1-34066</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
-    <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>2.2.0-preview1-34066</MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
-    <MicrosoftExtensionsOptionsPackageVersion>2.2.0-preview1-34066</MicrosoftExtensionsOptionsPackageVersion>
+    <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>2.2.0-preview1-34074</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
+    <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>2.2.0-preview1-34074</MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
+    <MicrosoftExtensionsOptionsPackageVersion>2.2.0-preview1-34074</MicrosoftExtensionsOptionsPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.2.0-preview1-26424-04</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestInvoker.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestInvoker.cs
@@ -30,16 +30,6 @@ namespace Microsoft.Extensions.Logging.Testing
         {
         }
 
-        protected override Task BeforeTestMethodInvokedAsync()
-        {
-            if (_output != null)
-            {
-                _output.Initialize(MessageBus, Test);
-            }
-
-            return base.BeforeTestMethodInvokedAsync();
-        }
-
         protected override async Task AfterTestMethodInvokedAsync()
         {
             await base.AfterTestMethodInvokedAsync();
@@ -70,6 +60,7 @@ namespace Microsoft.Extensions.Logging.Testing
                 if (loggedTestClass.TestOutputHelper == null)
                 {
                     loggedTestClass.TestOutputHelper = _output = new TestOutputHelper();
+                    _output.Initialize(MessageBus, Test);
                 }
 
                 AssemblyTestLog

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/LoggedTestXunitTests.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/LoggedTestXunitTests.cs
@@ -130,12 +130,27 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
         }
     }
 
+    public class LoggedTestXunitInitializationTests : TestLoggedTest
+    {
+        [Fact]
+        public void ITestOutputHelperInitializedByDefault()
+        {
+            Assert.True(ITestOutputHelperIsInitialized);
+        }
+    }
+
     public class TestLoggedTest : LoggedTest
     {
         public bool SetupInvoked { get; private set; } = false;
+        public bool ITestOutputHelperIsInitialized { get; private set; } = false;
 
         public override void AdditionalSetup()
         {
+            try
+            {
+                TestOutputHelper.WriteLine("Test");
+                ITestOutputHelperIsInitialized = true;
+            } catch { }
             SetupInvoked = true;
         }
     }


### PR DESCRIPTION
Addresses #819. Though this is a good thing to fix, I don't think this is causing the exception you are seeing. 

The exceptions that might occur are caught here: https://github.com/aspnet/Logging/blob/dev/src/Microsoft.Extensions.Logging.Testing/XunitLoggerProvider.cs#L90-L100. This explains why our tests were working and were writing to file. However, I'm no longer sure why debugging is broken on your machine.