### PR TITLE
Add an ability to disable scope capturing

### DIFF
--- a/benchmarks/Logging.Performance/ScopesOverheadBenchmark.cs
+++ b/benchmarks/Logging.Performance/ScopesOverheadBenchmark.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Extensions.Logging.Performance
         [Params(true, false)]
         public bool HasISupportLoggingScopeLogger { get; set; } = false;
 
+        [Params(true, false)]
+        public bool CaptureScopes { get; set; } = false;
+
         // Baseline as this is the fastest way to do nothing
         [Benchmark(Baseline = true)]
         public void FilteredByLevel()
@@ -58,6 +61,8 @@ namespace Microsoft.Extensions.Logging.Performance
             {
                 services.AddSingleton<ILoggerProvider, LoggerProvider<NoopLogger>>();
             }
+
+            services.Configure<LoggerFilterOptions>(options => options.CaptureScopes = CaptureScopes);
 
             _logger = services.BuildServiceProvider().GetService<ILoggerFactory>().CreateLogger("Logger");
         }

--- a/src/Microsoft.Extensions.Logging.Configuration/LoggerFilterConfigureOptions.cs
+++ b/src/Microsoft.Extensions.Logging.Configuration/LoggerFilterConfigureOptions.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Extensions.Logging
                 return;
             }
 
+            options.CaptureScopes = _configuration.GetValue<bool>(nameof(options.CaptureScopes));
+
             foreach (var configurationSection in _configuration.GetChildren())
             {
                 if (configurationSection.Key.Equals(LogLevelKey, StringComparison.OrdinalIgnoreCase))

--- a/src/Microsoft.Extensions.Logging/Logger.cs
+++ b/src/Microsoft.Extensions.Logging/Logger.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Extensions.Logging
             }
         }
 
+        public bool CaptureScopes { get; set; }
+
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
             var loggers = Loggers;
@@ -124,7 +126,7 @@ namespace Microsoft.Extensions.Logging
         {
             var loggers = Loggers;
 
-            if (loggers == null)
+            if (loggers == null || !CaptureScopes)
             {
                 return NullScope.Instance;
             }

--- a/src/Microsoft.Extensions.Logging/LoggerFactory.cs
+++ b/src/Microsoft.Extensions.Logging/LoggerFactory.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Extensions.Logging
                     ApplyRules(loggerInformation, categoryName, 0, loggerInformation.Length);
 
                     logger.Value.Loggers = loggerInformation;
+                    logger.Value.CaptureScopes = filterOptions.CaptureScopes;
                 }
             }
         }
@@ -75,7 +76,8 @@ namespace Microsoft.Extensions.Logging
                 {
                     logger = new Logger(this)
                     {
-                        Loggers = CreateLoggers(categoryName)
+                        Loggers = CreateLoggers(categoryName),
+                        CaptureScopes = _filterOptions.CaptureScopes
                     };
                     _loggers[categoryName] = logger;
                 }

--- a/src/Microsoft.Extensions.Logging/LoggerFilterOptions.cs
+++ b/src/Microsoft.Extensions.Logging/LoggerFilterOptions.cs
@@ -8,6 +8,11 @@ namespace Microsoft.Extensions.Logging
     public class LoggerFilterOptions
     {
         /// <summary>
+        /// Gets or sets value indicating whether logging scopes are being captured. Defaults to <c>true</c>
+        /// </summary>
+        public bool CaptureScopes { get; set; } = true;
+
+        /// <summary>
         /// Gets or sets the minimum level of log messages if none of the rules match.
         /// </summary>
         public LogLevel MinLevel { get; set; }

--- a/test/Microsoft.Extensions.Logging.Test/LoggerFilterTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/LoggerFilterTest.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Options;
@@ -28,7 +25,7 @@ namespace Microsoft.Extensions.Logging.Test
     }
   }
 }";
-            var config = CreateConfiguration(() => json);
+            var config = TestConfiguration.Create(() => json);
             var loggerProvider = new TestLoggerProvider(new TestSink(), isEnabled: true);
 
             var factory = TestLoggerBuilder.Create(builder => builder
@@ -74,7 +71,7 @@ namespace Microsoft.Extensions.Logging.Test
     }
   }
 }";
