### PR TITLE
Optimize BeginScope performance

### DIFF
--- a/src/Microsoft.Extensions.Logging/Logger.cs
+++ b/src/Microsoft.Extensions.Logging/Logger.cs
@@ -9,40 +9,13 @@ namespace Microsoft.Extensions.Logging
 {
     internal class Logger : ILogger
     {
-        private readonly LoggerFactory _loggerFactory;
-
-        private LoggerInformation[] _loggers;
-
-        private int _scopeCount;
-
-        public Logger(LoggerFactory loggerFactory)
-        {
-            _loggerFactory = loggerFactory;
-        }
-
-        public LoggerInformation[] Loggers
-        {
-            get { return _loggers; }
-            set
-            {
-                var scopeSize = 0;
-                foreach (var loggerInformation in value)
-                {
-                    if (loggerInformation.CreateScopes)
-                    {
-                        scopeSize++;
-                    }
-                }
-                _scopeCount = scopeSize;
-                _loggers = value;
-            }
-        }
-
-        public bool CaptureScopes { get; set; }
+        public LoggerInformation[] Loggers { get;set; }
+        public MessageLogger[] MessageLoggers { get; set; }
+        public ScopeLogger[] ScopeLoggers { get; set; }
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
-            var loggers = Loggers;
+            var loggers = MessageLoggers;
             if (loggers == null)
             {
                 return;
@@ -80,7 +53,7 @@ namespace Microsoft.Extensions.Logging
 
         public bool IsEnabled(LogLevel logLevel)
         {
-            var loggers = Loggers;
+            var loggers = MessageLoggers;
             if (loggers == null)
             {
                 return false;
@@ -124,56 +97,27 @@ namespace Microsoft.Extensions.Logging
 
         public IDisposable BeginScope<TState>(TState state)
         {
-            var loggers = Loggers;
+            var loggers = ScopeLoggers;
 
-            if (loggers == null || !CaptureScopes)
+            if (loggers == null)
             {
                 return NullScope.Instance;
             }
 
-            var scopeProvider = _loggerFactory.ScopeProvider;
-            var scopeCount = _scopeCount;
-
-            if (scopeProvider != null)
+            if (loggers.Length == 1)
             {
-                // if external scope is used for all providers
-                // we can return it's IDisposable directly
-                // without wrapping and saving on allocation
-                if (scopeCount == 0)
-                {
-                    return scopeProvider.Push(state);
-                }
-                else
-                {
-                    scopeCount++;
-                }
-
+                return loggers[0].CreateScope(state);
             }
 
-            var scope = new Scope(scopeCount);
+            var scope = new Scope(loggers.Length);
             List<Exception> exceptions = null;
             for (var index = 0; index < loggers.Length; index++)
             {
-                var loggerInformation = loggers[index];
-                if (!loggerInformation.CreateScopes)
-                {
-                    continue;
-                }
+                var scopeLogger = loggers[index];
 
                 try
                 {
-                    scopeCount--;
-                    // _loggers and _scopeCount are not updated atomically
-                    // there might be a situation when count was updated with
-                    // lower value then we have loggers
-                    // This is small race that happens only on configuraiton reload
-                    // and we are protecting from it by checkig that there is enough space
-                    // in Scope
-                    if (scopeCount >= 0)
-                    {
-                        var disposable = loggerInformation.Logger.BeginScope(state);
-                        scope.SetDisposable(scopeCount, disposable);
-                    }
+                    scope.SetDisposable(index, scopeLogger.CreateScope(state));
                 }
                 catch (Exception ex)
                 {
@@ -184,11 +128,6 @@ namespace Microsoft.Extensions.Logging
 
                     exceptions.Add(ex);
                 }
-            }
-
-            if (scopeProvider != null)
-            {
-                scope.SetDisposable(0, scopeProvider.Push(state));
             }
 
             if (exceptions != null && exceptions.Count > 0)

--- a/src/Microsoft.Extensions.Logging/Logger.cs
+++ b/src/Microsoft.Extensions.Logging/Logger.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.Logging
 {
     internal class Logger : ILogger
     {
-        public LoggerInformation[] Loggers { get;set; }
+        public LoggerInformation[] Loggers { get; set; }
         public MessageLogger[] MessageLoggers { get; set; }
         public ScopeLogger[] ScopeLoggers { get; set; }
 

--- a/src/Microsoft.Extensions.Logging/LoggerFactory.cs
+++ b/src/Microsoft.Extensions.Logging/LoggerFactory.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Extensions.Logging
         private (MessageLogger[] MessageLoggers, ScopeLogger[] ScopeLoggers) ApplyFilters(LoggerInformation[] loggers)
         {
             var messageLoggers = new List<MessageLogger>();
-            var scopeLoggers = _filterOptions.CaptureScopes? new List<ScopeLogger>() : null;
+            var scopeLoggers = _filterOptions.CaptureScopes ? new List<ScopeLogger>() : null;
 
             foreach (var loggerInformation in loggers)
             {

--- a/src/Microsoft.Extensions.Logging/LoggerFactory.cs
+++ b/src/Microsoft.Extensions.Logging/LoggerFactory.cs
@@ -154,30 +154,17 @@ namespace Microsoft.Extensions.Logging
                     continue;
                 }
 
-                messageLoggers.Add(new MessageLogger
-                {
-                    Logger = loggerInformation.Logger,
-                    Category = loggerInformation.Category,
-                    ProviderType = loggerInformation.ProviderType,
-                    Filter = filter,
-                    MinLevel = minLevel
-                });
+                messageLoggers.Add(new MessageLogger(loggerInformation.Logger, loggerInformation.Category, loggerInformation.ProviderType, minLevel, filter));
 
                 if (!loggerInformation.ExternalScope)
                 {
-                    scopeLoggers?.Add(new ScopeLogger
-                    {
-                        Logger = loggerInformation.Logger
-                    });
+                    scopeLoggers?.Add(new ScopeLogger(logger: loggerInformation.Logger, externalScopeProvider: null));
                 }
             }
 
             if (_scopeProvider != null)
             {
-                scopeLoggers?.Add(new ScopeLogger
-                {
-                    ExternalScopeProvider = _scopeProvider
-                });
+                scopeLoggers?.Add(new ScopeLogger(logger: null, externalScopeProvider: _scopeProvider));
             }
 
             return (messageLoggers.ToArray(), scopeLoggers?.ToArray());

--- a/src/Microsoft.Extensions.Logging/LoggerFactory.cs
+++ b/src/Microsoft.Extensions.Logging/LoggerFactory.cs
@@ -49,8 +49,9 @@ namespace Microsoft.Extensions.Logging
             lock (_sync)
             {
                 _filterOptions = filterOptions;
-                foreach (var logger in _loggers.Values)
+                foreach (var registeredLogger in _loggers)
                 {
+                    var logger = registeredLogger.Value;
                     (logger.MessageLoggers, logger.ScopeLoggers) = ApplyFilters(logger.Loggers);
                 }
             }

--- a/src/Microsoft.Extensions.Logging/LoggerFactory.cs
+++ b/src/Microsoft.Extensions.Logging/LoggerFactory.cs
@@ -19,8 +19,7 @@ namespace Microsoft.Extensions.Logging
         private volatile bool _disposed;
         private IDisposable _changeTokenRegistration;
         private LoggerFilterOptions _filterOptions;
-
-        internal LoggerExternalScopeProvider ScopeProvider { get; private set; }
+        private LoggerExternalScopeProvider _scopeProvider;
 
         public LoggerFactory() : this(Enumerable.Empty<ILoggerProvider>())
         {
@@ -50,15 +49,9 @@ namespace Microsoft.Extensions.Logging
             lock (_sync)
             {
                 _filterOptions = filterOptions;
-                foreach (var logger in _loggers)
+                foreach (var logger in _loggers.Values)
                 {
-                    var loggerInformation = logger.Value.Loggers;
-                    var categoryName = logger.Key;
-
-                    ApplyRules(loggerInformation, categoryName, 0, loggerInformation.Length);
-
-                    logger.Value.Loggers = loggerInformation;
-                    logger.Value.CaptureScopes = filterOptions.CaptureScopes;
+                    (logger.MessageLoggers, logger.ScopeLoggers) = ApplyFilters(logger.Loggers);
                 }
             }
         }
@@ -74,11 +67,13 @@ namespace Microsoft.Extensions.Logging
             {
                 if (!_loggers.TryGetValue(categoryName, out var logger))
                 {
-                    logger = new Logger(this)
+                    logger = new Logger
                     {
                         Loggers = CreateLoggers(categoryName),
-                        CaptureScopes = _filterOptions.CaptureScopes
                     };
+
+                    (logger.MessageLoggers, logger.ScopeLoggers) = ApplyFilters(logger.Loggers);
+
                     _loggers[categoryName] = logger;
                 }
 
@@ -97,18 +92,17 @@ namespace Microsoft.Extensions.Logging
             {
                 AddProviderRegistration(provider, dispose: true);
 
-                foreach (var logger in _loggers)
+                foreach (var existingLogger in _loggers)
                 {
-                    var loggerInformation = logger.Value.Loggers;
-                    var categoryName = logger.Key;
+                    var logger = existingLogger.Value;
+                    var loggerInformation = existingLogger.Value.Loggers;
 
+                    var newLoggerIndex = loggerInformation.Length;
                     Array.Resize(ref loggerInformation, loggerInformation.Length + 1);
-                    var newLoggerIndex = loggerInformation.Length - 1;
+                    loggerInformation[newLoggerIndex] = new LoggerInformation(provider, existingLogger.Key);
 
-                    SetLoggerInformation(ref loggerInformation[newLoggerIndex], provider, categoryName);
-                    ApplyRules(loggerInformation, categoryName, newLoggerIndex, 1);
-
-                    logger.Value.Loggers = loggerInformation;
+                    logger.Loggers = loggerInformation;
+                    (logger.MessageLoggers, logger.ScopeLoggers) = ApplyFilters(logger.Loggers);
                 }
             }
         }
@@ -123,50 +117,70 @@ namespace Microsoft.Extensions.Logging
 
             if (provider is ISupportExternalScope supportsExternalScope)
             {
-                if (ScopeProvider == null)
+                if (_scopeProvider == null)
                 {
-                    ScopeProvider = new LoggerExternalScopeProvider();
+                    _scopeProvider = new LoggerExternalScopeProvider();
                 }
 
-                supportsExternalScope.SetScopeProvider(ScopeProvider);
+                supportsExternalScope.SetScopeProvider(_scopeProvider);
             }
-        }
-
-        private void SetLoggerInformation(ref LoggerInformation loggerInformation, ILoggerProvider provider,  string categoryName)
-        {
-            loggerInformation.Logger = provider.CreateLogger(categoryName);
-            loggerInformation.ProviderType = provider.GetType();
-            loggerInformation.ExternalScope = provider is ISupportExternalScope;
         }
 
         private LoggerInformation[] CreateLoggers(string categoryName)
         {
             var loggers = new LoggerInformation[_providerRegistrations.Count];
-            for (int i = 0; i < _providerRegistrations.Count; i++)
+            for (var i = 0; i < _providerRegistrations.Count; i++)
             {
-                SetLoggerInformation(ref loggers[i], _providerRegistrations[i].Provider, categoryName);
+                loggers[i] = new LoggerInformation(_providerRegistrations[i].Provider, categoryName);
             }
-
-            ApplyRules(loggers, categoryName, 0, loggers.Length);
             return loggers;
         }
 
-        private void ApplyRules(LoggerInformation[] loggers, string categoryName, int start, int count)
+        private (MessageLogger[] MessageLoggers, ScopeLogger[] ScopeLoggers) ApplyFilters(LoggerInformation[] loggers)
         {
-            for (var index = start; index < start + count; index++)
-            {
-                ref var loggerInformation = ref loggers[index];
+            var messageLoggers = new List<MessageLogger>();
+            var scopeLoggers = _filterOptions.CaptureScopes? new List<ScopeLogger>() : null;
 
+            foreach (var loggerInformation in loggers)
+            {
                 RuleSelector.Select(_filterOptions,
                     loggerInformation.ProviderType,
-                    categoryName,
+                    loggerInformation.Category,
                     out var minLevel,
                     out var filter);
 
-                loggerInformation.Category = categoryName;
-                loggerInformation.MinLevel = minLevel;
-                loggerInformation.Filter = filter;
+                if (minLevel != null && minLevel > LogLevel.Critical)
+                {
+                    continue;
+                }
+
+                messageLoggers.Add(new MessageLogger
+                {
+                    Logger = loggerInformation.Logger,
+                    Category = loggerInformation.Category,
+                    ProviderType = loggerInformation.ProviderType,
+                    Filter = filter,
+                    MinLevel = minLevel
+                });
+
+                if (!loggerInformation.ExternalScope)
+                {
+                    scopeLoggers?.Add(new ScopeLogger
+                    {
+                        Logger = loggerInformation.Logger
+                    });
+                }
             }
+
+            if (_scopeProvider != null)
+            {
+                scopeLoggers?.Add(new ScopeLogger
+                {
+                    ExternalScopeProvider = _scopeProvider
+                });
+            }
+
+            return (messageLoggers.ToArray(), scopeLoggers?.ToArray());
         }
 
         /// <summary>

--- a/src/Microsoft.Extensions.Logging/LoggerFactory.cs
+++ b/src/Microsoft.Extensions.Logging/LoggerFactory.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Extensions.Logging
                 foreach (var existingLogger in _loggers)
                 {
                     var logger = existingLogger.Value;
-                    var loggerInformation = existingLogger.Value.Loggers;
+                    var loggerInformation = logger.Loggers;
 
                     var newLoggerIndex = loggerInformation.Length;
                     Array.Resize(ref loggerInformation, loggerInformation.Length + 1);

--- a/src/Microsoft.Extensions.Logging/LoggerInformation.cs
+++ b/src/Microsoft.Extensions.Logging/LoggerInformation.cs
@@ -5,17 +5,26 @@ using System;
 
 namespace Microsoft.Extensions.Logging
 {
-    internal struct MessageLogger
+    internal readonly struct MessageLogger
     {
-        public ILogger Logger { get; set; }
+        public MessageLogger(ILogger logger, string category, Type providerType, LogLevel? minLevel, Func<string, string, LogLevel, bool> filter)
+        {
+            Logger = logger;
+            Category = category;
+            ProviderType = providerType;
+            MinLevel = minLevel;
+            Filter = filter;
+        }
 
-        public string Category { get; set; }
+        public ILogger Logger { get; }
 
-        public Type ProviderType { get; set; }
+        public string Category { get; }
 
-        public LogLevel? MinLevel { get; set; }
+        public Type ProviderType { get; }
 
-        public Func<string, string, LogLevel, bool> Filter { get; set; }
+        public LogLevel? MinLevel { get; }
+
+        public Func<string, string, LogLevel, bool> Filter { get; }
 
         public bool IsEnabled(LogLevel level)
         {
@@ -33,11 +42,17 @@ namespace Microsoft.Extensions.Logging
         }
     }
 
-    internal struct ScopeLogger
+    internal readonly struct ScopeLogger
     {
-        public ILogger Logger { get; set; }
+        public ScopeLogger(ILogger logger, IExternalScopeProvider externalScopeProvider)
+        {
+            Logger = logger;
+            ExternalScopeProvider = externalScopeProvider;
+        }
 
-        public IExternalScopeProvider ExternalScopeProvider { get; set; }
+        public ILogger Logger { get; }
+
+        public IExternalScopeProvider ExternalScopeProvider { get; }
 
         public IDisposable CreateScope<TState>(TState state)
         {
@@ -49,7 +64,7 @@ namespace Microsoft.Extensions.Logging
         }
     }
 
-    internal struct LoggerInformation
+    internal readonly struct LoggerInformation
     {
         public LoggerInformation(ILoggerProvider provider, string category) : this()
         {
@@ -59,12 +74,12 @@ namespace Microsoft.Extensions.Logging
             ExternalScope = provider is ISupportExternalScope;
         }
 
-        public ILogger Logger { get; set; }
+        public ILogger Logger { get; }
 
-        public string Category { get; set; }
+        public string Category { get; }
 
-        public Type ProviderType { get; set; }
+        public Type ProviderType { get; }
 
-        public bool ExternalScope { get; set; }
+        public bool ExternalScope { get; }
     }
 }

--- a/test/Microsoft.Extensions.Logging.Test/LoggerFactoryTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/LoggerFactoryTest.cs
@@ -133,6 +133,16 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Fact]
+        public void BeginScope_ReturnsInternalSourceTokenDirectly()
+        {
+            var loggerProvider = new InternalScopeLoggerProvider();
+            var loggerFactory = new LoggerFactory(new[] { loggerProvider });
+            var logger = loggerFactory.CreateLogger("Logger");
+            var scope = logger.BeginScope("Scope");
+            Assert.Contains("LoggerExternalScopeProvider+Scope", scope.GetType().FullName);
+        }
+
+        [Fact]
         public void BeginScope_ReturnsCompositeToken_ForMultipleLoggers()
         {
             var loggerProvider = new ExternalScopeLoggerProvider();


### PR DESCRIPTION
By unloading more logic from the hot path to logger creation time.

Fixes: https://github.com/aspnet/Logging/issues/894
Fixes: https://github.com/aspnet/Logging/issues/714

Also `LoggerFactory` is much more readable now.

Before:
```

               Method | CaptureScopes |     Mean |    Error |   StdDev |        Op/s |  Gen 0 | Allocated |
--------------------- |-------------- |---------:|---------:|---------:|------------:|-------:|----------:|
 MultipleMixedLoggers |         False | 185.4 ns | 1.233 ns | 1.093 ns | 5,393,087.5 |      - |       0 B |
 MultipleMixedLoggers |          True | 310.3 ns | 3.418 ns | 2.854 ns | 3,222,362.8 | 0.0005 |     168 B |
              
```
After:

```
 Method | CaptureScopes |     Mean |    Error |   StdDev |        Op/s |  Gen 0 | Allocated |
--------------------- |-------------- |---------:|---------:|---------:|------------:|-------:|----------:|
 MultipleMixedLoggers |         False | 173.6 ns | 2.438 ns | 2.281 ns | 5,761,550.5 |      - |       0 B |
 MultipleMixedLoggers |          True | 280.3 ns | 5.552 ns | 6.818 ns | 3,567,640.0 | 0.0005 |     168 B |
```
