### PR TITLE
Decrease logging overhead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ project.lock.json
 .build/
 .testPublish/
 global.json
+BenchmarkDotNet.Artifacts/

--- a/Logging.sln
+++ b/Logging.sln
@@ -60,6 +60,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Loggin
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Logging.Analyzer.Test", "test\Microsoft.Extensions.Logging.Analyzer.Test\Microsoft.Extensions.Logging.Analyzer.Test.csproj", "{C0391E46-FD04-4D52-BE40-1F21CE83E037}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{0BE8FABE-0FE7-4DF1-ABDE-27BB0D86F881}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Logging.Performance", "benchmarks\Logging.Performance\Logging.Performance.csproj", "{67B77ED1-8827-4088-8724-4A0AF4351FB7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -134,6 +138,10 @@ Global
 		{C0391E46-FD04-4D52-BE40-1F21CE83E037}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C0391E46-FD04-4D52-BE40-1F21CE83E037}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C0391E46-FD04-4D52-BE40-1F21CE83E037}.Release|Any CPU.Build.0 = Release|Any CPU
+		{67B77ED1-8827-4088-8724-4A0AF4351FB7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{67B77ED1-8827-4088-8724-4A0AF4351FB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{67B77ED1-8827-4088-8724-4A0AF4351FB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{67B77ED1-8827-4088-8724-4A0AF4351FB7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -156,6 +164,7 @@ Global
 		{6D921637-507E-4CDC-8C5F-C3D6B62D118C} = {699DB330-0095-4266-B7B0-3EAB3710CA49}
 		{99DF369F-40A4-4088-8308-1C361B59DF4E} = {699DB330-0095-4266-B7B0-3EAB3710CA49}
 		{C0391E46-FD04-4D52-BE40-1F21CE83E037} = {09920C51-6220-4D8D-94DC-E70C13446187}
+		{67B77ED1-8827-4088-8724-4A0AF4351FB7} = {0BE8FABE-0FE7-4DF1-ABDE-27BB0D86F881}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BA58E3CA-3A01-46A7-B57F-FD7A188EDC79}

--- a/benchmarks/Logging.Performance/LogValuesBenchmarks.cs
+++ b/benchmarks/Logging.Performance/LogValuesBenchmarks.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/benchmarks/Logging.Performance/LogValuesBenchmarks.cs
+++ b/benchmarks/Logging.Performance/LogValuesBenchmarks.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Extensions.Logging.Performance
+{
+    [AspNetCoreBenchmark]
+    public class FormattingBenchmarks : LoggingBenchmarkBase
+    {
+        private ILogger _logger;
+
+        [Benchmark]
+        public void TwoArguments()
+        {
+            TwoArgumentErrorMessage(_logger, 1, "string", Exception);
+        }
+
+        //[Benchmark(Baseline = true)]
+        //public void NoArguments()
+        //{
+        //    NoArgumentErrorMessage(_logger, Exception);
+        //}
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton<ILoggerProvider, LoggerProvider<MessageFormattingLogger>>();
+
+            _logger = services.BuildServiceProvider().GetService<ILoggerFactory>().CreateLogger("Logger");
+        }
+
+        public class MessageFormattingLogger: ILogger
+        {
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                formatter(state, exception);
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return true;
+            }
+
+            public IDisposable BeginScope<TState>(TState state)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/benchmarks/Logging.Performance/LogValuesBenchmarks.cs
+++ b/benchmarks/Logging.Performance/LogValuesBenchmarks.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Extensions.Logging.Performance
             TwoArgumentErrorMessage(_logger, 1, "string", Exception);
         }
 
-        //[Benchmark(Baseline = true)]
-        //public void NoArguments()
-        //{
-        //    NoArgumentErrorMessage(_logger, Exception);
-        //}
+        [Benchmark(Baseline = true)]
+        public void NoArguments()
+        {
+            NoArgumentErrorMessage(_logger, Exception);
+        }
 
         [GlobalSetup]
         public void Setup()

--- a/benchmarks/Logging.Performance/Logging.Performance.csproj
+++ b/benchmarks/Logging.Performance/Logging.Performance.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RootNamespace>Microsoft.Extensions.DependencyInjection.Performance</RootNamespace>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Extensions.Logging\Microsoft.Extensions.Logging.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.BenchmarkRunner.Sources" Version="$(MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/Logging.Performance/Logging.Performance.csproj
+++ b/benchmarks/Logging.Performance/Logging.Performance.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RootNamespace>Microsoft.Extensions.DependencyInjection.Performance</RootNamespace>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>Microsoft.Extensions.Logging.Performance</RootNamespace>
     <OutputType>Exe</OutputType>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/benchmarks/Logging.Performance/LoggingBenchmarkBase.cs
+++ b/benchmarks/Logging.Performance/LoggingBenchmarkBase.cs
@@ -10,8 +10,9 @@ namespace Microsoft.Extensions.Logging.Performance
         protected static readonly Action<ILogger, Exception> NoArgumentTraceMessage = LoggerMessage.Define(LogLevel.Trace, 0, "Message");
         protected static readonly Action<ILogger, Exception> NoArgumentErrorMessage = LoggerMessage.Define(LogLevel.Error, 0, "Message");
 
-        protected static readonly Action<ILogger,  int, string, Exception> TwoArgumentTraceMessage = LoggerMessage.Define<int, string>(LogLevel.Trace, 0, "Message {Argument1} {Argument2}");
-        protected static readonly Action<ILogger,  int, string, Exception> TwoArgumentErrorMessage = LoggerMessage.Define<int, string>(LogLevel.Error, 0, "Message {Argument1} {Argument2}");
+        protected static readonly Action<ILogger, int, string, Exception> TwoArgumentTraceMessage = LoggerMessage.Define<int, string>(LogLevel.Trace, 0, "Message {Argument1} {Argument2}");
+        protected static readonly Action<ILogger, int, string, Exception> TwoArgumentErrorMessage = LoggerMessage.Define<int, string>(LogLevel.Error, 0, "Message {Argument1} {Argument2}");
+
         protected static Exception Exception = ((Func<Exception>)(() => {
             try
             {

--- a/benchmarks/Logging.Performance/LoggingBenchmarkBase.cs
+++ b/benchmarks/Logging.Performance/LoggingBenchmarkBase.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.Logging.Performance
+{
+    public class LoggingBenchmarkBase
+    {
+        protected static readonly Action<ILogger, Exception> NoArgumentTraceMessage = LoggerMessage.Define(LogLevel.Trace, 0, "Message");
+        protected static readonly Action<ILogger, Exception> NoArgumentErrorMessage = LoggerMessage.Define(LogLevel.Error, 0, "Message");
+
+        protected static readonly Action<ILogger,  int, string, Exception> TwoArgumentTraceMessage = LoggerMessage.Define<int, string>(LogLevel.Trace, 0, "Message {Argument1} {Argument2}");
+        protected static readonly Action<ILogger,  int, string, Exception> TwoArgumentErrorMessage = LoggerMessage.Define<int, string>(LogLevel.Error, 0, "Message {Argument1} {Argument2}");
+        protected static Exception Exception = ((Func<Exception>)(() => {
+            try
+            {
+                throw new Exception();
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+        }))();
+
+        public class LoggerProvider<T>: ILoggerProvider
+            where T: ILogger, new()
+        {
+            public void Dispose()
+            {
+            }
+
+            public ILogger CreateLogger(string categoryName)
+            {
+                return new T();
+            }
+        }
+    }
+}

--- a/benchmarks/Logging.Performance/LoggingOverheadBenchmark.cs
+++ b/benchmarks/Logging.Performance/LoggingOverheadBenchmark.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Extensions.Logging.Performance
+{
+    [AspNetCoreBenchmark]
+    public class LoggingOverheadBenchmark: LoggingBenchmarkBase
+    {
+        private ILogger _logger;
+
+        [Benchmark]
+        public void NoArguments_FilteredByLevel()
+        {
+            _logger.LogTrace(Exception, "Message");
+        }
+
+        // Baseline as this is the fastest way to do nothing
+        [Benchmark(Baseline = true)]
+        public void NoArguments_DefineMessage_FilteredByLevel()
+        {
+            NoArgumentTraceMessage(_logger, Exception);
+        }
+
+        [Benchmark]
+        public void NoArguments()
+        {
+            _logger.LogError(Exception, "Message");
+        }
+
+        [Benchmark]
+        public void NoArguments_DefineMessage()
+        {
+            NoArgumentErrorMessage(_logger, Exception);
+        }
+
+        [Benchmark]
+        public void TwoArguments()
+        {
+            _logger.LogError(Exception, "Message {Argument1} {Argument2}", 1, "string");
+        }
+
+        [Benchmark]
+        public void TwoArguments_FilteredByLevel()
+        {
+            _logger.LogTrace(Exception, "Message {Argument1} {Argument2}", 1, "string");
+        }
+
+        [Benchmark]
+        public void TwoArguments_DefineMessage()
+        {
+            TwoArgumentErrorMessage(_logger, 1, "string", Exception);
+        }
+
+        [Benchmark]
+        public void TwoArguments_DefineMessage_FilteredByLevel()
+        {
+            TwoArgumentTraceMessage(_logger, 1, "string", Exception);
+        }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton<ILoggerProvider, LoggerProvider<NoopLogger>>();
+            _logger = services.BuildServiceProvider().GetService<ILoggerFactory>().CreateLogger("Logger");
+        }
+    }
+
+    public class NoopLogger : ILogger
+    {
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            return null;
+        }
+    }
+}

--- a/benchmarks/Logging.Performance/ScopesOverheadBenchmark.cs
+++ b/benchmarks/Logging.Performance/ScopesOverheadBenchmark.cs
@@ -1,52 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.Logging.Performance
 {
-    [AspNetCoreBenchmark]
-    public class LogValuesBenchmarks : LoggingBenchmarkBase
-    {
-        private ILogger _logger;
-
-        [Benchmark]
-        public void NotFiltered_InsideScope()
-        {
-            TwoArgumentErrorMessage(_logger, 1, "string", Exception);
-        }
-
-        [GlobalSetup]
-        public void Setup()
-        {
-            var services = new ServiceCollection();
-            services.AddLogging();
-            services.AddSingleton<ILoggerProvider, LoggerProvider<MessageFormattingLogger>>();
-
-            _logger = services.BuildServiceProvider().GetService<ILoggerFactory>().CreateLogger("Logger");
-        }
-
-        public class MessageFormattingLogger: ILogger
-        {
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
-            {
-                formatter(state, exception);
-            }
-
-            public bool IsEnabled(LogLevel logLevel)
-            {
-                return true;
-            }
-
-            public IDisposable BeginScope<TState>(TState state)
-            {
-                return null;
-            }
-        }
-    }
-
     [AspNetCoreBenchmark]
     public class ScopesOverheadBenchmark: LoggingBenchmarkBase
     {

--- a/benchmarks/Logging.Performance/ScopesOverheadBenchmark.cs
+++ b/benchmarks/Logging.Performance/ScopesOverheadBenchmark.cs
@@ -11,11 +11,8 @@ namespace Microsoft.Extensions.Logging.Performance
     {
         private ILogger _logger;
 
-        //[Params(true, false)]
+        [Params(true, false)]
         public bool HasISupportLoggingScopeLogger { get; set; } = false;
-
-        //[Params(true, false)]
-        public bool CaptureScopes { get; set; } = false;
 
         // Baseline as this is the fastest way to do nothing
         [Benchmark(Baseline = true)]
@@ -61,8 +58,6 @@ namespace Microsoft.Extensions.Logging.Performance
             {
                 services.AddSingleton<ILoggerProvider, LoggerProvider<NoopLogger>>();
             }
-
-            services.Configure<LoggerFilterOptions>(options => options.CaptureScopes = CaptureScopes);
 
             _logger = services.BuildServiceProvider().GetService<ILoggerFactory>().CreateLogger("Logger");
         }

--- a/benchmarks/Logging.Performance/ScopesOverheadBenchmark.cs
+++ b/benchmarks/Logging.Performance/ScopesOverheadBenchmark.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Extensions.Logging.Performance
+{
+    [AspNetCoreBenchmark]
+    public class LogValuesBenchmarks : LoggingBenchmarkBase
+    {
+        private ILogger _logger;
+
+        [Benchmark]
+        public void NotFiltered_InsideScope()
+        {
+            TwoArgumentErrorMessage(_logger, 1, "string", Exception);
+        }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddSingleton<ILoggerProvider, LoggerProvider<MessageFormattingLogger>>();
+
+            _logger = services.BuildServiceProvider().GetService<ILoggerFactory>().CreateLogger("Logger");
+        }
+
+        public class MessageFormattingLogger: ILogger
+        {
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                formatter(state, exception);
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return true;
+            }
+
+            public IDisposable BeginScope<TState>(TState state)
+            {
+                return null;
+            }
+        }
+    }
+
+    [AspNetCoreBenchmark]
+    public class ScopesOverheadBenchmark: LoggingBenchmarkBase
+    {
+        private ILogger _logger;
+
+        //[Params(true, false)]
+        public bool HasISupportLoggingScopeLogger { get; set; } = false;
+
+        //[Params(true, false)]
+        public bool CaptureScopes { get; set; } = false;
+
+        // Baseline as this is the fastest way to do nothing
+        [Benchmark(Baseline = true)]
+        public void FilteredByLevel()
+        {
+            TwoArgumentTraceMessage(_logger, 1, "string", Exception);
+        }
+
+        [Benchmark]
+        public void FilteredByLevel_InsideScope()
+        {
+            using (_logger.BeginScope("string"))
+            {
+                TwoArgumentTraceMessage(_logger, 1, "string", Exception);
+            }
+        }
+
+        [Benchmark]
+        public void NotFiltered()
+        {
+            TwoArgumentErrorMessage(_logger, 1, "string", Exception);
+        }
+
+        [Benchmark]
+        public void NotFiltered_InsideScope()
+        {
+            using (_logger.BeginScope("string"))
+            {
+                TwoArgumentErrorMessage(_logger, 1, "string", Exception);
+            }
+        }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            if (HasISupportLoggingScopeLogger)
+            {
+                services.AddSingleton<ILoggerProvider, LoggerProviderWithISupportExternalScope>();
+            }
+            else
+            {
+                services.AddSingleton<ILoggerProvider, LoggerProvider<NoopLogger>>();
+            }
+
+            services.Configure<LoggerFilterOptions>(options => options.CaptureScopes = CaptureScopes);
+
+            _logger = services.BuildServiceProvider().GetService<ILoggerFactory>().CreateLogger("Logger");
+        }
+
+        class LoggerProviderWithISupportExternalScope: LoggerProvider<NoopLogger>, ISupportExternalScope
+        {
+            public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+            {
+            }
+        }
+    }
+}

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -35,7 +35,7 @@
     <XunitAbstractionsPackageVersion>2.0.1</XunitAbstractionsPackageVersion>
     <XunitAssertPackageVersion>2.3.1</XunitAssertPackageVersion>
     <XunitExtensibilityExecutionPackageVersion>2.3.1</XunitExtensibilityExecutionPackageVersion>
-    <XunitPackageVersion>2.4.0</XunitPackageVersion>
+    <XunitPackageVersion>2.3.1</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.4.0</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions: Pinned" />

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,8 +3,10 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
+    <BenchmarkDotNetPackageVersion>0.10.13</BenchmarkDotNetPackageVersion>
     <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20181004.7</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreAnalyzerTestingPackageVersion>3.0.0-alpha1-10584</MicrosoftAspNetCoreAnalyzerTestingPackageVersion>
+    <MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>3.0.0-alpha1-10584</MicrosoftAspNetCoreBenchmarkRunnerSourcesPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-alpha1-10584</MicrosoftAspNetCoreTestingPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>2.8.0</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>3.0.0-alpha1-10584</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
@@ -33,7 +35,7 @@
     <XunitAbstractionsPackageVersion>2.0.1</XunitAbstractionsPackageVersion>
     <XunitAssertPackageVersion>2.3.1</XunitAssertPackageVersion>
     <XunitExtensibilityExecutionPackageVersion>2.3.1</XunitExtensibilityExecutionPackageVersion>
-    <XunitPackageVersion>2.3.1</XunitPackageVersion>
+    <XunitPackageVersion>2.4.0</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.4.0</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions: Pinned" />

--- a/src/Microsoft.Extensions.Logging.Abstractions/Internal/FormattedLogValues.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/Internal/FormattedLogValues.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Logging.Internal
     /// LogValues to enable formatting options supported by <see cref="M:string.Format"/>.
     /// This also enables using {NamedformatItem} in the format string.
     /// </summary>
-    public class FormattedLogValues : IReadOnlyList<KeyValuePair<string, object>>
+    public readonly struct FormattedLogValues : IReadOnlyList<KeyValuePair<string, object>>
     {
         internal const int MaxCachedFormatters = 1024;
         private const string NullFormat = "[null]";
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.Logging.Internal
 
         public FormattedLogValues(string format, params object[] values)
         {
-            if (values?.Length != 0 && format != null)
+            if (values != null && values.Length != 0 && format != null)
             {
                 if (_count >= MaxCachedFormatters)
                 {
@@ -45,6 +45,10 @@ namespace Microsoft.Extensions.Logging.Internal
                         return new LogValuesFormatter(f);
                     });
                 }
+            }
+            else
+            {
+                _formatter = null;
             }
 
             _originalMessage = format ?? NullFormat;

--- a/src/Microsoft.Extensions.Logging.Abstractions/Internal/LogValuesFormatter.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/Internal/LogValuesFormatter.cs
@@ -119,30 +119,31 @@ namespace Microsoft.Extensions.Logging.Internal
             {
                 for (int i = 0; i < values.Length; i++)
                 {
-                    var value = values[i];
-
-                    if (value == null)
-                    {
-                        values[i] = NullValue;
-                        continue;
-                    }
-
-                    // since 'string' implements IEnumerable, special case it
-                    if (value is string)
-                    {
-                        continue;
-                    }
-
-                    // if the value implements IEnumerable, build a comma separated string.
-                    var enumerable = value as IEnumerable;
-                    if (enumerable != null)
-                    {
-                        values[i] = string.Join(", ", enumerable.Cast<object>().Select(o => o ?? NullValue));
-                    }
+                    values[i] = FormatArgument(values[i]);
                 }
             }
 
             return string.Format(CultureInfo.InvariantCulture, _format, values ?? EmptyArray);
+        }
+
+        internal string Format()
+        {
+            return _format;
+        }
+
+        internal string Format(object arg0)
+        {
+            return string.Format(CultureInfo.InvariantCulture, _format, FormatArgument(arg0));
+        }
+
+        internal string Format(object arg0, object arg1)
+        {
+            return string.Format(CultureInfo.InvariantCulture, _format, FormatArgument(arg0), FormatArgument(arg1));
+        }
+
+        internal string Format(object arg0, object arg1, object arg2)
+        {
+            return string.Format(CultureInfo.InvariantCulture, _format, FormatArgument(arg0), FormatArgument(arg1), FormatArgument(arg2));
         }
 
         public KeyValuePair<string, object> GetValue(object[] values, int index)
@@ -171,5 +172,29 @@ namespace Microsoft.Extensions.Logging.Internal
             valueArray[valueArray.Length - 1] = new KeyValuePair<string, object>("{OriginalFormat}", OriginalFormat);
             return valueArray;
         }
+
+        private object FormatArgument(object value)
+        {
+            if (value == null)
+            {
+                return NullValue;
+            }
+
+            // since 'string' implements IEnumerable, special case it
+            if (value is string)
+            {
+                return value;
+            }
+
+            // if the value implements IEnumerable, build a comma separated string.
+            var enumerable = value as IEnumerable;
+            if (enumerable != null)
+            {
+                return string.Join(", ", enumerable.Cast<object>().Select(o => o ?? NullValue));
+            }
+
+            return value;
+        }
+
     }
 }

--- a/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/LoggerExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Logging
     /// </summary>
     public static class LoggerExtensions
     {
-        private static readonly Func<object, Exception, string> _messageFormatter = MessageFormatter;
+        private static readonly Func<FormattedLogValues, Exception, string> _messageFormatter = MessageFormatter;
 
         //------------------------------------------DEBUG------------------------------------------//
 
@@ -425,7 +425,7 @@ namespace Microsoft.Extensions.Logging
 
         //------------------------------------------HELPERS------------------------------------------//
 
-        private static string MessageFormatter(object state, Exception error)
+        private static string MessageFormatter(FormattedLogValues state, Exception error)
         {
             return state.ToString();
         }

--- a/src/Microsoft.Extensions.Logging.Abstractions/LoggerMessage.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/LoggerMessage.cs
@@ -245,11 +245,9 @@ namespace Microsoft.Extensions.Logging
             return logValuesFormatter;
         }
 
-        private class LogValues : IReadOnlyList<KeyValuePair<string, object>>
+        private readonly struct LogValues : IReadOnlyList<KeyValuePair<string, object>>
         {
-            public static Func<object, Exception, string> Callback = (state, exception) => ((LogValues)state)._formatter.Format(((LogValues)state).ToArray());
-
-            private static object[] _valueArray = new object[0];
+            public static readonly Func<LogValues, Exception, string> Callback = (state, exception) => state.ToString();
 
             private readonly LogValuesFormatter _formatter;
 
@@ -270,22 +268,14 @@ namespace Microsoft.Extensions.Logging
                 }
             }
 
-            public int Count
-            {
-                get
-                {
-                    return 1;
-                }
-            }
+            public int Count => 1;
 
             public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
             {
                 yield return this[0];
             }
 
-            public object[] ToArray() => _valueArray;
-
-            public override string ToString() => _formatter.Format(ToArray());
+            public override string ToString() => _formatter.Format();
 
             IEnumerator IEnumerable.GetEnumerator()
             {
@@ -293,9 +283,9 @@ namespace Microsoft.Extensions.Logging
             }
         }
 
