### PR TITLE
Add retry capability to tests

### DIFF
--- a/src/Microsoft.Extensions.Logging.Testing/LoggedTest/LoggedTestBase.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/LoggedTest/LoggedTestBase.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Extensions.Logging.Testing
         // Internal for testing
         internal string ResolvedTestClassName { get; set; }
 
+        internal RetryContext RetryContext { get; set; }
+
         public ILogger Logger { get; set; }
 
         public ILoggerFactory LoggerFactory { get; set; }
@@ -48,7 +50,7 @@ namespace Microsoft.Extensions.Logging.Testing
             TestOutputHelper = testOutputHelper;
 
             var classType = GetType();
-            var logLevelAttribute = methodInfo.GetCustomAttribute<LogLevelAttribute>() as LogLevelAttribute;
+            var logLevelAttribute = methodInfo.GetCustomAttribute<LogLevelAttribute>();
             var testName = testMethodArguments.Aggregate(methodInfo.Name, (a, b) => $"{a}-{(b ?? "null")}");
 
             var useShortClassName = methodInfo.DeclaringType.GetCustomAttribute<ShortClassNameAttribute>()

--- a/src/Microsoft.Extensions.Logging.Testing/RetryContext.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/RetryContext.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    public class RetryContext
+    {
+        internal int Limit { get; set; }
+
+        internal object TestClassInstance { get; set; }
+
+        internal string Reason { get; set; }
+
+        internal int CurrentIteration { get; set; }
+    }
+}

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestRunner.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/LoggedTestRunner.cs
@@ -5,8 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Testing.xunit;
+using Microsoft.Extensions.Logging.Testing;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -45,7 +48,83 @@ namespace Microsoft.Extensions.Logging.Testing
         protected override Task<decimal> InvokeTestMethodAsync(ExceptionAggregator aggregator)
             => InvokeTestMethodAsync(aggregator, null);
 
