### PR TITLE
Add readonly to EventId and ConsoleColors structures

### DIFF
--- a/src/Microsoft.Extensions.Logging.Abstractions/EventId.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/EventId.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Extensions.Logging
 {
-    public struct EventId
+    public readonly struct EventId
     {
         public static implicit operator EventId(int i)
         {

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions.Internal;
 using Microsoft.Extensions.Logging.Console.Internal;
 
@@ -274,7 +273,7 @@ namespace Microsoft.Extensions.Logging.Console
             }
         }
 
-        private struct ConsoleColors
+        private readonly struct ConsoleColors
         {
             public ConsoleColors(ConsoleColor? foreground, ConsoleColor? background)
             {


### PR DESCRIPTION
Add readonly to `EventId` and `ConsoleColors` structures.