### PR TITLE
Avoid calling ResetColor when colors are disabled

### DIFF
--- a/src/Microsoft.Extensions.Logging.Console/Internal/WindowsLogConsole.cs
+++ b/src/Microsoft.Extensions.Logging.Console/Internal/WindowsLogConsole.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.Logging.Console.Internal
 {
     public class WindowsLogConsole : IConsole
     {
-        private void SetColor(ConsoleColor? background, ConsoleColor? foreground)
+        private bool SetColor(ConsoleColor? background, ConsoleColor? foreground)
         {
             if (background.HasValue)
             {
@@ -18,6 +18,8 @@ namespace Microsoft.Extensions.Logging.Console.Internal
             {
                 System.Console.ForegroundColor = foreground.Value;
             }
+
+            return background.HasValue || foreground.HasValue;
         }
 
         private void ResetColor()
@@ -27,16 +29,22 @@ namespace Microsoft.Extensions.Logging.Console.Internal
 
         public void Write(string message, ConsoleColor? background, ConsoleColor? foreground)
         {
-            SetColor(background, foreground);
+            var colorChanged = SetColor(background, foreground);
             System.Console.Out.Write(message);
-            ResetColor();
+            if (colorChanged)
+            {
+                ResetColor();
+            }
         }
 
         public void WriteLine(string message, ConsoleColor? background, ConsoleColor? foreground)
         {
-            SetColor(background, foreground);
+            var colorChanged = SetColor(background, foreground);
             System.Console.Out.WriteLine(message);
-            ResetColor();
+            if (colorChanged)
+            {
+                ResetColor();
+            }
         }
 
         public void Flush()


### PR DESCRIPTION
Calling ResetColor is as expensive as writing messages:

Before:

![image](https://user-images.githubusercontent.com/1697911/47886022-0119e380-ddf5-11e8-87e8-de9b34a14bff.png)

After:

![image](https://user-images.githubusercontent.com/1697911/47886567-17756e80-ddf8-11e8-828c-69bd72d28b0d.png)