-        private class LogValues<T0> : IReadOnlyList<KeyValuePair<string, object>>
+        private readonly struct LogValues<T0> : IReadOnlyList<KeyValuePair<string, object>>
         {
-            public static Func<object, Exception, string> Callback = (state, exception) => ((LogValues<T0>)state)._formatter.Format(((LogValues<T0>)state).ToArray());
+            public static readonly Func<LogValues<T0>, Exception, string> Callback = (state, exception) => state.ToString();
 
             private readonly LogValuesFormatter _formatter;
             private readonly T0 _value0;
@@ -310,25 +300,19 @@ namespace Microsoft.Extensions.Logging
             {
                 get
                 {
-                    if (index == 0)
+                    switch (index)
                     {
-                        return new KeyValuePair<string, object>(_formatter.ValueNames[0], _value0);
+                        case 0:
+                            return new KeyValuePair<string, object>(_formatter.ValueNames[0], _value0);
+                        case 1:
+                            return new KeyValuePair<string, object>("{OriginalFormat}", _formatter.OriginalFormat);
+                        default:
+                            throw new IndexOutOfRangeException(nameof(index));
                     }
-                    else if (index == 1)
-                    {
-                        return new KeyValuePair<string, object>("{OriginalFormat}", _formatter.OriginalFormat);
-                    }
-                    throw new IndexOutOfRangeException(nameof(index));
                 }
             }
 
-            public int Count
-            {
-                get
-                {
-                    return 2;
-                }
-            }
+            public int Count => 2;
 
             public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
             {
@@ -338,9 +322,8 @@ namespace Microsoft.Extensions.Logging
                 }
             }
 
