### PR TITLE
Fixes the description for the property FileName

### DIFF
--- a/src/Microsoft.Extensions.Logging.AzureAppServices/AzureFileLoggerOptions.cs
+++ b/src/Microsoft.Extensions.Logging.AzureAppServices/AzureFileLoggerOptions.cs
@@ -51,8 +51,8 @@ namespace Microsoft.Extensions.Logging.AzureAppServices
         }
 
         /// <summary>
-        /// Gets or sets a string representing the name of the file used to store the logging information.
-        /// The current date, in the format YYYYMMDD will be added after the given filename.
+        /// Gets or sets a string representing the prefix of the file name used to store the logging information.
+        /// The current date, in the format YYYYMMDD will be added after the given value.
         /// Defaults to <c>diagnostics-</c>.
         /// </summary>
         public string FileName

--- a/src/Microsoft.Extensions.Logging.AzureAppServices/AzureFileLoggerOptions.cs
+++ b/src/Microsoft.Extensions.Logging.AzureAppServices/AzureFileLoggerOptions.cs
@@ -51,8 +51,8 @@ namespace Microsoft.Extensions.Logging.AzureAppServices
         }
 
         /// <summary>
-        /// Gets or sets a strictly positive value representing the maximum retained file count or null for no limit.
-        /// Defaults to <c>2</c>.
+        /// Gets or sets a string representing the name of the file used to store the logging information.
+        /// Defaults to <c>diagnostics-</c>.
         /// </summary>
         public string FileName
         {

--- a/src/Microsoft.Extensions.Logging.AzureAppServices/AzureFileLoggerOptions.cs
+++ b/src/Microsoft.Extensions.Logging.AzureAppServices/AzureFileLoggerOptions.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Extensions.Logging.AzureAppServices
 
         /// <summary>
         /// Gets or sets a string representing the name of the file used to store the logging information.
+        /// The current date, in the format YYYYMMDD will be added after the given filename.
         /// Defaults to <c>diagnostics-</c>.
         /// </summary>
         public string FileName


### PR DESCRIPTION
The property FileName was the same as the one for `RetainedFileCountLimit`, this commits changes to something that describes this property more correctly.

Fixes #863