### PR TITLE
Implementing IDisposable on WindowsEventLog #860

### DIFF
--- a/src/Microsoft.Extensions.Logging.EventLog/WindowsEventLog.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/WindowsEventLog.cs
@@ -1,12 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging.EventLog.Internal;
 
 namespace Microsoft.Extensions.Logging.EventLog
 {
-    public class WindowsEventLog : IEventLog
+    public class WindowsEventLog : IEventLog, IDisposable
     {
         // https://msdn.microsoft.com/EN-US/library/windows/desktop/aa363679.aspx
         private const int MaximumMessageSize = 31839;
@@ -29,6 +30,11 @@ namespace Microsoft.Extensions.Logging.EventLog
         public void WriteEntry(string message, EventLogEntryType type, int eventID, short category)
         {
             DiagnosticsEventLog.WriteEvent(new EventInstance(eventID, category, type), message);
+        }
+
+        public void Dispose()
+        {
+            DiagnosticsEventLog.Dispose();
         }
     }
 }


### PR DESCRIPTION
Implements the IDisposable interface on WindowsEventLog to dispose the instance of EventLog created on the constructor. Cf. #860. 