### PR TITLE
Timestamp and ITestOutputHelper fixes

### DIFF
--- a/src/Microsoft.Extensions.Logging.Testing/XunitLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/XunitLoggerFactoryExtensions.cs
@@ -22,6 +22,12 @@ namespace Microsoft.Extensions.Logging
             return builder;
         }
 
+        public static ILoggingBuilder AddXunit(this ILoggingBuilder builder, ITestOutputHelper output, LogLevel minLevel, DateTimeOffset? logStart)
+        {
+            builder.Services.AddSingleton<ILoggerProvider>(new XunitLoggerProvider(output, minLevel, logStart));
+            return builder;
+        }
+
         public static ILoggerFactory AddXunit(this ILoggerFactory loggerFactory, ITestOutputHelper output)
         {
             loggerFactory.AddProvider(new XunitLoggerProvider(output));
@@ -31,6 +37,12 @@ namespace Microsoft.Extensions.Logging
         public static ILoggerFactory AddXunit(this ILoggerFactory loggerFactory, ITestOutputHelper output, LogLevel minLevel)
         {
             loggerFactory.AddProvider(new XunitLoggerProvider(output, minLevel));
+            return loggerFactory;
+        }
+
+        public static ILoggerFactory AddXunit(this ILoggerFactory loggerFactory, ITestOutputHelper output, LogLevel minLevel, DateTimeOffset? logStart)
+        {
+            loggerFactory.AddProvider(new XunitLoggerProvider(output, minLevel, logStart));
             return loggerFactory;
         }
     }

--- a/src/Microsoft.Extensions.Logging.Testing/XunitLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/XunitLoggerProvider.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Extensions.Logging.Testing
     {
         private readonly ITestOutputHelper _output;
         private readonly LogLevel _minLevel;
+        private readonly DateTimeOffset? _logStart;
 
         public XunitLoggerProvider(ITestOutputHelper output)
             : this(output, LogLevel.Trace)
@@ -19,14 +20,20 @@ namespace Microsoft.Extensions.Logging.Testing
         }
 
         public XunitLoggerProvider(ITestOutputHelper output, LogLevel minLevel)
+            : this(output, minLevel, null)
+        {
+        }
+
+        public XunitLoggerProvider(ITestOutputHelper output, LogLevel minLevel, DateTimeOffset? logStart)
         {
             _output = output;
             _minLevel = minLevel;
+            _logStart = logStart;
         }
 
         public ILogger CreateLogger(string categoryName)
         {
-            return new XunitLogger(_output, categoryName, _minLevel);
+            return new XunitLogger(_output, categoryName, _minLevel, _logStart);
         }
 
         public void Dispose()
@@ -40,12 +47,14 @@ namespace Microsoft.Extensions.Logging.Testing
         private readonly string _category;
         private readonly LogLevel _minLogLevel;
         private readonly ITestOutputHelper _output;
+        private DateTimeOffset? _logStart;
 
-        public XunitLogger(ITestOutputHelper output, string category, LogLevel minLogLevel)
+        public XunitLogger(ITestOutputHelper output, string category, LogLevel minLogLevel, DateTimeOffset? logStart)
         {
             _minLogLevel = minLogLevel;
             _category = category;
             _output = output;
+            _logStart = logStart;
         }
 
         public void Log<TState>(
@@ -59,7 +68,8 @@ namespace Microsoft.Extensions.Logging.Testing
             // Buffer the message into a single string in order to avoid shearing the message when running across multiple threads.
             var messageBuilder = new StringBuilder();
 
-            var timestamp = DateTime.Now.ToString("s");
+            var timestamp = _logStart.HasValue ? $"{(DateTimeOffset.UtcNow - _logStart.Value).TotalSeconds.ToString("N3")}s" : DateTimeOffset.UtcNow.ToString("s");
+
             var firstLinePrefix = $"| [{timestamp}] {_category} {logLevel}: ";
             var lines = formatter(state, exception).Split(NewLineChars, StringSplitOptions.RemoveEmptyEntries);
             messageBuilder.AppendLine(firstLinePrefix + lines.FirstOrDefault() ?? string.Empty);

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
@@ -50,9 +50,9 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
             var testLogContent = MakeConsistent(output.Output);
 
             Assert.Equal(
-@"[TIMESTAMP] TestLifetime Information: Starting test TestLogWritesToITestOutputHelper
-[TIMESTAMP] TestLogger Information: Information!
-[TIMESTAMP] TestLifetime Information: Finished test TestLogWritesToITestOutputHelper in DURATION
+@"[OFFSET] TestLifetime Information: Starting test TestLogWritesToITestOutputHelper at TIMESTAMP
+[OFFSET] TestLogger Information: Information!
+[OFFSET] TestLifetime Information: Finished test TestLogWritesToITestOutputHelper in DURATION
 ", testLogContent, ignoreLineEndingDifferences: true);
         }
 
@@ -101,12 +101,12 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
                 var testLogContent = MakeConsistent(File.ReadAllText(testLog));
 
                 Assert.Equal(
-@"[TIMESTAMP] [GlobalTestLog] [Information] Global Test Logging initialized. Configure the output directory via 'LoggingTestingFileLoggingDirectory' MSBuild property or set 'LoggingTestingDisableFileLogging' to 'true' to disable file logging.
+@"[OFFSET] [GlobalTestLog] [Information] Global Test Logging initialized at ""TIMESTAMP"". Configure the output directory via 'LoggingTestingFileLoggingDirectory' MSBuild property or set 'LoggingTestingDisableFileLogging' to 'true' to disable file logging.
 [OFFSET] [GlobalTestLog] [Information] Starting test ""FakeTestName""
 [OFFSET] [GlobalTestLog] [Information] Finished test ""FakeTestName"" in DURATION
 ", globalLogContent, ignoreLineEndingDifferences: true);
                 Assert.Equal(
-@"[TIMESTAMP] [TestLifetime] [Information] Starting test ""FakeTestName""
+@"[OFFSET] [TestLifetime] [Information] Starting test ""FakeTestName"" at ""TIMESTAMP""
 [OFFSET] [TestLogger] [Information] Information!
 [OFFSET] [TestLogger] [Verbose] Trace!
 [OFFSET] [TestLifetime] [Information] Finished test ""FakeTestName"" in DURATION


### PR DESCRIPTION
- Standardize timestamp to use offsets in xunit output.
- Return the TestOutputHelper's output back to xunit so it doesn't go to /dev/null. 