-            public object[] ToArray() => new object[] { _value0 };
 
-            public override string ToString() => _formatter.Format(ToArray());
+            public override string ToString() => _formatter.Format(_value0);
 
             IEnumerator IEnumerable.GetEnumerator()
             {
@@ -348,9 +331,9 @@ namespace Microsoft.Extensions.Logging
             }
         }
 
-        private class LogValues<T0, T1> : IReadOnlyList<KeyValuePair<string, object>>
+        private readonly struct LogValues<T0, T1> : IReadOnlyList<KeyValuePair<string, object>>
         {
-            public static Func<object, Exception, string> Callback = (state, exception) => ((LogValues<T0, T1>)state)._formatter.Format(((LogValues<T0, T1>)state).ToArray());
+            public static readonly Func<LogValues<T0, T1>, Exception, string> Callback = (state, exception) => state.ToString();
 
             private readonly LogValuesFormatter _formatter;
             private readonly T0 _value0;
@@ -381,13 +364,7 @@ namespace Microsoft.Extensions.Logging
                 }
             }
 
-            public int Count
-            {
-                get
-                {
-                    return 3;
-                }
-            }
+            public int Count => 3;
 
             public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
             {
@@ -397,9 +374,7 @@ namespace Microsoft.Extensions.Logging
                 }
             }
 
