### PR TITLE
Add opt-out for file logging and add error when FileLoggerAttribute is missing

### DIFF
--- a/src/Microsoft.Extensions.Logging.Testing/TestFrameworkFileLoggerAttribute.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/TestFrameworkFileLoggerAttribute.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Logging.Testing
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
     public class TestFrameworkFileLoggerAttribute : Attribute
     {
-        public TestFrameworkFileLoggerAttribute(string tfm, string baseDirectory)
+        public TestFrameworkFileLoggerAttribute(string tfm, string baseDirectory = null)
         {
             TFM = tfm;
             BaseDirectory = baseDirectory;

--- a/src/Microsoft.Extensions.Logging.Testing/build/Microsoft.Extensions.Logging.Testing.props
+++ b/src/Microsoft.Extensions.Logging.Testing/build/Microsoft.Extensions.Logging.Testing.props
@@ -1,5 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
+    <!-- Priority: LoggingTestingDisableFileLogging > LoggingTestingFileLoggingDirectory > ASPNETCORE_TEST_LOG_DIR > Default location -->
+    <LoggingTestingFileLoggingDirectory Condition="'$(LoggingTestingFileLoggingDirectory)' == ''">$(ASPNETCORE_TEST_LOG_DIR)</LoggingTestingFileLoggingDirectory>
     <LoggingTestingFileLoggingDirectory Condition="'$(LoggingTestingFileLoggingDirectory)' == '' AND '$(RepositoryRoot)' != ''">$(RepositoryRoot)artifacts\logs\</LoggingTestingFileLoggingDirectory>
   </PropertyGroup>
 
@@ -14,7 +16,7 @@
 
       <AssemblyAttribute Include="Microsoft.Extensions.Logging.Testing.TestFrameworkFileLoggerAttribute">
         <_Parameter1>$(TargetFramework)</_Parameter1>
-        <_Parameter2>$(LoggingTestingFileLoggingDirectory)</_Parameter2>
+        <_Parameter2 Condition="'$(LoggingTestingDisableFileLogging)' != 'true'">$(LoggingTestingFileLoggingDirectory)</_Parameter2>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
                 var testLogContent = MakeConsistent(File.ReadAllText(testLog));
 
                 Assert.Equal(
-@"[TIMESTAMP] [GlobalTestLog] [Information] Global Test Logging initialized. Set the 'ASPNETCORE_TEST_LOG_DIR' Environment Variable to set the locations of files on disk.
+@"[TIMESTAMP] [GlobalTestLog] [Information] Global Test Logging initialized. Configure the output directory via 'LoggingTestingFileLoggingDirectory' MSBuild property or set 'LoggingTestingDisableFileLogging' to 'true' to disable file logging.
 [OFFSET] [GlobalTestLog] [Information] Starting test ""FakeTestName""
 [OFFSET] [GlobalTestLog] [Information] Finished test ""FakeTestName"" in DURATION
 ", globalLogContent, ignoreLineEndingDifferences: true);


### PR DESCRIPTION
Couldn't find a way to ensure references to Logging.Testing are marked with PrivateAssets="None" so I'm opting to add a more explicit error instead. Also adding an environment variable to turn off file logging which is now on by default and there's no way of turning it off.