### PR TITLE
Default test log level to Debug

### DIFF
--- a/src/Microsoft.Extensions.Logging.Testing/LoggedTest/LoggedTestBase.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/LoggedTest/LoggedTestBase.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.Logging.Testing
         public void AddTestLogging(IServiceCollection services) => services.AddSingleton(LoggerFactory);
 
         // For back compat
-        public IDisposable StartLog(out ILoggerFactory loggerFactory, [CallerMemberName] string testName = null) => StartLog(out loggerFactory, LogLevel.Information, testName);
+        public IDisposable StartLog(out ILoggerFactory loggerFactory, [CallerMemberName] string testName = null) => StartLog(out loggerFactory, LogLevel.Debug, testName);
 
         // For back compat
         public IDisposable StartLog(out ILoggerFactory loggerFactory, LogLevel minLogLevel, [CallerMemberName] string testName = null)

--- a/src/Microsoft.Extensions.Logging.Testing/LoggedTest/LoggedTestBase.cs
+++ b/src/Microsoft.Extensions.Logging.Testing/LoggedTest/LoggedTestBase.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Extensions.Logging.Testing
                     TestOutputHelper,
                     ResolvedTestClassName,
                     out var loggerFactory,
-                    logLevelAttribute?.LogLevel ?? LogLevel.Trace,
+                    logLevelAttribute?.LogLevel ?? LogLevel.Debug,
                     out var resolvedTestName,
                     out var logOutputDirectory,
                     testName);


### PR DESCRIPTION
We default to Debug in AssemblyTestLog https://github.com/aspnet/Logging/blob/2e30d867a412cd7b543f7ec0ed3932be0d08b8e3/src/Microsoft.Extensions.Logging.Testing/AssemblyTestLog.cs#L61 we should do so here too.