-        private Task<decimal> InvokeTestMethodAsync(ExceptionAggregator aggregator, ITestOutputHelper output)
-            => new LoggedTestInvoker(Test, MessageBus, TestClass, ConstructorArguments, TestMethod, TestMethodArguments, BeforeAfterAttributes, aggregator, CancellationTokenSource, output).RunAsync();
+        private async Task<decimal> InvokeTestMethodAsync(ExceptionAggregator aggregator, ITestOutputHelper output)
+        {
+            var retryAttribute = GetRetryAttribute(TestMethod);
+            if (!typeof(LoggedTestBase).IsAssignableFrom(TestClass) || retryAttribute == null)
+            {
+                return await new LoggedTestInvoker(Test, MessageBus, TestClass, ConstructorArguments, TestMethod, TestMethodArguments, BeforeAfterAttributes, aggregator, CancellationTokenSource, output, null).RunAsync();
+            }
+
+            var retryPredicateMethodName = retryAttribute.RetryPredicateName;
+            var retryPredicateMethod = TestClass.GetMethod(retryPredicateMethodName,
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static,
+                null,
+                new Type[] { typeof(Exception) },
+                null)
+                ?? throw new InvalidOperationException($"No valid static retry predicate method {retryPredicateMethodName} was found on the type {TestClass.FullName}.");
+
+            if (retryPredicateMethod.ReturnType != typeof(bool))
+            {
+                throw new InvalidOperationException($"Retry predicate method {retryPredicateMethodName} on {TestClass.FullName} does not return bool.");
+            }
+
+            var retryContext = new RetryContext()
+            {
+                Limit = retryAttribute.RetryLimit,
+                Reason = retryAttribute.RetryReason,
+            };
+
+            var retryAggregator = new ExceptionAggregator();
+            var loggedTestInvoker = new LoggedTestInvoker(Test, MessageBus, TestClass, ConstructorArguments, TestMethod, TestMethodArguments, BeforeAfterAttributes, retryAggregator, CancellationTokenSource, output, retryContext);
+            var totalTime = 0.0M;
+
+            do
+            {
+                retryAggregator.Clear();
+                totalTime += await loggedTestInvoker.RunAsync();
+                retryContext.CurrentIteration++;
+            }
+            while (retryAggregator.HasExceptions
+                && retryContext.CurrentIteration < retryContext.Limit
+                && (retryPredicateMethod.IsStatic
+                    ? (bool)retryPredicateMethod.Invoke(null, new object[] { retryAggregator.ToException() })
+                    : (bool)retryPredicateMethod.Invoke(retryContext.TestClassInstance, new object[] { retryAggregator.ToException() }))
+                );
+
+            aggregator.Aggregate(retryAggregator);
+            return totalTime;
+        }
+
+
+        private RetryTestAttribute GetRetryAttribute(MethodInfo methodInfo)
+        {
+            var os = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? OperatingSystems.MacOSX
+                : RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? OperatingSystems.Windows
+                : OperatingSystems.Linux;
+
+            var attributeCandidate = methodInfo.GetCustomAttribute<RetryTestAttribute>();
+
+            if (attributeCandidate != null && (attributeCandidate.OperatingSystems & os) != 0)
+            {
+                return attributeCandidate;
+            }
+
+            attributeCandidate = methodInfo.DeclaringType.GetCustomAttribute<RetryTestAttribute>();
+
+            if (attributeCandidate != null && (attributeCandidate.OperatingSystems & os) != 0)
+            {
+                return attributeCandidate;
+            }
+
+            attributeCandidate = methodInfo.DeclaringType.Assembly.GetCustomAttribute<RetryTestAttribute>();
+
+            if (attributeCandidate != null && (attributeCandidate.OperatingSystems & os) != 0)
+            {
+                return attributeCandidate;
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Microsoft.Extensions.Logging.Testing/Xunit/RetryTestAttribute.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/Xunit/RetryTestAttribute.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel;
+using Microsoft.AspNetCore.Testing.xunit;
+
+namespace Microsoft.Extensions.Logging.Testing
+{
+    /// <summary>
+    /// WARNING: This attribute should only be used on well understood flaky test failures caused by external issues and should be removed once the underlying issues have been resolved.
+    /// This is not intended to be a long term solution to ensure passing of flaky tests but instead a method to improve test reliability without reducing coverage.
+    /// Issues should be filed to remove these attributes from affected tests as soon as the underlying issue is fixed.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
+    public class RetryTestAttribute : Attribute
+    {
+        /// <summary>
+        /// WARNING: This attribute should only be used on well understood flaky test failures caused by external issues and should be removed once the underlying issues have been resolved.
+        /// This is not intended to be a long term solution to ensure passing of flaky tests but instead a method to improve test reliability without reducing coverage.
+        /// Issues should be filed to remove these attributes from affected tests as soon as the underlying issue is fixed.
+        /// </summary>
+        /// <param name="retryPredicateName">The predicate of the format Func&lt;Exception,bool&gt; that is used to determine if the test should be retried</param>
+        /// <param name="retryReason">The reason for retrying the test</param>
+        /// <param name="retryLimit">The number of retries to attempt before failing the test, for most purposes this this should be kept at 2 to avoid excessive retries.</param>
+        public RetryTestAttribute(string retryPredicateName, string retryReason, int retryLimit = 2)
+            : this(retryPredicateName, retryReason, OperatingSystems.Linux | OperatingSystems.MacOSX | OperatingSystems.Windows, retryLimit) { }
+
+        /// <summary>
+        /// WARNING: This attribute should only be used on well understood flaky test failures caused by external issuesand should be removed once the underlying issues have been resolved.
+        /// This is not intended to be a long term solution to ensure passing of flaky tests but instead a method to improve test reliability without reducing coverage.
+        /// Issues should be filed to remove these attributes from affected tests as soon as the underlying issue is fixed.
+        /// </summary>
+        /// <param name="operatingSystems">The os(es) this retry should be attempted on.</param>
+        /// <param name="retryPredicateName">The predicate of the format Func&lt;Exception,bool&gt; that is used to determine if the test should be retried</param>
+        /// <param name="retryReason">The reason for retrying the test</param>
+        /// <param name="retryLimit">The number of retries to attempt before failing the test, for most purposes this this should be kept at 2 to avoid excessive retries.</param>
+        public RetryTestAttribute(string retryPredicateName, string retryReason, OperatingSystems operatingSystems, int retryLimit = 2)
+        {
+            if (string.IsNullOrEmpty(retryPredicateName))
+            {
+                throw new ArgumentNullException(nameof(RetryPredicateName), "A valid non-empty predicate method name must be provided.");
+            }
+            if (string.IsNullOrEmpty(retryReason))
+            {
+                throw new ArgumentNullException(nameof(retryReason), "A valid non-empty reason for retrying the test must be provided.");
+            }
+            if (retryLimit < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(retryLimit), retryLimit, "Retry count must be positive.");
+            }
+
+            OperatingSystems = operatingSystems;
+            RetryPredicateName = retryPredicateName;
+            RetryReason = retryReason;
+            RetryLimit = retryLimit;
+        }
+
+        public string RetryPredicateName { get; }
+
+        public string RetryReason { get; }
+
+        public int RetryLimit { get; }
+
+        public OperatingSystems OperatingSystems { get; }
+    }
+}

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/LoggedTestXunitRetryTests.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/LoggedTestXunitRetryTests.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Testing.xunit;
+using Xunit;
+
+namespace Microsoft.Extensions.Logging.Testing.Tests
+{
+    [RetryTest(nameof(RetryAllPredicate), "sample reason")]
+    public class LoggedTestXunitRetryTests : LoggedTest
+    {
+        [Fact]
+        public void CompletesWithoutRetryOnSuccess()
+        {
+            Assert.Equal(2, RetryContext.Limit);
+
+            // This assert would fail on the second run
+            Assert.Equal(0, RetryContext.CurrentIteration);
+        }
+
+        [Fact]
+        public void RetriesUntilSuccess()
+        {
+            // This assert will fail the first time but pass on the second
+            Assert.Equal(1, RetryContext.CurrentIteration);
+
+            // This assert will ensure a message is logged for retried tests.
+            Assert.Equal(1, TestSink.Writes.Count);
+            var loggedMessage = TestSink.Writes.ToArray()[0];
+            Assert.Equal(LogLevel.Warning, loggedMessage.LogLevel);
+            Assert.Equal($"{nameof(RetriesUntilSuccess)} failed and retry conditions are met, re-executing. The reason for failure is sample reason.", loggedMessage.Message);
+        }
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Windows)]
+        [RetryTest(nameof(RetryAllPredicate), "sample reason", OperatingSystems.Windows, 3)]
+        public void RetryCountNotOverridenWhenOSDoesNotMatch()
+        {
+            Assert.Equal(2, RetryContext.Limit);
+        }
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
+        [RetryTest(nameof(RetryAllPredicate), "sample reason", OperatingSystems.Windows, 3)]
+        public void RetryCountOverridenWhenOSMatches()
+        {
+            Assert.Equal(3, RetryContext.Limit);
+        }
+
+        [Fact]
+        [RetryTest(nameof(RetryInvalidOperationExceptionPredicate), "sample reason")]
+        public void RetryIfPredicateIsTrue()
+        {
+            if (RetryContext.CurrentIteration == 0)
+            {
+                Logger.LogWarning("Throw on first iteration");
+                throw new Exception();
+            }
+
+            // This assert will ensure a message is logged for retried tests.
+            Assert.Equal(1, TestSink.Writes.Count);
+            var loggedMessage = TestSink.Writes.ToArray()[0];
+            Assert.Equal(LogLevel.Warning, loggedMessage.LogLevel);
+            Assert.Equal($"{nameof(RetryIfPredicateIsTrue)} failed and retry conditions are met, re-executing. The reason for failure is sample reason.", loggedMessage.Message);
+        }
+
+        // Static predicates are valid
+        private static bool RetryAllPredicate(Exception e)
+            => true;
+
+        // Instance predicates are valid
+        private bool RetryInvalidOperationExceptionPredicate(Exception e)
+            => TestSink.Writes.Any(m => m.Message.Contains("Throw on first iteration"));
+    }
+
+    [RetryTest(nameof(RetryAllPredicate), "sample reason")]
+    public class LoggedTestXunitRetryConstructorTest : LoggedTest
+    {
+        private static int _constructorInvocationCount;
+
+        public LoggedTestXunitRetryConstructorTest()
+        {
+            _constructorInvocationCount++;
+        }
+
+        [Fact]
+        public void RetriesUntilSuccess()
+        {
+            // The constructor is invoked before the test method but the current iteration is updated after
+            Assert.Equal(_constructorInvocationCount, RetryContext.CurrentIteration + 1);
+
+            // This assert will fail the first time but pass on the second
+            Assert.Equal(1, RetryContext.CurrentIteration);
+        }
+
+        private static bool RetryAllPredicate(Exception e)
+            => true;
+    }
+}


### PR DESCRIPTION
I'm piggy-backing off the infrastructure we have in place for LoggedTest since that is much simpler than creating its own set of discoverers, runners and invokers. It would also make it hard to handle a test class that's both logged and retried. The trade-off is that all retried tests must also be logged and I think that's reasonable since most of the tests would be functional tests that should be logged anyway.

Backgound:

We have some functional tests in Kestrel that's flaky on macOS due to underlying issues in the kernel. We don't want to disable all affected tests since that would dramatically reduce our coverage. In these cases, we would want to retry tests. This should only be allowed on tests with well known diagnosis and when all other possible fixes has been implemented.

This will help us resolve flaky test issues such as https://github.com/aspnet/KestrelHttpServer/issues/2907.