### PR TITLE
Add support for category wildcards

### DIFF
--- a/src/Microsoft.Extensions.Logging/LoggerRuleSelector.cs
+++ b/src/Microsoft.Extensions.Logging/LoggerRuleSelector.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Extensions.Logging
 {
     internal class LoggerRuleSelector
     {
+        private static readonly char[] WildcardChar = { '*' };
+
         public void Select(LoggerFilterOptions options, Type providerType, string category, out LogLevel? minLevel, out Func<string, string, LogLevel, bool> filter)
         {
             filter = null;
@@ -47,9 +49,17 @@ namespace Microsoft.Extensions.Logging
                 return false;
             }
 
-            if (rule.CategoryName != null && !category.StartsWith(rule.CategoryName, StringComparison.OrdinalIgnoreCase))
+            if (rule.CategoryName != null)
             {
-                return false;
+                var categoryParts = rule.CategoryName.Split(WildcardChar, 2);
+                var prefix = categoryParts[0];
+                var suffix = categoryParts.Length > 1 ? categoryParts[1] : string.Empty;
+
+                if (!category.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ||
+                    !category.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
             }
 
             if (current?.ProviderName != null)

--- a/src/Microsoft.Extensions.Logging/LoggerRuleSelector.cs
+++ b/src/Microsoft.Extensions.Logging/LoggerRuleSelector.cs
@@ -51,7 +51,12 @@ namespace Microsoft.Extensions.Logging
 
             if (rule.CategoryName != null)
             {
-                var categoryParts = rule.CategoryName.Split(WildcardChar, 2);
+                var categoryParts = rule.CategoryName.Split(WildcardChar);
+                if (categoryParts.Length > 2)
+                {
+                    throw new InvalidOperationException("Only one wildcard character is allowed in category name.");
+                }
+
                 var prefix = categoryParts[0];
                 var suffix = categoryParts.Length > 1 ? categoryParts[1] : string.Empty;
 

--- a/test/Microsoft.Extensions.Logging.Test/LoggerFilterTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/LoggerFilterTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Configuration;
@@ -429,6 +430,23 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Null(options.Value.Rules.Single().CategoryName);
         }
 
+        [Fact]
+        public void MultipleWildcardsAreNotAllowed()
+        {
+            var options = new LoggerFilterOptions()
+            {
+                Rules = { new LoggerFilterRule(providerName: null, categoryName: "*A*", logLevel: null, filter: null)}
+            };
+            var testSink1 = new TestSink();
+            var loggerFactory = new LoggerFactory(new[]
+            {
+                new TestLoggerProvider2(testSink1)
+            }, options);
+
+            var exception = Assert.Throws<InvalidOperationException>(() => loggerFactory.CreateLogger("Category"));
+            Assert.Equal("Only one wildcard character is allowed in category name.", exception.Message);
+        }
+
         [Theory]
         [MemberData(nameof(FilterTestData))]
         public void FilterTest(LoggerFilterOptions options, (string category, LogLevel level, bool expectInProvider1, bool expectInProvider2) message)
@@ -449,7 +467,6 @@ namespace Microsoft.Extensions.Logging.Test
             Assert.Equal(message.expectInProvider1 ? 1 : 0, testSink1.Writes.Count);
             Assert.Equal(message.expectInProvider2 ? 1 : 0, testSink2.Writes.Count);
         }
-
 
         public static TheoryData<LoggerFilterOptions, (string, LogLevel, bool, bool)> FilterTestData =
             new TheoryData<LoggerFilterOptions, (string, LogLevel, bool, bool)>()
@@ -613,7 +630,7 @@ namespace Microsoft.Extensions.Logging.Test
                         }
                     },
                     ("Category.B.Sub", LogLevel.Trace, true, false)
-                },
+                }
             };
     }
 }

--- a/test/Microsoft.Extensions.Logging.Test/LoggerFilterTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/LoggerFilterTest.cs
@@ -580,6 +580,40 @@ namespace Microsoft.Extensions.Logging.Test
                     },
                     ("Category.Sub", LogLevel.Trace, true, false)
                 },
+                { // Wildcards allowed in category names
+                    new LoggerFilterOptions()
+                    {
+                        MinLevel = LogLevel.Critical,
+                        Rules =
+                        {
+                            new LoggerFilterRule(typeof(TestLoggerProvider).FullName, "Category.*.Sub", LogLevel.Trace, null),
+                            new LoggerFilterRule(null, null, LogLevel.Critical, null)
+                        }
+                    },
+                    ("Category.B.Sub", LogLevel.Trace, true, false)
+                },
+                { // Wildcards allowed in the beginning of category names
+                    new LoggerFilterOptions()
+                    {
+                        MinLevel = LogLevel.Critical,
+                        Rules =
+                        {
+                            new LoggerFilterRule(typeof(TestLoggerProvider).FullName, "*.Sub", LogLevel.Trace, null),
+                        }
+                    },
+                    ("Category.B.Sub", LogLevel.Trace, true, false)
+                },
+                { // Wildcards allowed in the end of category names
+                    new LoggerFilterOptions()
+                    {
+                        MinLevel = LogLevel.Critical,
+                        Rules =
+                        {
+                            new LoggerFilterRule(typeof(TestLoggerProvider).FullName, "Cat*", LogLevel.Trace, null),
+                        }
+                    },
+                    ("Category.B.Sub", LogLevel.Trace, true, false)
+                },
             };
     }
 }


### PR DESCRIPTION
Only a single wildcard character is supported per category name.

Fixes: https://github.com/aspnet/Logging/issues/779