-            public object[] ToArray() => new object[] { _value0, _value1 };
-
-            public override string ToString() => _formatter.Format(ToArray());
+            public override string ToString() => _formatter.Format(_value0, _value1);
 
             IEnumerator IEnumerable.GetEnumerator()
             {
@@ -407,22 +382,16 @@ namespace Microsoft.Extensions.Logging
             }
         }
 
-        private class LogValues<T0, T1, T2> : IReadOnlyList<KeyValuePair<string, object>>
+        private readonly struct LogValues<T0, T1, T2> : IReadOnlyList<KeyValuePair<string, object>>
         {
-            public static Func<object, Exception, string> Callback = (state, exception) => ((LogValues<T0, T1, T2>)state)._formatter.Format(((LogValues<T0, T1, T2>)state).ToArray());
+            public static readonly Func<LogValues<T0, T1, T2>, Exception, string> Callback = (state, exception) => state.ToString();
 
             private readonly LogValuesFormatter _formatter;
-            public T0 _value0;
-            public T1 _value1;
-            public T2 _value2;
+            private readonly T0 _value0;
+            private readonly T1 _value1;
+            private readonly T2 _value2;
 
-            public int Count
-            {
-                get
-                {
-                    return 4;
-                }
-            }
+            public int Count => 4;
 
             public KeyValuePair<string, object> this[int index]
             {
@@ -452,9 +421,7 @@ namespace Microsoft.Extensions.Logging
                 _value2 = value2;
             }
 
-            public object[] ToArray() => new object[] { _value0, _value1, _value2 };
-
-            public override string ToString() => _formatter.Format(ToArray());
+            public override string ToString() => _formatter.Format(_value0, _value1, _value2);
 
             public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
             {
@@ -470,23 +437,17 @@ namespace Microsoft.Extensions.Logging
             }
         }
 