-            var config = CreateConfiguration(() => json);
+            var config = TestConfiguration.Create(() => json);
             var loggerProvider = new TestLoggerProvider(new TestSink(), isEnabled: true);
             var factory = TestLoggerBuilder.Create(builder => builder
                 .AddConfiguration(config.GetSection("Logging"))
@@ -121,7 +118,7 @@ namespace Microsoft.Extensions.Logging.Test
     }
   }
 }";
-            var config = CreateConfiguration(() => json);
+            var config = TestConfiguration.Create(() => json);
 
             var loggerProvider = new TestLoggerProvider(new TestSink(), isEnabled: true);
             var factory = TestLoggerBuilder.Create(builder => builder
@@ -155,7 +152,7 @@ namespace Microsoft.Extensions.Logging.Test
     }
   }
 }";
-            var config = CreateConfiguration(() => json);
+            var config = TestConfiguration.Create(() => json);
 
             var loggerProvider = new TestLoggerProvider(new TestSink(), isEnabled: true);
             var factory = TestLoggerBuilder.Create(builder => builder
@@ -187,7 +184,7 @@ namespace Microsoft.Extensions.Logging.Test
     }
   }
 }";
-            var config = CreateConfiguration(() => json);
+            var config = TestConfiguration.Create(() => json);
 
             var loggerProvider = new TestLoggerProvider(new TestSink(), isEnabled: true);
             var factory = TestLoggerBuilder.Create(builder => builder
@@ -315,7 +312,7 @@ namespace Microsoft.Extensions.Logging.Test
     }
   }
 }";
-            var config = CreateConfiguration(() => json);
+            var config = TestConfiguration.Create(() => json);
             var loggerProvider = new TestLoggerProvider(new TestSink(), isEnabled: true);
 
             var factory = TestLoggerBuilder.Create(builder => builder
@@ -426,7 +423,7 @@ namespace Microsoft.Extensions.Logging.Test
                                                             .Build())
                 )
                 .BuildServiceProvider();
-            
+
             var options = serviceProvider.GetRequiredService<IOptions<LoggerFilterOptions>>();
 
             Assert.Null(options.Value.Rules.Single().CategoryName);
@@ -584,32 +581,5 @@ namespace Microsoft.Extensions.Logging.Test
                     ("Category.Sub", LogLevel.Trace, true, false)
                 },
             };
-
-
-        internal ConfigurationRoot CreateConfiguration(Func<string> getJson)
-        {
-            var provider = new TestConfiguration(new JsonConfigurationSource { Optional = true }, getJson);
-            return new ConfigurationRoot(new List<IConfigurationProvider> { provider });
-        }
-
-        private class TestConfiguration : JsonConfigurationProvider
-        {
-            private Func<string> _json;
-            public TestConfiguration(JsonConfigurationSource source, Func<string> json)
-                : base(source)
-            {
-                _json = json;
-            }
-
-            public override void Load()
-            {
-                var stream = new MemoryStream();
-                var writer = new StreamWriter(stream);
-                writer.Write(_json());
-                writer.Flush();
-                stream.Seek(0, SeekOrigin.Begin);
-                Load(stream);
-            }
-        }
     }
 }

--- a/test/Microsoft.Extensions.Logging.Test/LoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/LoggerTest.cs
@@ -149,6 +149,103 @@ namespace Microsoft.Extensions.Logging.Test
             logger.Verify(l => l.BeginScope(It.IsAny<object>()), Times.Never);
         }
 
