### PR TITLE
Fix EventSource logger for cases where listener exists before app starts

### DIFF
--- a/src/Microsoft.Extensions.Logging.EventSource/LoggingEventSource.cs
+++ b/src/Microsoft.Extensions.Logging.EventSource/LoggingEventSource.cs
@@ -105,12 +105,14 @@ namespace Microsoft.Extensions.Logging.EventSource
         /// </summary>
         internal static readonly LoggingEventSource Instance = new LoggingEventSource();
 
-        private LoggerFilterRule[] _filterSpec;
+        // It's important to have _filterSpec initialization here rather than in ctor
+        // base ctor might call OnEventCommand and set filter spec
+        // having assingment in ctor would overwrite the value
+        private LoggerFilterRule[] _filterSpec = new LoggerFilterRule[0];
         private CancellationTokenSource _cancellationTokenSource;
 
         private LoggingEventSource() : base(EventSourceSettings.EtwSelfDescribingEventFormat)
         {
-            _filterSpec = new LoggerFilterRule[0];
         }
 
         /// <summary>
@@ -207,7 +209,7 @@ namespace Microsoft.Extensions.Logging.EventSource
         private void FireChangeToken()
         {
             var tcs = Interlocked.Exchange(ref _cancellationTokenSource, null);
-            tcs.Cancel();
+            tcs?.Cancel();
         }
 
          /// <summary>

--- a/test/Microsoft.Extensions.Logging.EventSource.Test/EventSourceLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.EventSource.Test/EventSourceLoggerTest.cs
@@ -114,6 +114,37 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Fact]
+        public void Logs_AsExpected_WithDefaults_EnabledEarly()
+        {
+            using (var testListener = new TestEventListener())
+            {
+                var listenerSettings = new TestEventListener.ListenerSettings();
+                listenerSettings.Keywords = (EventKeywords)(-1);
+                listenerSettings.FilterSpec = null;
+                listenerSettings.Level = default(EventLevel);
+                testListener.EnableEvents(listenerSettings);
+
+                LogStuff(CreateLoggerFactory());
+
+                // Use testListener.DumpEvents as necessary to examine what exactly the listener received
+
+                VerifyEvents(testListener,
+                    "E1FM", "E1MSG", "E1JS",
+                    // Second event is omitted because default LogLevel == Debug
+                    "E3FM", "E3MSG", "E3JS",
+                    "OuterScopeJsonStart",
+                    "E4FM", "E4MSG", "E4JS",
+                    "E5FM", "E5MSG", "E5JS",
+                    "InnerScopeJsonStart",
+                    "E6FM", "E6MSG", "E6JS",
+                    "InnerScopeJsonStop",
+                    "E7FM", "E7MSG", "E7JS",
+                    "OuterScopeJsonStop",
+                    "E8FM", "E8MSG", "E8JS");
+            }
+        }
+
+        [Fact]
         public void Logs_Nothing_IfNotEnabled()
         {
             using (var testListener = new TestEventListener())
@@ -487,6 +518,8 @@ namespace Microsoft.Extensions.Logging.Test
 
             private System.Diagnostics.Tracing.EventSource _loggingEventSource;
 
+            private ListenerSettings _enableWhenCreated;
+
             public TestEventListener()
             {
                 Events = new List<string>();
@@ -496,13 +529,25 @@ namespace Microsoft.Extensions.Logging.Test
 
             public void EnableEvents(ListenerSettings settings)
             {
+                if (_loggingEventSource != null)
+                {
+                    EnableEvents(_loggingEventSource, settings.Level, settings.Keywords,  GetArguments(settings));
+                }
+                else
+                {
+                    _enableWhenCreated = settings;
+                }
+            }
+
+            private static Dictionary<string, string> GetArguments(ListenerSettings settings)
+            {
                 var args = new Dictionary<string, string>();
                 if (!string.IsNullOrEmpty(settings.FilterSpec))
                 {
                     args["FilterSpecs"] = settings.FilterSpec;
                 }
 
-                EnableEvents(_loggingEventSource, settings.Level, settings.Keywords, args);
+                return args;
             }
 
             protected override void OnEventSourceCreated(System.Diagnostics.Tracing.EventSource eventSource)
@@ -510,6 +555,12 @@ namespace Microsoft.Extensions.Logging.Test
                 if (eventSource.Name == "Microsoft-Extensions-Logging")
                 {
                     _loggingEventSource = eventSource;
+                }
+
+                if (_enableWhenCreated != null)
+                {
+                    EnableEvents(_loggingEventSource, _enableWhenCreated.Level, _enableWhenCreated.Keywords, GetArguments(_enableWhenCreated));
+                    _enableWhenCreated = null;
                 }
             }
 


### PR DESCRIPTION
Found some issues with the logger when doing E2E testing with perfview.