-        private class LogValues<T0, T1, T2, T3> : IReadOnlyList<KeyValuePair<string, object>>
+        private readonly struct LogValues<T0, T1, T2, T3> : IReadOnlyList<KeyValuePair<string, object>>
         {
-            public static Func<object, Exception, string> Callback = (state, exception) => ((LogValues<T0, T1, T2, T3>)state)._formatter.Format(((LogValues<T0, T1, T2, T3>)state).ToArray());
+            public static readonly Func<LogValues<T0, T1, T2, T3>, Exception, string> Callback = (state, exception) => state._formatter.Format(state.ToArray());
 
             private readonly LogValuesFormatter _formatter;
-            public T0 _value0;
-            public T1 _value1;
-            public T2 _value2;
-            public T3 _value3;
+            private readonly T0 _value0;
+            private readonly T1 _value1;
+            private readonly T2 _value2;
+            private readonly T3 _value3;
 
-            public int Count
-            {
-                get
-                {
-                    return 5;
-                }
-            }
+            public int Count => 5;
 
             public KeyValuePair<string, object> this[int index]
             {
@@ -519,7 +480,7 @@ namespace Microsoft.Extensions.Logging
                 _value3 = value3;
             }
 
-            public object[] ToArray() => new object[] { _value0, _value1, _value2, _value3 };
+            private object[] ToArray() => new object[] { _value0, _value1, _value2, _value3 };
 
             public override string ToString() => _formatter.Format(ToArray());
 
@@ -537,24 +498,18 @@ namespace Microsoft.Extensions.Logging
             }
         }
 
