### PR TITLE
Remove redundant if condition from ConsoleLogger

### DIFF
--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
@@ -168,19 +168,16 @@ namespace Microsoft.Extensions.Logging.Console
                 logBuilder.AppendLine(exception.ToString());
             }
 
-            if (logBuilder.Length > 0)
+            var hasLevel = !string.IsNullOrEmpty(logLevelString);
+            // Queue log message
+            _queueProcessor.EnqueueMessage(new LogMessageEntry()
             {
-                var hasLevel = !string.IsNullOrEmpty(logLevelString);
-                // Queue log message
-                _queueProcessor.EnqueueMessage(new LogMessageEntry()
-                {
-                    Message = logBuilder.ToString(),
-                    MessageColor = DefaultConsoleColor,
-                    LevelString = hasLevel ? logLevelString : null,
-                    LevelBackground = hasLevel ? logLevelColors.Background : null,
-                    LevelForeground = hasLevel ? logLevelColors.Foreground : null
-                });
-            }
+                Message = logBuilder.ToString(),
+                MessageColor = DefaultConsoleColor,
+                LevelString = hasLevel ? logLevelString : null,
+                LevelBackground = hasLevel ? logLevelColors.Background : null,
+                LevelForeground = hasLevel ? logLevelColors.Foreground : null
+            });
 
             logBuilder.Clear();
             if (logBuilder.Capacity > 1024)


### PR DESCRIPTION
Remove [redundant `if` condition](https://github.com/aspnet/Logging/blob/bdd33cdcfd6345c01f820ae0726c49b2c3bc4939/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs#L171) that checks for the `StringBuilder` being empty, when it always contains [at least 6 characters](https://github.com/aspnet/Logging/blob/bdd33cdcfd6345c01f820ae0726c49b2c3bc4939/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs#L143-L147) (`':'`, `' '`, `'['`, `'{digit}'`, `']'`, `'\n'`).