### PR TITLE
Change azure logger defaults

### DIFF
--- a/src/Microsoft.Extensions.Logging.AzureAppServices/AzureBlobLoggerOptions.cs
+++ b/src/Microsoft.Extensions.Logging.AzureAppServices/AzureBlobLoggerOptions.cs
@@ -11,11 +11,6 @@ namespace Microsoft.Extensions.Logging.AzureAppServices
     /// </summary>
     public class AzureBlobLoggerOptions: BatchingLoggerOptions
     {
-        public AzureBlobLoggerOptions()
-        {
-            BatchSize = 32;
-        }
-
         private string _blobName = "applicationLog.txt";
 
         /// <summary>

--- a/src/Microsoft.Extensions.Logging.AzureAppServices/Internal/BatchingLoggerOptions.cs
+++ b/src/Microsoft.Extensions.Logging.AzureAppServices/Internal/BatchingLoggerOptions.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Extensions.Logging.AzureAppServices.Internal
 {
     public class BatchingLoggerOptions
     {
-        private int? _batchSize = 32;
-        private int? _backgroundQueueSize;
+        private int? _batchSize;
+        private int? _backgroundQueueSize = 1000;
         private TimeSpan _flushPeriod = TimeSpan.FromSeconds(1);
 
         /// <summary>
@@ -30,7 +30,7 @@ namespace Microsoft.Extensions.Logging.AzureAppServices.Internal
         /// <summary>
         /// Gets or sets the maximum size of the background log message queue or null for no limit.
         /// After maximum queue size is reached log event sink would start blocking.
-        /// Defaults to <c>null</c>.
+        /// Defaults to <c>1000</c>.
         /// </summary>
         public int? BackgroundQueueSize
         {
@@ -48,6 +48,7 @@ namespace Microsoft.Extensions.Logging.AzureAppServices.Internal
         /// <summary>
         /// Gets or sets a maximum number of events to include in a single batch or null for no limit.
         /// </summary>
+        /// Defaults to <c>null</c>.
         public int? BatchSize
         {
             get { return _batchSize; }


### PR DESCRIPTION
Fixes: https://github.com/aspnet/Logging/issues/821

We had it backwards with limited batch size and unlimited queue.

Queue size is now 1000 and batch size is unlimited to unload logs as fast as possible.