-        private class LogValues<T0, T1, T2, T3, T4> : IReadOnlyList<KeyValuePair<string, object>>
+        private readonly struct LogValues<T0, T1, T2, T3, T4> : IReadOnlyList<KeyValuePair<string, object>>
         {
-            public static Func<object, Exception, string> Callback = (state, exception) => ((LogValues<T0, T1, T2, T3, T4>)state)._formatter.Format(((LogValues<T0, T1, T2, T3, T4>)state).ToArray());
+            public static readonly Func<LogValues<T0, T1, T2, T3, T4>, Exception, string> Callback = (state, exception) => state._formatter.Format(state.ToArray());
 
             private readonly LogValuesFormatter _formatter;
-            public T0 _value0;
-            public T1 _value1;
-            public T2 _value2;
-            public T3 _value3;
-            public T4 _value4;
+            private readonly T0 _value0;
+            private readonly T1 _value1;
+            private readonly T2 _value2;
+            private readonly T3 _value3;
+            private readonly T4 _value4;
 
-            public int Count
-            {
-                get
-                {
-                    return 6;
-                }
-            }
+            public int Count => 6;
 
             public KeyValuePair<string, object> this[int index]
             {
@@ -590,7 +545,7 @@ namespace Microsoft.Extensions.Logging
                 _value4 = value4;
             }
 
-            public object[] ToArray() => new object[] { _value0, _value1, _value2, _value3, _value4 };
+            private object[] ToArray() => new object[] { _value0, _value1, _value2, _value3, _value4 };
 
             public override string ToString() => _formatter.Format(ToArray());
 
@@ -608,25 +563,19 @@ namespace Microsoft.Extensions.Logging
             }
         }
 
-        private class LogValues<T0, T1, T2, T3, T4, T5> : IReadOnlyList<KeyValuePair<string, object>>
+        private readonly struct LogValues<T0, T1, T2, T3, T4, T5> : IReadOnlyList<KeyValuePair<string, object>>
         {
-            public static Func<object, Exception, string> Callback = (state, exception) => ((LogValues<T0, T1, T2, T3, T4, T5>)state)._formatter.Format(((LogValues<T0, T1, T2, T3, T4, T5>)state).ToArray());
+            public static readonly Func<LogValues<T0, T1, T2, T3, T4, T5>, Exception, string> Callback = (state, exception) => state._formatter.Format(state.ToArray());
 
             private readonly LogValuesFormatter _formatter;
-            public T0 _value0;
-            public T1 _value1;
-            public T2 _value2;
-            public T3 _value3;
-            public T4 _value4;
-            public T5 _value5;
+            private readonly T0 _value0;
+            private readonly T1 _value1;
+            private readonly T2 _value2;
+            private readonly T3 _value3;
+            private readonly T4 _value4;
+            private readonly T5 _value5;
 
-            public int Count
-            {
-                get
-                {
-                    return 7;
-                }
-            }
+            public int Count => 7;
 
             public KeyValuePair<string, object> this[int index]
             {
@@ -665,86 +614,7 @@ namespace Microsoft.Extensions.Logging
                 _value5 = value5;
             }
 
-            public object[] ToArray() => new object[] { _value0, _value1, _value2, _value3, _value4, _value5 };
-
-            public override string ToString() => _formatter.Format(ToArray());
-
-            public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
-            {
-                for (int i = 0; i < Count; ++i)
-                {
-                    yield return this[i];
-                }
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return GetEnumerator();
-            }
-        }
-
-        private class LogValues<T0, T1, T2, T3, T4, T5, T6> : IReadOnlyList<KeyValuePair<string, object>>
-        {
-            public static Func<object, Exception, string> Callback = (state, exception) => ((LogValues<T0, T1, T2, T3, T4, T5, T6>)state)._formatter.Format(((LogValues<T0, T1, T2, T3, T4, T5, T6>)state).ToArray());
-
-            private readonly LogValuesFormatter _formatter;
-            public T0 _value0;
-            public T1 _value1;
-            public T2 _value2;
-            public T3 _value3;
-            public T4 _value4;
-            public T5 _value5;
-            public T6 _value6;
-
-            public int Count
-            {
-                get
-                {
-                    return 8;
-                }
-            }
-
-            public KeyValuePair<string, object> this[int index]
-            {
-                get
-                {
-                    switch (index)
-                    {
-                        case 0:
-                            return new KeyValuePair<string, object>(_formatter.ValueNames[0], _value0);
-                        case 1:
-                            return new KeyValuePair<string, object>(_formatter.ValueNames[1], _value1);
-                        case 2:
-                            return new KeyValuePair<string, object>(_formatter.ValueNames[2], _value2);
-                        case 3:
-                            return new KeyValuePair<string, object>(_formatter.ValueNames[3], _value3);
-                        case 4:
-                            return new KeyValuePair<string, object>(_formatter.ValueNames[4], _value4);
-                        case 5:
-                            return new KeyValuePair<string, object>(_formatter.ValueNames[5], _value5);
-                        case 6:
-                            return new KeyValuePair<string, object>(_formatter.ValueNames[6], _value6);
-                        case 7:
-                            return new KeyValuePair<string, object>("{OriginalFormat}", _formatter.OriginalFormat);
-                        default:
-                            throw new IndexOutOfRangeException(nameof(index));
-                    }
-                }
-            }
-
-            public LogValues(LogValuesFormatter formatter, T0 value0, T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6)
-            {
-                _formatter = formatter;
-                _value0 = value0;
-                _value1 = value1;
-                _value2 = value2;
-                _value3 = value3;
-                _value4 = value4;
-                _value5 = value5;
-                _value6 = value6;
-            }
-
-            public object[] ToArray() => new object[] { _value0, _value1, _value2, _value3, _value4, _value5, _value6 };
+            private object[] ToArray() => new object[] { _value0, _value1, _value2, _value3, _value4, _value5 };
 
             public override string ToString() => _formatter.Format(ToArray());
 
@@ -763,4 +633,3 @@ namespace Microsoft.Extensions.Logging
         }
     }
 }
