### PR TITLE
Expose logging directory and resolved test name so we can write addit…

### DIFF
--- a/src/Microsoft.Extensions.Logging.Testing/LoggedTest/LoggedTestBase.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/LoggedTest/LoggedTestBase.cs
@@ -21,12 +21,13 @@ namespace Microsoft.Extensions.Logging.Testing
         }
 
         // Internal for testing
-        internal string ResolvedTestMethodName { get; set; }
-
-        // Internal for testing
         internal string ResolvedTestClassName { get; set; }
 
         internal RetryContext RetryContext { get; set; }
+
+        public string ResolvedLogOutputDirectory { get; set; }
+
+        public string ResolvedTestMethodName { get; set; }
 
         public ILogger Logger { get; set; }
 
@@ -55,21 +56,22 @@ namespace Microsoft.Extensions.Logging.Testing
 
             var useShortClassName = methodInfo.DeclaringType.GetCustomAttribute<ShortClassNameAttribute>()
                 ?? methodInfo.DeclaringType.Assembly.GetCustomAttribute<ShortClassNameAttribute>();
-            var resolvedClassName = useShortClassName == null ? classType.FullName : classType.Name;
+            // internal for testing
+            ResolvedTestClassName = useShortClassName == null ? classType.FullName : classType.Name;
 
             _testLog = AssemblyTestLog
                 .ForAssembly(classType.GetTypeInfo().Assembly)
                 .StartTestLog(
                     TestOutputHelper,
-                    resolvedClassName,
+                    ResolvedTestClassName,
                     out var loggerFactory,
                     logLevelAttribute?.LogLevel ?? LogLevel.Trace,
                     out var resolvedTestName,
+                    out var logOutputDirectory,
                     testName);
 
-            // internal for testing
+            ResolvedLogOutputDirectory = logOutputDirectory;
             ResolvedTestMethodName = resolvedTestName;
-            ResolvedTestClassName = resolvedClassName;
 
             LoggerFactory = loggerFactory;
             Logger = loggerFactory.CreateLogger(classType);

--- a/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
+++ b/test/Microsoft.Extensions.Logging.Testing.Tests/AssemblyTestLogTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.Logging.Testing.Tests
                 var illegalTestName = "Testing-https://localhost:5000";
                 var escapedTestName = "Testing-https_localhost_5000";
                 using (var testAssemblyLog = AssemblyTestLog.Create(ThisAssemblyName, baseDirectory: tempDir))
-                using (testAssemblyLog.StartTestLog(output: null, className: "FakeTestAssembly.FakeTestClass", loggerFactory: out var testLoggerFactory, minLogLevel: LogLevel.Trace, resolvedTestName: out var resolvedTestname, testName: illegalTestName))
+                using (testAssemblyLog.StartTestLog(output: null, className: "FakeTestAssembly.FakeTestClass", loggerFactory: out var testLoggerFactory, minLogLevel: LogLevel.Trace, resolvedTestName: out var resolvedTestname, out var _, testName: illegalTestName))
                 {
                     Assert.Equal(escapedTestName, resolvedTestname);
                 }


### PR DESCRIPTION
…ional logs

This would help with https://github.com/aspnet/KestrelHttpServer/issues/2880. There I needed to direct Chrome to write logs to a specified location. I could alternatively direct chrome to write to a temporary file and them write the contents to TestLogger but network and shutdown logs are very verbose and it's better to keep them in their own files.