### PR TITLE
Fix lazy formatter creation condition

### DIFF
--- a/src/Microsoft.Extensions.Logging.Abstractions/Internal/FormattedLogValues.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/Internal/FormattedLogValues.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.Logging.Internal
 
         public FormattedLogValues(string format, params object[] values)
         {
-            if (values?.Length != 0 && format != null)
+            if (values != null && values.Length != 0 && format != null)
             {
                 if (_count >= MaxCachedFormatters)
                 {


### PR DESCRIPTION
Fixes: https://github.com/aspnet/Logging/issues/824

We have existing tests for passing null to FormattedLogValues:
https://github.com/aspnet/Logging/blob/master/test/Microsoft.Extensions.Logging.Test/FormattedLogValuesTest.cs