-

--- a/src/Microsoft.Extensions.Logging.Abstractions/LoggerMessage.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/LoggerMessage.cs
@@ -459,7 +459,7 @@ namespace Microsoft.Extensions.Logging
 
         private readonly struct LogValues<T0, T1, T2, T3> : IReadOnlyList<KeyValuePair<string, object>>
         {
-            public static readonly Func<LogValues<T0, T1, T2, T3>, Exception, string> Callback = (state, exception) => state._formatter.Format(state.ToArray());
+            public static readonly Func<LogValues<T0, T1, T2, T3>, Exception, string> Callback = (state, exception) => state.ToString();
 
             private readonly LogValuesFormatter _formatter;
             private readonly T0 _value0;
@@ -520,7 +520,7 @@ namespace Microsoft.Extensions.Logging
 
         private readonly struct LogValues<T0, T1, T2, T3, T4> : IReadOnlyList<KeyValuePair<string, object>>
         {
-            public static readonly Func<LogValues<T0, T1, T2, T3, T4>, Exception, string> Callback = (state, exception) => state._formatter.Format(state.ToArray());
+            public static readonly Func<LogValues<T0, T1, T2, T3, T4>, Exception, string> Callback = (state, exception) => state.ToString();
 
             private readonly LogValuesFormatter _formatter;
             private readonly T0 _value0;
@@ -585,7 +585,7 @@ namespace Microsoft.Extensions.Logging
 
         private readonly struct LogValues<T0, T1, T2, T3, T4, T5> : IReadOnlyList<KeyValuePair<string, object>>
         {
-            public static readonly Func<LogValues<T0, T1, T2, T3, T4, T5>, Exception, string> Callback = (state, exception) => state._formatter.Format(state.ToArray());
+            public static readonly Func<LogValues<T0, T1, T2, T3, T4, T5>, Exception, string> Callback = (state, exception) => state.ToString();
 
             private readonly LogValuesFormatter _formatter;
             private readonly T0 _value0;

--- a/src/Microsoft.Extensions.Logging.Abstractions/LoggerMessage.cs
+++ b/src/Microsoft.Extensions.Logging.Abstractions/LoggerMessage.cs
@@ -102,11 +102,16 @@ namespace Microsoft.Extensions.Logging
         {
             var formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 1);
 
+            void Log(ILogger logger, T1 arg1, Exception exception)
+            {
+                logger.Log(logLevel, eventId, new LogValues<T1>(formatter, arg1), exception, LogValues<T1>.Callback);
+            }
+
             return (logger, arg1, exception) =>
             {
                 if (logger.IsEnabled(logLevel))
                 {
-                    logger.Log(logLevel, eventId, new LogValues<T1>(formatter, arg1), exception, LogValues<T1>.Callback);
+                    Log(logger, arg1, exception);
                 }
             };
         }
@@ -124,11 +129,16 @@ namespace Microsoft.Extensions.Logging
         {
             var formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 2);
 
+            void Log(ILogger logger, T1 arg1, T2 arg2, Exception exception)
+            {
+                logger.Log(logLevel, eventId, new LogValues<T1, T2>(formatter, arg1, arg2), exception, LogValues<T1, T2>.Callback);
+            }
+
             return (logger, arg1, arg2, exception) =>
             {
                 if (logger.IsEnabled(logLevel))
                 {
-                    logger.Log(logLevel, eventId, new LogValues<T1, T2>(formatter, arg1, arg2), exception, LogValues<T1, T2>.Callback);
+                    Log(logger, arg1, arg2, exception);
                 }
             };
         }
@@ -147,11 +157,16 @@ namespace Microsoft.Extensions.Logging
         {
             var formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 3);
 
+            void Log(ILogger logger, T1 arg1, T2 arg2, T3 arg3, Exception exception)
+            {
+                logger.Log(logLevel, eventId, new LogValues<T1, T2, T3>(formatter, arg1, arg2, arg3), exception, LogValues<T1, T2, T3>.Callback);
+            }
+
             return (logger, arg1, arg2, arg3, exception) =>
             {
                 if (logger.IsEnabled(logLevel))
                 {
-                    logger.Log(logLevel, eventId, new LogValues<T1, T2, T3>(formatter, arg1, arg2, arg3), exception, LogValues<T1, T2, T3>.Callback);
+                    Log(logger, arg1, arg2, arg3, exception);
                 }
             };
         }
