### PR TITLE
Change the file logger directory to use tfm

### DIFF
--- a/src/Microsoft.Extensions.Logging.Testing/LoggedTest/ILoggedTest.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/LoggedTest/ILoggedTest.cs
@@ -7,7 +7,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Extensions.Logging.Testing
 {
-    public interface ILoggedTest
+    public interface ILoggedTest : IDisposable
     {
         ILogger Logger { get; }
 

--- a/src/Microsoft.Extensions.Logging.Testing/LoggedTest/LoggedTestBase.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/LoggedTest/LoggedTestBase.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Extensions.Logging.Testing
 {
     public class LoggedTestBase : ILoggedTest
     {
+        private IDisposable _testLog;
+
         // Obsolete but keeping for back compat
         public LoggedTestBase(ITestOutputHelper output = null)
         {
@@ -53,7 +55,7 @@ namespace Microsoft.Extensions.Logging.Testing
                 ?? methodInfo.DeclaringType.Assembly.GetCustomAttribute<ShortClassNameAttribute>();
             var resolvedClassName = useShortClassName == null ? classType.FullName : classType.Name;
 
-            AssemblyTestLog
+            _testLog = AssemblyTestLog
                 .ForAssembly(classType.GetTypeInfo().Assembly)
                 .StartTestLog(
                     TestOutputHelper,
@@ -70,5 +72,7 @@ namespace Microsoft.Extensions.Logging.Testing
             LoggerFactory = loggerFactory;
             Logger = loggerFactory.CreateLogger(classType);
         }
+
+        public virtual void Dispose() => _testLog.Dispose();
     }
 }

--- a/src/Microsoft.Extensions.Logging.Testing/TestFrameworkFileLoggerAttribute.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/TestFrameworkFileLoggerAttribute.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+    public class TestFrameworkFileLoggerAttribute : Attribute
+    {
+        public TestFrameworkFileLoggerAttribute(string tfm, string baseDirectory)
+        {
+            TFM = tfm;
+            BaseDirectory = baseDirectory;
+        }
+
+        public string TFM { get; }
+        public string BaseDirectory { get; }
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/build/Microsoft.Extensions.Logging.Testing.props
+++ b/src/Microsoft.Extensions.Logging.Testing/build/Microsoft.Extensions.Logging.Testing.props
@@ -1,8 +1,21 @@
 ﻿<Project>
-  <ItemGroup>
-    <AssemblyAttribute Include="Xunit.TestFramework">
-      <_Parameter1>Microsoft.Extensions.Logging.Testing.LoggedTestFramework</_Parameter1>
-      <_Parameter2>Microsoft.Extensions.Logging.Testing</_Parameter2>
-    </AssemblyAttribute>
-  </ItemGroup>
+  <PropertyGroup>
+    <LoggingTestingFileLoggingDirectory Condition="'$(LoggingTestingFileLoggingDirectory)' == '' AND '$(RepositoryRoot)' != ''">$(RepositoryRoot)artifacts\logs\</LoggingTestingFileLoggingDirectory>
+  </PropertyGroup>
+
+  <Target Name="SetLoggingTestingAssemblyAttributes"
+    BeforeTargets="GetAssemblyAttributes"
+    Condition="'$(GenerateLoggingTestingAssemblyAttributes)' != 'false'">
+    <ItemGroup>
+      <AssemblyAttribute Include="Xunit.TestFramework">
+        <_Parameter1>Microsoft.Extensions.Logging.Testing.LoggedTestFramework</_Parameter1>
+        <_Parameter2>Microsoft.Extensions.Logging.Testing</_Parameter2>
+      </AssemblyAttribute>
+
+      <AssemblyAttribute Include="Microsoft.Extensions.Logging.Testing.TestFrameworkFileLoggerAttribute">
+        <_Parameter1>$(TargetFramework)</_Parameter1>
+        <_Parameter2>$(LoggingTestingFileLoggingDirectory)</_Parameter2>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xunit;
@@ -15,7 +14,9 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
 {
     public class AssemblyTestLogTests : LoggedTest
     {
-        private static readonly Assembly ThisAssembly = typeof(AssemblyTestLog).GetTypeInfo().Assembly;
+        private static readonly Assembly ThisAssembly = typeof(AssemblyTestLogTests).GetTypeInfo().Assembly;
+        private static readonly string ThisAssemblyName = ThisAssembly.GetName().Name;
+        private static readonly string TFM = new DirectoryInfo(AppContext.BaseDirectory).Name;
 
         [Fact]
         public void FullClassNameUsedWhenShortClassNameAttributeNotSpecified()
@@ -35,7 +36,7 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
         public void TestLogWritesToITestOutputHelper()
         {
             var output = new TestTestOutputHelper();
-            var assemblyLog = AssemblyTestLog.Create("NonExistant.Test.Assembly", baseDirectory: null);
+            var assemblyLog = AssemblyTestLog.Create(ThisAssemblyName, baseDirectory: null);
 
             using (assemblyLog.StartTestLog(output, "NonExistant.Test.Class", out var loggerFactory))
             {
@@ -61,7 +62,7 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
             {
                 var illegalTestName = "Testing-https://localhost:5000";
                 var escapedTestName = "Testing-https_localhost_5000";
-                using (var testAssemblyLog = AssemblyTestLog.Create("FakeTestAssembly", baseDirectory: tempDir))
+                using (var testAssemblyLog = AssemblyTestLog.Create(ThisAssemblyName, baseDirectory: tempDir))
                 using (testAssemblyLog.StartTestLog(output: null, className: "FakeTestAssembly.FakeTestClass", loggerFactory: out var testLoggerFactory, minLogLevel: LogLevel.Trace, resolvedTestName: out var resolvedTestname, testName: illegalTestName))
                 {
                     Assert.Equal(escapedTestName, resolvedTestname);
@@ -76,11 +77,11 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
                 // but it's also testing the test logging facility. So this is pretty meta ;)
                 var logger = LoggerFactory.CreateLogger("Test");
 
-                using (var testAssemblyLog = AssemblyTestLog.Create("FakeTestAssembly", tempDir))
+                using (var testAssemblyLog = AssemblyTestLog.Create(ThisAssemblyName, tempDir))
                 {
                     logger.LogInformation("Created test log in {baseDirectory}", tempDir);
 
-                    using (testAssemblyLog.StartTestLog(output: null, className: "FakeTestAssembly.FakeTestClass", loggerFactory: out var testLoggerFactory, minLogLevel: LogLevel.Trace, testName: "FakeTestName"))
+                    using (testAssemblyLog.StartTestLog(output: null, className: $"{ThisAssemblyName}.FakeTestClass", loggerFactory: out var testLoggerFactory, minLogLevel: LogLevel.Trace, testName: "FakeTestName"))
                     {
                         var testLogger = testLoggerFactory.CreateLogger("TestLogger");
                         testLogger.LogInformation("Information!");
@@ -90,8 +91,8 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
 
                 logger.LogInformation("Finished test log in {baseDirectory}", tempDir);
 
-                var globalLogPath = Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription.TrimStart('.'), "global.log");
-                var testLog = Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription.TrimStart('.'), "FakeTestClass", $"FakeTestName.log");
+                var globalLogPath = Path.Combine(tempDir, ThisAssemblyName, TFM, "global.log");
+                var testLog = Path.Combine(tempDir, ThisAssemblyName, TFM, "FakeTestClass", "FakeTestName.log");
 
                 Assert.True(File.Exists(globalLogPath), $"Expected global log file {globalLogPath} to exist");
                 Assert.True(File.Exists(testLog), $"Expected test log file {testLog} to exist");
@@ -100,7 +101,7 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
                 var testLogContent = MakeConsistent(File.ReadAllText(testLog));
 
                 Assert.Equal(
-@"[TIMESTAMP] [GlobalTestLog] [Information] Global Test Logging initialized. Set the 'ASPNETCORE_TEST_LOG_DIR' Environment Variable in order to create log files on disk.
+@"[TIMESTAMP] [GlobalTestLog] [Information] Global Test Logging initialized. Set the 'ASPNETCORE_TEST_LOG_DIR' Environment Variable to set the locations of files on disk.
 [OFFSET] [GlobalTestLog] [Information] Starting test ""FakeTestName""
 [OFFSET] [GlobalTestLog] [Information] Finished test ""FakeTestName"" in DURATION
 ", globalLogContent, ignoreLineEndingDifferences: true);
@@ -118,18 +119,18 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
             {
                 var longTestName = new string('0', 50) + new string('1', 50) + new string('2', 50) + new string('3', 50) + new string('4', 50);
                 var logger = LoggerFactory.CreateLogger("Test");
-                using (var testAssemblyLog = AssemblyTestLog.Create("FakeTestAssembly", tempDir))
+                using (var testAssemblyLog = AssemblyTestLog.Create(ThisAssemblyName, tempDir))
                 {
                     logger.LogInformation("Created test log in {baseDirectory}", tempDir);
 
-                    using (testAssemblyLog.StartTestLog(output: null, className: "FakeTestAssembly.FakeTestClass", loggerFactory: out var testLoggerFactory, minLogLevel: LogLevel.Trace, testName: longTestName))
+                    using (testAssemblyLog.StartTestLog(output: null, className: $"{ThisAssemblyName}.FakeTestClass", loggerFactory: out var testLoggerFactory, minLogLevel: LogLevel.Trace, testName: longTestName))
                     {
                         testLoggerFactory.CreateLogger("TestLogger").LogInformation("Information!");
                     }
                 }
                 logger.LogInformation("Finished test log in {baseDirectory}", tempDir);
 
-                var testLogFiles = new DirectoryInfo(Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription.TrimStart('.'), "FakeTestClass")).EnumerateFiles();
+                var testLogFiles = new DirectoryInfo(Path.Combine(tempDir, ThisAssemblyName, TFM, "FakeTestClass")).EnumerateFiles();
                 var testLog = Assert.Single(testLogFiles);
                 var testFileName = Path.GetFileNameWithoutExtension(testLog.Name);
 
@@ -144,13 +145,13 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
             RunTestLogFunctionalTest((tempDir) =>
             {
                 var logger = LoggerFactory.CreateLogger("Test");
-                using (var testAssemblyLog = AssemblyTestLog.Create("FakeTestAssembly", tempDir))
+                using (var testAssemblyLog = AssemblyTestLog.Create(ThisAssemblyName, tempDir))
                 {
                     logger.LogInformation("Created test log in {baseDirectory}", tempDir);
 
                     for (var i = 0; i < 10; i++)
                     {
-                        using (testAssemblyLog.StartTestLog(output: null, className: "FakeTestAssembly.FakeTestClass", loggerFactory: out var testLoggerFactory, minLogLevel: LogLevel.Trace, testName: "FakeTestName"))
+                        using (testAssemblyLog.StartTestLog(output: null, className: $"{ThisAssemblyName}.FakeTestClass", loggerFactory: out var testLoggerFactory, minLogLevel: LogLevel.Trace, testName: "FakeTestName"))
                         {
                             testLoggerFactory.CreateLogger("TestLogger").LogInformation("Information!");
                         }
@@ -159,12 +160,12 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
                 logger.LogInformation("Finished test log in {baseDirectory}", tempDir);
 
                 // The first log file exists
-                Assert.True(File.Exists(Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription.TrimStart('.'), "FakeTestClass", $"FakeTestName.log")));
+                Assert.True(File.Exists(Path.Combine(tempDir, ThisAssemblyName, TFM, "FakeTestClass", "FakeTestName.log")));
 
                 // Subsequent files exist
                 for (var i = 0; i < 9; i++)
                 {
-                    Assert.True(File.Exists(Path.Combine(tempDir, "FakeTestAssembly", RuntimeInformation.FrameworkDescription.TrimStart('.'), "FakeTestClass", $"FakeTestName.{i}.log")));
+                    Assert.True(File.Exists(Path.Combine(tempDir, ThisAssemblyName, TFM, "FakeTestClass", $"FakeTestName.{i}.log")));
                 }
             });
 


### PR DESCRIPTION
Old Path: Logging\artifacts\logs\Microsoft.Extensions.Logging.Testing.Tests\NET Framework 4.7.2650.0\AssemblyTestLogTests\ForAssembly_ReturnsSameInstanceForSameAssembly.log
New Path: Logging\artifacts\logs\Microsoft.Extensions.Logging.Testing.Tests\net461\AssemblyTestLogTests\ForAssembly_ReturnsSameInstanceForSameAssembly.log