+        [Fact]
+        public void ScopesAreNotCreatedWhenScopesAreDisabled()
+        {
+            var provider = new Mock<ILoggerProvider>();
+            var logger = new Mock<ILogger>();
+
+            provider.Setup(loggerProvider => loggerProvider.CreateLogger(It.IsAny<string>()))
+                .Returns(logger.Object);
+
+            var factory = TestLoggerBuilder.Create(
+                builder => {
+                    builder.AddProvider(provider.Object);
+                    builder.Services.Configure<LoggerFilterOptions>(options => options.CaptureScopes = false);
+                });
+
+            var newLogger = factory.CreateLogger("Logger");
+            using (newLogger.BeginScope("Scope"))
+            {
+            }
+
+            provider.Verify(p => p.CreateLogger("Logger"), Times.Once);
+            logger.Verify(l => l.BeginScope(It.IsAny<object>()), Times.Never);
+        }
+
+        [Fact]
+        public void ScopesAreNotCreatedInIScopeProviderWhenScopesAreDisabled()
+        {
+            var provider = new Mock<ILoggerProvider>();
+            var logger = new Mock<ILogger>();
+
+            IExternalScopeProvider externalScopeProvider = null;
+
+            provider.Setup(loggerProvider => loggerProvider.CreateLogger(It.IsAny<string>()))
+                .Returns(logger.Object);
+            provider.As<ISupportExternalScope>().Setup(scope => scope.SetScopeProvider(It.IsAny<IExternalScopeProvider>()))
+                .Callback((IExternalScopeProvider scopeProvider) => externalScopeProvider = scopeProvider);
+
+            var factory = TestLoggerBuilder.Create(
+                builder => {
+                    builder.AddProvider(provider.Object);
+                    builder.Services.Configure<LoggerFilterOptions>(options => options.CaptureScopes = false);
+                });
+
+            var newLogger = factory.CreateLogger("Logger");
+            int scopeCount = 0;
+
+            using (newLogger.BeginScope("Scope"))
+            {
+                externalScopeProvider.ForEachScope<object>((_, __) => scopeCount ++, null);
+            }
+
+            provider.Verify(p => p.CreateLogger("Logger"), Times.Once);
+            logger.Verify(l => l.BeginScope(It.IsAny<object>()), Times.Never);
+            Assert.Equal(0, scopeCount);
+        }
+
+        [Fact]
+        public void CaptureScopesIsReadFromConfiguration()
+        {
+            var provider = new Mock<ILoggerProvider>();
+            var logger = new Mock<ILogger>();
+            var json = @"{ ""CaptureScopes"": ""false"" }";
+
+            var config = TestConfiguration.Create(() => json);
+            IExternalScopeProvider externalScopeProvider = null;
+
+            provider.Setup(loggerProvider => loggerProvider.CreateLogger(It.IsAny<string>()))
+                .Returns(logger.Object);
+            provider.As<ISupportExternalScope>().Setup(scope => scope.SetScopeProvider(It.IsAny<IExternalScopeProvider>()))
+                .Callback((IExternalScopeProvider scopeProvider) => externalScopeProvider = scopeProvider);
+
+            var factory = TestLoggerBuilder.Create(
+                builder => {
+                    builder.AddProvider(provider.Object);
+                    builder.AddConfiguration(config);
+                });
+
+            var newLogger = factory.CreateLogger("Logger");
+            int scopeCount = 0;
+
+            using (newLogger.BeginScope("Scope"))
+            {
+                externalScopeProvider.ForEachScope<object>((_, __) => scopeCount ++, null);
+                Assert.Equal(0, scopeCount);
+            }
+
+            json = @"{ ""CaptureScopes"": ""true"" }";
+            config.Reload();
+
+            scopeCount = 0;
+            using (newLogger.BeginScope("Scope"))
+            {
+                externalScopeProvider.ForEachScope<object>((_, __) => scopeCount ++, null);
+                Assert.Equal(1, scopeCount);
+            }
+        }
+
         private class CustomLoggerProvider : ILoggerProvider
         {
             private readonly string _providerName;

--- a/test/Microsoft.Extensions.Logging.Test/TestConfiguration.cs
+++ b/test/Microsoft.Extensions.Logging.Test/TestConfiguration.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Json;
+
+namespace Microsoft.Extensions.Logging.Test
+{
+    internal class TestConfiguration : JsonConfigurationProvider
+    {
+        private Func<string> _json;
+        public TestConfiguration(JsonConfigurationSource source, Func<string> json)
+            : base(source)
+        {
+            _json = json;
+        }
+
+        public override void Load()
+        {
+            var stream = new MemoryStream();
+            var writer = new StreamWriter(stream);
+            writer.Write(_json());
+            writer.Flush();
+            stream.Seek(0, SeekOrigin.Begin);
+            Load(stream);
+        }
+
+        public static ConfigurationRoot Create(Func<string> getJson)
+        {
+            var provider = new TestConfiguration(new JsonConfigurationSource { Optional = true }, getJson);
+            return new ConfigurationRoot(new List<IConfigurationProvider> { provider });
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/aspnet/Logging/issues/714
https://github.com/aspnet/Logging/issues/875


After adding a common infrastructure for capturing scopes (IExternalScopeProvider) it became impossible for providers to control if scopes are being captured.

Most prominent example of this is console logger that became slower in common case event when `IncludeScopes` is set to false.

This change adds `CaptureScopes` flag that disables capturing scopes for all loggers. There is no point to add a flag per provider because our goal is to use `IExternalScopeProvider` in all of them to avoid the overhead and disabling single provider wouldn't have any effect until all that use `IExternalScopeProvider` are disabled.

With `CaptureScopes == false` performance is the same as using logger provider that doesn't implement `ISupportLoggingScopeLogger` and doesn't capture scopes on it's own.

```

                      Method | HasISupportLoggingScopeLogger | CaptureScopes |      Mean |     Error |    StdDev |         Op/s | Scaled | ScaledSD |  Gen 0 | Allocated |
---------------------------- |------------------------------ |-------------- |----------:|----------:|----------:|-------------:|-------:|---------:|-------:|----------:|
             FilteredByLevel |                         False |         False |  19.57 ns | 0.2992 ns | 0.2798 ns | 51,090,030.2 |   1.00 |     0.00 |      - |       0 B |
 FilteredByLevel_InsideScope |                         False |         False |  39.40 ns | 0.1414 ns | 0.1104 ns | 25,383,664.0 |   2.01 |     0.03 |      - |       0 B |
                 NotFiltered |                         False |         False |  86.78 ns | 0.5746 ns | 0.4798 ns | 11,523,460.7 |   4.43 |     0.07 |      - |       0 B |
     NotFiltered_InsideScope |                         False |         False | 109.41 ns | 0.8339 ns | 0.7393 ns |  9,139,668.4 |   5.59 |     0.09 |      - |       0 B |
                             |                               |               |           |           |           |              |        |          |        |           |
             FilteredByLevel |                         False |          True |  19.19 ns | 0.4011 ns | 0.5215 ns | 52,101,606.4 |   1.00 |     0.00 |      - |       0 B |
 FilteredByLevel_InsideScope |                         False |          True |  66.82 ns | 0.3433 ns | 0.3212 ns | 14,966,621.4 |   3.48 |     0.09 | 0.0001 |      48 B |
                 NotFiltered |                         False |          True |  89.55 ns | 0.3671 ns | 0.3254 ns | 11,166,447.0 |   4.67 |     0.12 |      - |       0 B |
     NotFiltered_InsideScope |                         False |          True | 141.24 ns | 0.8599 ns | 0.8044 ns |  7,080,298.7 |   7.36 |     0.20 | 0.0002 |      48 B |
                             |                               |               |           |           |           |              |        |          |        |           |
             FilteredByLevel |                          True |         False |  18.47 ns | 0.0717 ns | 0.0599 ns | 54,128,189.3 |   1.00 |     0.00 |      - |       0 B |
 FilteredByLevel_InsideScope |                          True |         False |  39.14 ns | 0.4020 ns | 0.3564 ns | 25,550,048.8 |   2.12 |     0.02 |      - |       0 B |
                 NotFiltered |                          True |         False |  86.91 ns | 0.3148 ns | 0.2791 ns | 11,506,718.7 |   4.70 |     0.02 |      - |       0 B |
     NotFiltered_InsideScope |                          True |         False | 108.33 ns | 0.5558 ns | 0.5199 ns |  9,230,653.1 |   5.86 |     0.03 |      - |       0 B |
                             |                               |               |           |           |           |              |        |          |        |           |
             FilteredByLevel |                          True |          True |  18.53 ns | 0.1095 ns | 0.1024 ns | 53,974,673.8 |   1.00 |     0.00 |      - |       0 B |
 FilteredByLevel_InsideScope |                          True |          True | 106.42 ns | 1.0308 ns | 0.9643 ns |  9,396,924.5 |   5.74 |     0.06 | 0.0005 |     120 B |
                 NotFiltered |                          True |          True |  88.16 ns | 0.6263 ns | 0.5858 ns | 11,342,585.7 |   4.76 |     0.04 |      - |       0 B |
     NotFiltered_InsideScope |                          True |          True | 179.54 ns | 6.9407 ns | 6.1528 ns |  5,569,871.4 |   9.69 |     0.32 | 0.0005 |     120 B |

```

cc @benaadams 