@@ -171,11 +186,16 @@ namespace Microsoft.Extensions.Logging
         {
             var formatter = CreateLogValuesFormatter(formatString, expectedNamedParameterCount: 4);
 
+            void Log(ILogger logger, T1 arg1, T2 arg2, T3 arg3, T4 arg4, Exception exception)
+            {
+                logger.Log(logLevel, eventId, new LogValues<T1, T2, T3, T4>(formatter, arg1, arg2, arg3, arg4), exception, LogValues<T1, T2, T3, T4>.Callback);
+            }
+
             return (logger, arg1, arg2, arg3, arg4, exception) =>
             {
                 if (logger.IsEnabled(logLevel))
                 {
-                    logger.Log(logLevel, eventId, new LogValues<T1, T2, T3, T4>(formatter, arg1, arg2, arg3, arg4), exception, LogValues<T1, T2, T3, T4>.Callback);
+                    Log(logger, arg1, arg2, arg3, arg4, exception);
                 }
             };
         }


### PR DESCRIPTION
1. Make a lot of things struct to avoid boxing
2. Add specialized overloads for 1-3 parameter messages that match `string.Format` and avoid allocation
3. Fix some special casing for no argument logs

### Before
```

                                     Method |      Mean |     Error |    StdDev |         Op/s | Scaled | ScaledSD |  Gen 0 | Allocated |
------------------------------------------- |----------:|----------:|----------:|-------------:|-------:|---------:|-------:|----------:|
                NoArguments_FilteredByLevel |  54.30 ns | 0.4572 ns | 0.4053 ns | 18,415,469.9 |   2.72 |     0.02 | 0.0001 |      40 B |
  NoArguments_DefineMessage_FilteredByLevel |  19.94 ns | 0.1230 ns | 0.1027 ns | 50,138,751.2 |   1.00 |     0.00 |      - |       0 B |
                                NoArguments |  74.18 ns | 1.2185 ns | 1.1398 ns | 13,480,512.4 |   3.72 |     0.06 | 0.0001 |      40 B |
                  NoArguments_DefineMessage |  78.33 ns | 1.0545 ns | 0.9348 ns | 12,766,084.6 |   3.93 |     0.05 | 0.0001 |      24 B |
                               TwoArguments | 146.06 ns | 1.7506 ns | 1.6375 ns |  6,846,641.8 |   7.32 |     0.09 | 0.0005 |     104 B |
               TwoArguments_FilteredByLevel | 128.65 ns | 2.5191 ns | 2.8000 ns |  7,772,791.9 |   6.45 |     0.14 | 0.0005 |     104 B |
                 TwoArguments_DefineMessage |  89.52 ns | 0.9914 ns | 0.9274 ns | 11,170,548.1 |   4.49 |     0.05 | 0.0001 |      40 B |
 TwoArguments_DefineMessage_FilteredByLevel |  20.63 ns | 0.2005 ns | 0.1875 ns | 48,463,314.9 |   1.03 |     0.01 |      - |       0 B |


 
       Method |     Mean |    Error |   StdDev |        Op/s | Scaled | ScaledSD |  Gen 0 | Allocated |
------------- |---------:|---------:|---------:|------------:|-------:|---------:|-------:|----------:|
 TwoArguments | 355.1 ns | 6.855 ns | 8.161 ns | 2,815,805.2 |   1.65 |     0.04 | 0.0005 |     168 B |
  NoArguments | 215.3 ns | 3.141 ns | 2.785 ns | 4,645,103.7 |   1.00 |     0.00 |      - |      64 B |

```

### After
```
                                     Method |      Mean |     Error |    StdDev |         Op/s | Scaled | ScaledSD |  Gen 0 | Allocated |
------------------------------------------- |----------:|----------:|----------:|-------------:|-------:|---------:|-------:|----------:|
                NoArguments_FilteredByLevel |  49.29 ns | 0.5002 ns | 0.4679 ns | 20,286,488.9 |   2.60 |     0.04 |      - |       0 B |
  NoArguments_DefineMessage_FilteredByLevel |  18.96 ns | 0.2912 ns | 0.2724 ns | 52,732,789.4 |   1.00 |     0.00 |      - |       0 B |
                                NoArguments |  64.03 ns | 0.2904 ns | 0.2717 ns | 15,616,744.5 |   3.38 |     0.05 |      - |       0 B |
                  NoArguments_DefineMessage |  53.39 ns | 0.3256 ns | 0.3046 ns | 18,731,554.7 |   2.82 |     0.04 |      - |       0 B |
                               TwoArguments | 134.16 ns | 0.6308 ns | 0.5268 ns |  7,453,628.1 |   7.08 |     0.10 | 0.0002 |      64 B |
               TwoArguments_FilteredByLevel | 124.44 ns | 1.5384 ns | 1.3637 ns |  8,035,928.9 |   6.56 |     0.11 | 0.0002 |      64 B |
                 TwoArguments_DefineMessage |  96.02 ns | 0.6235 ns | 0.5206 ns | 10,414,278.9 |   5.06 |     0.07 |      - |       0 B |
 TwoArguments_DefineMessage_FilteredByLevel |  19.26 ns | 0.1237 ns | 0.1097 ns | 51,914,239.5 |   1.02 |     0.02 |      - |       0 B |

       Method |      Mean |     Error |    StdDev |         Op/s | Scaled | ScaledSD | Allocated |
------------- |----------:|----------:|----------:|-------------:|-------:|---------:|----------:|
 TwoArguments | 330.32 ns | 4.2330 ns | 3.9595 ns |  3,027,379.5 |   5.94 |     0.10 |      88 B |
  NoArguments |  55.58 ns | 0.8043 ns | 0.7523 ns | 17,992,955.1 |   1.00 |     0.00 |       0 B |
```

This doesn't address scope impact but adds benchmarks to be able to iterate on perf further. 