### PR TITLE
Obsolete old-style logging APIs

### DIFF
--- a/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesDiagnosticsSettings.cs
+++ b/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesDiagnosticsSettings.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Logging.AzureAppServices
     /// <summary>
     /// Settings for Azure diagnostics logging.
     /// </summary>
-    [Obsolete("Use AzureBlobLoggerOptions and AzureFileLoggerOptions to configure options.")]
+    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is AzureBlobLoggerOptions.")]
     public class AzureAppServicesDiagnosticsSettings
     {
         private TimeSpan _blobCommitPeriod = TimeSpan.FromSeconds(5);

--- a/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesDiagnosticsSettings.cs
+++ b/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesDiagnosticsSettings.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Extensions.Logging.AzureAppServices
     /// <summary>
     /// Settings for Azure diagnostics logging.
     /// </summary>
+    [Obsolete("Use AzureBlobLoggerOptions and AzureFileLoggerOptions to configure options.")]
     public class AzureAppServicesDiagnosticsSettings
     {
         private TimeSpan _blobCommitPeriod = TimeSpan.FromSeconds(5);

--- a/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesLoggerFactoryExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -94,6 +95,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds an Azure Web Apps diagnostics logger.
         /// </summary>
         /// <param name="factory">The extension method argument</param>
+        [Obsolete("Use AddAzureWebAppDiagnostics(this ILoggingBuilder builder) overload")]
         public static ILoggerFactory AddAzureWebAppDiagnostics(this ILoggerFactory factory)
         {
             return AddAzureWebAppDiagnostics(factory, new AzureAppServicesDiagnosticsSettings());
@@ -104,6 +106,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The extension method argument</param>
         /// <param name="settings">The setting object to configure loggers.</param>
+        [Obsolete("Use AddAzureWebAppDiagnostics(this ILoggingBuilder builder) overload")]
         public static ILoggerFactory AddAzureWebAppDiagnostics(this ILoggerFactory factory, AzureAppServicesDiagnosticsSettings settings)
         {
             var context = WebAppContext.Default;

--- a/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesLoggerFactoryExtensions.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds an Azure Web Apps diagnostics logger.
         /// </summary>
         /// <param name="factory">The extension method argument</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddAzureWebAppDiagnostics(this ILoggingBuilder builder) overload")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddAzureWebAppDiagnostics(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddAzureWebAppDiagnostics(this ILoggerFactory factory)
         {
             return AddAzureWebAppDiagnostics(factory, new AzureAppServicesDiagnosticsSettings());
@@ -106,7 +106,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The extension method argument</param>
         /// <param name="settings">The setting object to configure loggers.</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddAzureWebAppDiagnostics(this ILoggingBuilder builder) overload")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddAzureWebAppDiagnostics(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddAzureWebAppDiagnostics(this ILoggerFactory factory, AzureAppServicesDiagnosticsSettings settings)
         {
             var context = WebAppContext.Default;

--- a/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.AzureAppServices/AzureAppServicesLoggerFactoryExtensions.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds an Azure Web Apps diagnostics logger.
         /// </summary>
         /// <param name="factory">The extension method argument</param>
-        [Obsolete("Use AddAzureWebAppDiagnostics(this ILoggingBuilder builder) overload")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddAzureWebAppDiagnostics(this ILoggingBuilder builder) overload")]
         public static ILoggerFactory AddAzureWebAppDiagnostics(this ILoggerFactory factory)
         {
             return AddAzureWebAppDiagnostics(factory, new AzureAppServicesDiagnosticsSettings());
@@ -106,7 +106,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The extension method argument</param>
         /// <param name="settings">The setting object to configure loggers.</param>
-        [Obsolete("Use AddAzureWebAppDiagnostics(this ILoggingBuilder builder) overload")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddAzureWebAppDiagnostics(this ILoggingBuilder builder) overload")]
         public static ILoggerFactory AddAzureWebAppDiagnostics(this ILoggerFactory factory, AzureAppServicesDiagnosticsSettings settings)
         {
             var context = WebAppContext.Default;

--- a/src/Microsoft.Extensions.Logging.Console/ConfigurationConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConfigurationConsoleLoggerSettings.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Logging.Console
 {
+    [Obsolete("Use ConsoleLoggerOptions")]
     public class ConfigurationConsoleLoggerSettings : IConsoleLoggerSettings
     {
         private readonly IConfiguration _configuration;

--- a/src/Microsoft.Extensions.Logging.Console/ConfigurationConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConfigurationConsoleLoggerSettings.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Logging.Console
 {
-    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is ConsoleLoggerOptions")]
+    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is ConsoleLoggerOptions.")]
     public class ConfigurationConsoleLoggerSettings : IConsoleLoggerSettings
     {
         private readonly IConfiguration _configuration;

--- a/src/Microsoft.Extensions.Logging.Console/ConfigurationConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConfigurationConsoleLoggerSettings.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Logging.Console
 {
-    [Obsolete("Use ConsoleLoggerOptions")]
+    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is ConsoleLoggerOptions")]
     public class ConfigurationConsoleLoggerSettings : IConsoleLoggerSettings
     {
         private readonly IConfiguration _configuration;

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging.Console.Internal;
 
 namespace Microsoft.Extensions.Logging.Console
 {
+    [Obsolete("Use ConsoleLoggerProvider to construct console loggers")]
     public class ConsoleLogger : ILogger
     {
         private static readonly string _loglevelPadding = ": ";

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging.Console.Internal;
 
 namespace Microsoft.Extensions.Logging.Console
 {
-    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is ConsoleLoggerProvider")]
+    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is ConsoleLoggerProvider.")]
     public class ConsoleLogger : ILogger
     {
         private static readonly string _loglevelPadding = ": ";

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLogger.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging.Console.Internal;
 
 namespace Microsoft.Extensions.Logging.Console
 {
-    [Obsolete("Use ConsoleLoggerProvider to construct console loggers")]
+    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is ConsoleLoggerProvider")]
     public class ConsoleLogger : ILogger
     {
         private static readonly string _loglevelPadding = ": ";

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerFactoryExtensions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds a console logger that is enabled for <see cref="LogLevel"/>.Information or higher.
         /// </summary>
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
-        [Obsolete("Use AddConsole(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddConsole(this ILoggerFactory factory)
         {
             return factory.AddConsole(includeScopes: false);
@@ -61,7 +61,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="includeScopes">A value which indicates whether log scope information should be displayed
         /// in the output.</param>
-        [Obsolete("Use AddConsole(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddConsole(this ILoggerFactory factory, bool includeScopes)
         {
             factory.AddConsole((n, l) => l >= LogLevel.Information, includeScopes);
@@ -73,7 +73,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged</param>
-        [Obsolete("Use AddConsole(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddConsole(this ILoggerFactory factory, LogLevel minLevel)
         {
             factory.AddConsole(minLevel, includeScopes: false);
@@ -87,7 +87,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged</param>
         /// <param name="includeScopes">A value which indicates whether log scope information should be displayed
         /// in the output.</param>
-        [Obsolete("Use AddConsole(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddConsole(
             this ILoggerFactory factory,
             LogLevel minLevel,
@@ -102,7 +102,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="filter">The category filter to apply to logs.</param>
-        [Obsolete("Use AddConsole(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddConsole(
             this ILoggerFactory factory,
             Func<string, LogLevel, bool> filter)
@@ -118,7 +118,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="filter">The category filter to apply to logs.</param>
         /// <param name="includeScopes">A value which indicates whether log scope information should be displayed
         /// in the output.</param>
-        [Obsolete("Use AddConsole(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddConsole(
             this ILoggerFactory factory,
             Func<string, LogLevel, bool> filter,
@@ -134,7 +134,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="settings">The settings to apply to created <see cref="ConsoleLogger"/>'s.</param>
         /// <returns></returns>
-        [Obsolete("Use AddConsole(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddConsole(
             this ILoggerFactory factory,
             IConsoleLoggerSettings settings)
@@ -148,7 +148,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="configuration">The <see cref="IConfiguration"/> to use for <see cref="IConsoleLoggerSettings"/>.</param>
         /// <returns></returns>
-        [Obsolete("Use AddConsole(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddConsole(this ILoggerFactory factory, IConfiguration configuration)
         {
             var settings = new ConfigurationConsoleLoggerSettings(configuration);

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerFactoryExtensions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds a console logger that is enabled for <see cref="LogLevel"/>.Information or higher.
         /// </summary>
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddConsole(this ILoggerFactory factory)
         {
             return factory.AddConsole(includeScopes: false);
@@ -61,7 +61,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="includeScopes">A value which indicates whether log scope information should be displayed
         /// in the output.</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddConsole(this ILoggerFactory factory, bool includeScopes)
         {
             factory.AddConsole((n, l) => l >= LogLevel.Information, includeScopes);
@@ -73,7 +73,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddConsole(this ILoggerFactory factory, LogLevel minLevel)
         {
             factory.AddConsole(minLevel, includeScopes: false);
@@ -87,7 +87,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged</param>
         /// <param name="includeScopes">A value which indicates whether log scope information should be displayed
         /// in the output.</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddConsole(
             this ILoggerFactory factory,
             LogLevel minLevel,
@@ -102,7 +102,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="filter">The category filter to apply to logs.</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddConsole(
             this ILoggerFactory factory,
             Func<string, LogLevel, bool> filter)
@@ -118,7 +118,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="filter">The category filter to apply to logs.</param>
         /// <param name="includeScopes">A value which indicates whether log scope information should be displayed
         /// in the output.</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddConsole(
             this ILoggerFactory factory,
             Func<string, LogLevel, bool> filter,
@@ -134,7 +134,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="settings">The settings to apply to created <see cref="ConsoleLogger"/>'s.</param>
         /// <returns></returns>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddConsole(
             this ILoggerFactory factory,
             IConsoleLoggerSettings settings)
@@ -148,7 +148,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="configuration">The <see cref="IConfiguration"/> to use for <see cref="IConsoleLoggerSettings"/>.</param>
         /// <returns></returns>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddConsole(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddConsole(this ILoggerFactory factory, IConfiguration configuration)
         {
             var settings = new ConfigurationConsoleLoggerSettings(configuration);

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerFactoryExtensions.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds a console logger that is enabled for <see cref="LogLevel"/>.Information or higher.
         /// </summary>
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
+        [Obsolete("Use AddConsole(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddConsole(this ILoggerFactory factory)
         {
             return factory.AddConsole(includeScopes: false);
@@ -60,6 +61,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="includeScopes">A value which indicates whether log scope information should be displayed
         /// in the output.</param>
+        [Obsolete("Use AddConsole(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddConsole(this ILoggerFactory factory, bool includeScopes)
         {
             factory.AddConsole((n, l) => l >= LogLevel.Information, includeScopes);
@@ -71,6 +73,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged</param>
+        [Obsolete("Use AddConsole(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddConsole(this ILoggerFactory factory, LogLevel minLevel)
         {
             factory.AddConsole(minLevel, includeScopes: false);
@@ -84,6 +87,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged</param>
         /// <param name="includeScopes">A value which indicates whether log scope information should be displayed
         /// in the output.</param>
+        [Obsolete("Use AddConsole(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddConsole(
             this ILoggerFactory factory,
             LogLevel minLevel,
@@ -98,6 +102,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="filter">The category filter to apply to logs.</param>
+        [Obsolete("Use AddConsole(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddConsole(
             this ILoggerFactory factory,
             Func<string, LogLevel, bool> filter)
@@ -113,6 +118,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="filter">The category filter to apply to logs.</param>
         /// <param name="includeScopes">A value which indicates whether log scope information should be displayed
         /// in the output.</param>
+        [Obsolete("Use AddConsole(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddConsole(
             this ILoggerFactory factory,
             Func<string, LogLevel, bool> filter,
@@ -128,6 +134,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="settings">The settings to apply to created <see cref="ConsoleLogger"/>'s.</param>
         /// <returns></returns>
+        [Obsolete("Use AddConsole(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddConsole(
             this ILoggerFactory factory,
             IConsoleLoggerSettings settings)
@@ -141,6 +148,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="configuration">The <see cref="IConfiguration"/> to use for <see cref="IConsoleLoggerSettings"/>.</param>
         /// <returns></returns>
+        [Obsolete("Use AddConsole(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddConsole(this ILoggerFactory factory, IConfiguration configuration)
         {
             var settings = new ConfigurationConsoleLoggerSettings(configuration);

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.Logging.Console
 {
+#pragma warning disable 618
     [ProviderAlias("Console")]
     public class ConsoleLoggerProvider : ILoggerProvider, ISupportExternalScope
     {
@@ -25,11 +26,13 @@ namespace Microsoft.Extensions.Logging.Console
         private bool _disableColors;
         private IExternalScopeProvider _scopeProvider;
 
+        [Obsolete("Use LoggerFactory to configure filtering and ConsoleLoggerOptions to configure logging options")]
         public ConsoleLoggerProvider(Func<string, LogLevel, bool> filter, bool includeScopes)
             : this(filter, includeScopes, false)
         {
         }
 
+        [Obsolete("Use LoggerFactory to configure filtering and ConsoleLoggerOptions to configure logging options")]
         public ConsoleLoggerProvider(Func<string, LogLevel, bool> filter, bool includeScopes, bool disableColors)
         {
             if (filter == null)
@@ -62,6 +65,7 @@ namespace Microsoft.Extensions.Logging.Console
             }
         }
 
+        [Obsolete("Use LoggerFactory to configure filtering and ConsoleLoggerOptions to configure logging options")]
         public ConsoleLoggerProvider(IConsoleLoggerSettings settings)
         {
             if (settings == null)
@@ -181,4 +185,5 @@ namespace Microsoft.Extensions.Logging.Console
             _scopeProvider = scopeProvider;
         }
     }
+#pragma warning restore 618
 }

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerProvider.cs
@@ -26,13 +26,13 @@ namespace Microsoft.Extensions.Logging.Console
         private bool _disableColors;
         private IExternalScopeProvider _scopeProvider;
 
-        [Obsolete("Use LoggerFactory to configure filtering and ConsoleLoggerOptions to configure logging options")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is using LoggerFactory to configure filtering and ConsoleLoggerOptions to configure logging options")]
         public ConsoleLoggerProvider(Func<string, LogLevel, bool> filter, bool includeScopes)
             : this(filter, includeScopes, false)
         {
         }
 
-        [Obsolete("Use LoggerFactory to configure filtering and ConsoleLoggerOptions to configure logging options")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is using LoggerFactory to configure filtering and ConsoleLoggerOptions to configure logging options")]
         public ConsoleLoggerProvider(Func<string, LogLevel, bool> filter, bool includeScopes, bool disableColors)
         {
             if (filter == null)
@@ -65,7 +65,7 @@ namespace Microsoft.Extensions.Logging.Console
             }
         }
 
-        [Obsolete("Use LoggerFactory to configure filtering and ConsoleLoggerOptions to configure logging options")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is using LoggerFactory to configure filtering and ConsoleLoggerOptions to configure logging options")]
         public ConsoleLoggerProvider(IConsoleLoggerSettings settings)
         {
             if (settings == null)

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerProvider.cs
@@ -9,7 +9,9 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.Logging.Console
 {
-#pragma warning disable 618
+// IConsoleLoggerSettings is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+
     [ProviderAlias("Console")]
     public class ConsoleLoggerProvider : ILoggerProvider, ISupportExternalScope
     {
@@ -26,13 +28,13 @@ namespace Microsoft.Extensions.Logging.Console
         private bool _disableColors;
         private IExternalScopeProvider _scopeProvider;
 
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is using LoggerFactory to configure filtering and ConsoleLoggerOptions to configure logging options")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is using LoggerFactory to configure filtering and ConsoleLoggerOptions to configure logging options.")]
         public ConsoleLoggerProvider(Func<string, LogLevel, bool> filter, bool includeScopes)
             : this(filter, includeScopes, false)
         {
         }
 
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is using LoggerFactory to configure filtering and ConsoleLoggerOptions to configure logging options")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is using LoggerFactory to configure filtering and ConsoleLoggerOptions to configure logging options.")]
         public ConsoleLoggerProvider(Func<string, LogLevel, bool> filter, bool includeScopes, bool disableColors)
         {
             if (filter == null)
@@ -185,5 +187,5 @@ namespace Microsoft.Extensions.Logging.Console
             _scopeProvider = scopeProvider;
         }
     }
-#pragma warning restore 618
+#pragma warning restore CS0618
 }

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerSettings.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Logging.Console
 {
-    [Obsolete("Use ConsoleLoggerOptions")]
+    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is ConsoleLoggerOptions")]
     public class ConsoleLoggerSettings : IConsoleLoggerSettings
     {
         public IChangeToken ChangeToken { get; set; }

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerSettings.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Logging.Console
 {
-    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is ConsoleLoggerOptions")]
+    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is ConsoleLoggerOptions.")]
     public class ConsoleLoggerSettings : IConsoleLoggerSettings
     {
         public IChangeToken ChangeToken { get; set; }

--- a/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/ConsoleLoggerSettings.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Logging.Console
 {
+    [Obsolete("Use ConsoleLoggerOptions")]
     public class ConsoleLoggerSettings : IConsoleLoggerSettings
     {
         public IChangeToken ChangeToken { get; set; }

--- a/src/Microsoft.Extensions.Logging.Console/IConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/IConsoleLoggerSettings.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Logging.Console
 {
+    [Obsolete("Use ConsoleLoggerOptions")]
     public interface IConsoleLoggerSettings
     {
         bool IncludeScopes { get; }

--- a/src/Microsoft.Extensions.Logging.Console/IConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/IConsoleLoggerSettings.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Logging.Console
 {
-    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is ConsoleLoggerOptions")]
+    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is ConsoleLoggerOptions.")]
     public interface IConsoleLoggerSettings
     {
         bool IncludeScopes { get; }

--- a/src/Microsoft.Extensions.Logging.Console/IConsoleLoggerSettings.cs
+++ b/src/Microsoft.Extensions.Logging.Console/IConsoleLoggerSettings.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Logging.Console
 {
-    [Obsolete("Use ConsoleLoggerOptions")]
+    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is ConsoleLoggerOptions")]
     public interface IConsoleLoggerSettings
     {
         bool IncludeScopes { get; }

--- a/src/Microsoft.Extensions.Logging.Debug/DebugLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Debug/DebugLoggerFactoryExtensions.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds a debug logger that is enabled for <see cref="LogLevel"/>.Information or higher.
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
+        [Obsolete("Use AddDebug(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddDebug(this ILoggerFactory factory)
         {
             return AddDebug(factory, LogLevel.Information);
@@ -38,6 +39,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
         /// <param name="filter">The function used to filter events based on the log level.</param>
+        [Obsolete("Use AddDebug(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddDebug(this ILoggerFactory factory, Func<string, LogLevel, bool> filter)
         {
             factory.AddProvider(new DebugLoggerProvider(filter));
@@ -49,6 +51,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
         /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged</param>
+        [Obsolete("Use AddDebug(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddDebug(this ILoggerFactory factory, LogLevel minLevel)
         {
             return AddDebug(

--- a/src/Microsoft.Extensions.Logging.Debug/DebugLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Debug/DebugLoggerFactoryExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds a debug logger that is enabled for <see cref="LogLevel"/>.Information or higher.
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddDebug(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddDebug(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddDebug(this ILoggerFactory factory)
         {
             return AddDebug(factory, LogLevel.Information);
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
         /// <param name="filter">The function used to filter events based on the log level.</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddDebug(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddDebug(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddDebug(this ILoggerFactory factory, Func<string, LogLevel, bool> filter)
         {
             factory.AddProvider(new DebugLoggerProvider(filter));
@@ -51,7 +51,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
         /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddDebug(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddDebug(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddDebug(this ILoggerFactory factory, LogLevel minLevel)
         {
             return AddDebug(

--- a/src/Microsoft.Extensions.Logging.Debug/DebugLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.Debug/DebugLoggerFactoryExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds a debug logger that is enabled for <see cref="LogLevel"/>.Information or higher.
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
-        [Obsolete("Use AddDebug(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddDebug(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddDebug(this ILoggerFactory factory)
         {
             return AddDebug(factory, LogLevel.Information);
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
         /// <param name="filter">The function used to filter events based on the log level.</param>
-        [Obsolete("Use AddDebug(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddDebug(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddDebug(this ILoggerFactory factory, Func<string, LogLevel, bool> filter)
         {
             factory.AddProvider(new DebugLoggerProvider(filter));
@@ -51,7 +51,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
         /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged</param>
-        [Obsolete("Use AddDebug(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddDebug(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddDebug(this ILoggerFactory factory, LogLevel minLevel)
         {
             return AddDebug(

--- a/src/Microsoft.Extensions.Logging.Debug/DebugLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Debug/DebugLoggerProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Logging.Debug
         /// Initializes a new instance of the <see cref="DebugLoggerProvider"/> class.
         /// </summary>
         /// <param name="filter">The function used to filter events based on the log level.</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is using LoggerFactory to configure filtering")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is using LoggerFactory to configure filtering.")]
         public DebugLoggerProvider(Func<string, LogLevel, bool> filter)
         {
             _filter = filter;

--- a/src/Microsoft.Extensions.Logging.Debug/DebugLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Debug/DebugLoggerProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.Logging.Debug
         /// Initializes a new instance of the <see cref="DebugLoggerProvider"/> class.
         /// </summary>
         /// <param name="filter">The function used to filter events based on the log level.</param>
-        [Obsolete("Use LoggerFactory to configure filtering")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is using LoggerFactory to configure filtering")]
         public DebugLoggerProvider(Func<string, LogLevel, bool> filter)
         {
             _filter = filter;

--- a/src/Microsoft.Extensions.Logging.Debug/DebugLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.Debug/DebugLoggerProvider.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Extensions.Logging.Debug
         /// Initializes a new instance of the <see cref="DebugLoggerProvider"/> class.
         /// </summary>
         /// <param name="filter">The function used to filter events based on the log level.</param>
+        [Obsolete("Use LoggerFactory to configure filtering")]
         public DebugLoggerProvider(Func<string, LogLevel, bool> filter)
         {
             _filter = filter;

--- a/src/Microsoft.Extensions.Logging.EventLog/EventLogLogger.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/EventLogLogger.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.Logging.EventLog
     /// <summary>
     /// A logger that writes messages to Windows Event Log.
     /// </summary>
-    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is using EventLogLoggerProvider to construct loggers")]
+    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is using EventLogLoggerProvider to construct loggers.")]
     public class EventLogLogger : ILogger
     {
         private readonly string _name;

--- a/src/Microsoft.Extensions.Logging.EventLog/EventLogLogger.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/EventLogLogger.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Extensions.Logging.EventLog
     /// <summary>
     /// A logger that writes messages to Windows Event Log.
     /// </summary>
+    [Obsolete("Use EventLogLoggerProvider to construct loggers")]
     public class EventLogLogger : ILogger
     {
         private readonly string _name;

--- a/src/Microsoft.Extensions.Logging.EventLog/EventLogLogger.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/EventLogLogger.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.Logging.EventLog
     /// <summary>
     /// A logger that writes messages to Windows Event Log.
     /// </summary>
-    [Obsolete("Use EventLogLoggerProvider to construct loggers")]
+    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is using EventLogLoggerProvider to construct loggers")]
     public class EventLogLogger : ILogger
     {
         private readonly string _name;

--- a/src/Microsoft.Extensions.Logging.EventLog/EventLogLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/EventLogLoggerProvider.cs
@@ -35,7 +35,9 @@ namespace Microsoft.Extensions.Logging.EventLog
         /// <inheritdoc />
         public ILogger CreateLogger(string name)
         {
-            return new EventLogLogger(name, _settings ?? new EventLogSettings());
+#pragma warning disable 618
+            return new EventLogLogger(name, _settings ?? new EventLogSettings(), _scopeProvider);
+#pragma warning restore 618
         }
 
         public void Dispose()

--- a/src/Microsoft.Extensions.Logging.EventLog/EventLogLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/EventLogLoggerProvider.cs
@@ -35,9 +35,10 @@ namespace Microsoft.Extensions.Logging.EventLog
         /// <inheritdoc />
         public ILogger CreateLogger(string name)
         {
-#pragma warning disable 618
-            return new EventLogLogger(name, _settings ?? new EventLogSettings(), _scopeProvider);
-#pragma warning restore 618
+            // EventLogLogger is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+            return new EventLogLogger(name, _settings ?? new EventLogSettings());
+#pragma warning restore CS0618
         }
 
         public void Dispose()

--- a/src/Microsoft.Extensions.Logging.EventLog/EventLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/EventLoggerFactoryExtensions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds an event logger that is enabled for <see cref="LogLevel"/>.Information or higher.
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddEventLog(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddEventLog(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddEventLog(this ILoggerFactory factory)
         {
             if (factory == null)
@@ -71,7 +71,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
         /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddEventLog(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddEventLog(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddEventLog(this ILoggerFactory factory, LogLevel minLevel)
         {
             if (factory == null)
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
         /// <param name="settings">The <see cref="EventLogSettings"/>.</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddEventLog(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddEventLog(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddEventLog(
             this ILoggerFactory factory,
             EventLogSettings settings)

--- a/src/Microsoft.Extensions.Logging.EventLog/EventLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/EventLoggerFactoryExtensions.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds an event logger that is enabled for <see cref="LogLevel"/>.Information or higher.
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
+        [Obsolete("Use AddEventLog(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddEventLog(this ILoggerFactory factory)
         {
             if (factory == null)
@@ -70,6 +71,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
         /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged</param>
+        [Obsolete("Use AddEventLog(this ILoggingBuilder builder) overload and LoggerFactory for filtering.")]
         public static ILoggerFactory AddEventLog(this ILoggerFactory factory, LogLevel minLevel)
         {
             if (factory == null)
@@ -88,6 +90,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
         /// <param name="settings">The <see cref="EventLogSettings"/>.</param>
+        [Obsolete("Use AddEventLog(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddEventLog(
             this ILoggerFactory factory,
             EventLogSettings settings)

--- a/src/Microsoft.Extensions.Logging.EventLog/EventLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/EventLoggerFactoryExtensions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds an event logger that is enabled for <see cref="LogLevel"/>.Information or higher.
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
-        [Obsolete("Use AddEventLog(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddEventLog(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddEventLog(this ILoggerFactory factory)
         {
             if (factory == null)
@@ -71,7 +71,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
         /// <param name="minLevel">The minimum <see cref="LogLevel"/> to be logged</param>
-        [Obsolete("Use AddEventLog(this ILoggingBuilder builder) overload and LoggerFactory for filtering.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddEventLog(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddEventLog(this ILoggerFactory factory, LogLevel minLevel)
         {
             if (factory == null)
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
         /// <param name="settings">The <see cref="EventLogSettings"/>.</param>
-        [Obsolete("Use AddEventLog(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddEventLog(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddEventLog(
             this ILoggerFactory factory,
             EventLogSettings settings)

--- a/src/Microsoft.Extensions.Logging.EventLog/WindowsEventLog.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/WindowsEventLog.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging.EventLog.Internal;
 
 namespace Microsoft.Extensions.Logging.EventLog
 {
-    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is using EventLogLoggerProvider")]
+    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is using EventLogLoggerProvider.")]
     public class WindowsEventLog : IEventLog
     {
         // https://msdn.microsoft.com/EN-US/library/windows/desktop/aa363679.aspx

--- a/src/Microsoft.Extensions.Logging.EventLog/WindowsEventLog.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/WindowsEventLog.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging.EventLog.Internal;
 
 namespace Microsoft.Extensions.Logging.EventLog
 {
-    [Obsolete("Use EventLogLoggerProvider.")]
+    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is using EventLogLoggerProvider")]
     public class WindowsEventLog : IEventLog
     {
         // https://msdn.microsoft.com/EN-US/library/windows/desktop/aa363679.aspx

--- a/src/Microsoft.Extensions.Logging.EventLog/WindowsEventLog.cs
+++ b/src/Microsoft.Extensions.Logging.EventLog/WindowsEventLog.cs
@@ -1,11 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using Microsoft.Extensions.Logging.EventLog.Internal;
 
 namespace Microsoft.Extensions.Logging.EventLog
 {
+    [Obsolete("Use EventLogLoggerProvider.")]
     public class WindowsEventLog : IEventLog
     {
         // https://msdn.microsoft.com/EN-US/library/windows/desktop/aa363679.aspx

--- a/src/Microsoft.Extensions.Logging.EventSource/EventSourceLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.EventSource/EventSourceLoggerFactoryExtensions.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds an event logger that is enabled for <see cref="LogLevel"/>.Information or higher.
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
+        [Obsolete("Use AddEventSourceLogger(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddEventSourceLogger(this ILoggerFactory factory)
         {
             if (factory == null)

--- a/src/Microsoft.Extensions.Logging.EventSource/EventSourceLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.EventSource/EventSourceLoggerFactoryExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds an event logger that is enabled for <see cref="LogLevel"/>.Information or higher.
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddEventSourceLogger(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddEventSourceLogger(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddEventSourceLogger(this ILoggerFactory factory)
         {
             if (factory == null)

--- a/src/Microsoft.Extensions.Logging.EventSource/EventSourceLoggerFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.EventSource/EventSourceLoggerFactoryExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.Logging
         /// Adds an event logger that is enabled for <see cref="LogLevel"/>.Information or higher.
         /// </summary>
         /// <param name="factory">The extension method argument.</param>
-        [Obsolete("Use AddEventSourceLogger(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddEventSourceLogger(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddEventSourceLogger(this ILoggerFactory factory)
         {
             if (factory == null)

--- a/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceFactoryExtensions.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="switchName">The name of the <see cref="SourceSwitch"/> to use.</param>
-        [Obsolete("Use AddTraceSource(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddTraceSource(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddTraceSource(
             this ILoggerFactory factory,
             string switchName)
@@ -141,7 +141,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="switchName">The name of the <see cref="SourceSwitch"/> to use.</param>
         /// <param name="listener">The <see cref="TraceListener"/> to use.</param>
-        [Obsolete("Use AddTraceSource(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddTraceSource(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddTraceSource(
             this ILoggerFactory factory,
             string switchName,
@@ -167,7 +167,7 @@ namespace Microsoft.Extensions.Logging
 
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="sourceSwitch">The <see cref="SourceSwitch"/> to use.</param>
-        [Obsolete("Use AddTraceSource(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddTraceSource(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddTraceSource(
             this ILoggerFactory factory,
             SourceSwitch sourceSwitch)
@@ -190,7 +190,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="sourceSwitch">The <see cref="SourceSwitch"/> to use.</param>
         /// <param name="listener">The <see cref="TraceListener"/> to use.</param>
-        [Obsolete("Use AddTraceSource(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddTraceSource(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddTraceSource(
             this ILoggerFactory factory,
             SourceSwitch sourceSwitch,

--- a/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceFactoryExtensions.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="switchName">The name of the <see cref="SourceSwitch"/> to use.</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddTraceSource(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddTraceSource(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddTraceSource(
             this ILoggerFactory factory,
             string switchName)
@@ -141,7 +141,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="switchName">The name of the <see cref="SourceSwitch"/> to use.</param>
         /// <param name="listener">The <see cref="TraceListener"/> to use.</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddTraceSource(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddTraceSource(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddTraceSource(
             this ILoggerFactory factory,
             string switchName,
@@ -167,7 +167,7 @@ namespace Microsoft.Extensions.Logging
 
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="sourceSwitch">The <see cref="SourceSwitch"/> to use.</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddTraceSource(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddTraceSource(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddTraceSource(
             this ILoggerFactory factory,
             SourceSwitch sourceSwitch)
@@ -190,7 +190,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="sourceSwitch">The <see cref="SourceSwitch"/> to use.</param>
         /// <param name="listener">The <see cref="TraceListener"/> to use.</param>
-        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddTraceSource(this ILoggingBuilder builder) overload.")]
+        [Obsolete("This method is obsolete and will be removed in a future version. The recommended alternative is AddTraceSource(this ILoggingBuilder builder).")]
         public static ILoggerFactory AddTraceSource(
             this ILoggerFactory factory,
             SourceSwitch sourceSwitch,

--- a/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceFactoryExtensions.cs
+++ b/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceFactoryExtensions.cs
@@ -120,6 +120,7 @@ namespace Microsoft.Extensions.Logging
         /// </summary>
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="switchName">The name of the <see cref="SourceSwitch"/> to use.</param>
+        [Obsolete("Use AddTraceSource(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddTraceSource(
             this ILoggerFactory factory,
             string switchName)
@@ -140,6 +141,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="switchName">The name of the <see cref="SourceSwitch"/> to use.</param>
         /// <param name="listener">The <see cref="TraceListener"/> to use.</param>
+        [Obsolete("Use AddTraceSource(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddTraceSource(
             this ILoggerFactory factory,
             string switchName,
@@ -165,6 +167,7 @@ namespace Microsoft.Extensions.Logging
 
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="sourceSwitch">The <see cref="SourceSwitch"/> to use.</param>
+        [Obsolete("Use AddTraceSource(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddTraceSource(
             this ILoggerFactory factory,
             SourceSwitch sourceSwitch)
@@ -187,6 +190,7 @@ namespace Microsoft.Extensions.Logging
         /// <param name="factory">The <see cref="ILoggerFactory"/> to use.</param>
         /// <param name="sourceSwitch">The <see cref="SourceSwitch"/> to use.</param>
         /// <param name="listener">The <see cref="TraceListener"/> to use.</param>
+        [Obsolete("Use AddTraceSource(this ILoggingBuilder builder) overload.")]
         public static ILoggerFactory AddTraceSource(
             this ILoggerFactory factory,
             SourceSwitch sourceSwitch,

--- a/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceLogger.cs
+++ b/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceLogger.cs
@@ -7,7 +7,7 @@ using DiagnosticsTraceSource = System.Diagnostics.TraceSource;
 
 namespace Microsoft.Extensions.Logging.TraceSource
 {
-    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is using TraceSourceLoggerProvider to construct loggers")]
+    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is using TraceSourceLoggerProvider to construct loggers.")]
     public class TraceSourceLogger : ILogger
     {
         private readonly DiagnosticsTraceSource _traceSource;

--- a/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceLogger.cs
+++ b/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceLogger.cs
@@ -7,7 +7,7 @@ using DiagnosticsTraceSource = System.Diagnostics.TraceSource;
 
 namespace Microsoft.Extensions.Logging.TraceSource
 {
-    [Obsolete("Use TraceSourceLoggerProvider to construct loggers")]
+    [Obsolete("This type is obsolete and will be removed in a future version. The recommended alternative is using TraceSourceLoggerProvider to construct loggers")]
     public class TraceSourceLogger : ILogger
     {
         private readonly DiagnosticsTraceSource _traceSource;

--- a/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceLogger.cs
+++ b/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceLogger.cs
@@ -7,6 +7,7 @@ using DiagnosticsTraceSource = System.Diagnostics.TraceSource;
 
 namespace Microsoft.Extensions.Logging.TraceSource
 {
+    [Obsolete("Use TraceSourceLoggerProvider to construct loggers")]
     public class TraceSourceLogger : ILogger
     {
         private readonly DiagnosticsTraceSource _traceSource;

--- a/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceLoggerProvider.cs
@@ -53,7 +53,9 @@ namespace Microsoft.Extensions.Logging.TraceSource
         /// <returns></returns>
         public ILogger CreateLogger(string name)
         {
+#pragma warning disable 618
             return new TraceSourceLogger(GetOrAddTraceSource(name));
+#pragma warning restore 618
         }
 
         private DiagnosticsTraceSource GetOrAddTraceSource(string name)

--- a/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceLoggerProvider.cs
+++ b/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceLoggerProvider.cs
@@ -53,9 +53,10 @@ namespace Microsoft.Extensions.Logging.TraceSource
         /// <returns></returns>
         public ILogger CreateLogger(string name)
         {
-#pragma warning disable 618
+            // TraceSourceLogger is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
             return new TraceSourceLogger(GetOrAddTraceSource(name));
-#pragma warning restore 618
+#pragma warning restore CS0618
         }
 
         private DiagnosticsTraceSource GetOrAddTraceSource(string name)

--- a/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceScope.cs
+++ b/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceScope.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.Logging.TraceSource
     /// <summary>
     /// Provides an IDisposable that represents a logical operation scope based on System.Diagnostics LogicalOperationStack
     /// </summary>
+    [Obsolete("This type is part of TraceSource logger implementation and shouldn't be used directly")]
     public class TraceSourceScope : IDisposable
     {
         // To detect redundant calls

--- a/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceScope.cs
+++ b/src/Microsoft.Extensions.Logging.TraceSource/TraceSourceScope.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.Logging.TraceSource
     /// <summary>
     /// Provides an IDisposable that represents a logical operation scope based on System.Diagnostics LogicalOperationStack
     /// </summary>
-    [Obsolete("This type is part of TraceSource logger implementation and shouldn't be used directly")]
+    [Obsolete("This type is obsolete and will be removed in a future version. This type is part of TraceSource logger implementation and shouldn't be used directly")]
     public class TraceSourceScope : IDisposable
     {
         // To detect redundant calls

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <DeveloperBuildTestTfms>netcoreapp2.2</DeveloperBuildTestTfms>
     <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
-
+    <NoWarn>618</NoWarn>
     <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestTfms);net461</StandardTestTfms>
   </PropertyGroup>
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <DeveloperBuildTestTfms>netcoreapp2.2</DeveloperBuildTestTfms>
     <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
-    <NoWarn>618</NoWarn>
     <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestTfms);net461</StandardTestTfms>
   </PropertyGroup>
 

--- a/test/Microsoft.Extensions.Logging.EventSource.Test/EventSourceLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.EventSource.Test/EventSourceLoggerTest.cs
@@ -10,7 +10,9 @@ using Microsoft.Extensions.Logging.EventSource;
 using Newtonsoft.Json;
 using Xunit;
 using Microsoft.Extensions.DependencyInjection;
-#pragma warning disable 618
+
+// AddEventSourceLogger(ILoggerProvider) overload is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace Microsoft.Extensions.Logging.Test
 {

--- a/test/Microsoft.Extensions.Logging.EventSource.Test/EventSourceLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.EventSource.Test/EventSourceLoggerTest.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging.EventSource;
 using Newtonsoft.Json;
 using Xunit;
 using Microsoft.Extensions.DependencyInjection;
+#pragma warning disable 618
 
 namespace Microsoft.Extensions.Logging.Test
 {

--- a/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
@@ -16,7 +16,9 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Moq;
 using Xunit;
-#pragma warning disable 618
+
+// ConsoleLogger is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace Microsoft.Extensions.Logging.Test
 {

--- a/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/ConsoleLoggerTest.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Moq;
 using Xunit;
+#pragma warning disable 618
 
 namespace Microsoft.Extensions.Logging.Test
 {

--- a/test/Microsoft.Extensions.Logging.Test/EventLogLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/EventLogLoggerTest.cs
@@ -8,7 +8,9 @@ using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.EventLog;
 using Microsoft.Extensions.Logging.EventLog.Internal;
 using Xunit;
-#pragma warning disable 618
+
+// EventLogLogger is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace Microsoft.Extensions.Logging
 {

--- a/test/Microsoft.Extensions.Logging.Test/EventLogLoggerTest.cs
+++ b/test/Microsoft.Extensions.Logging.Test/EventLogLoggerTest.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Testing.xunit;
 using Microsoft.Extensions.Logging.EventLog;
 using Microsoft.Extensions.Logging.EventLog.Internal;
 using Xunit;
+#pragma warning disable 618
 
 namespace Microsoft.Extensions.Logging
 {


### PR DESCRIPTION
Exploratory PR for obsoleting old logging APIs in 2.2 preparing for their removal in 3.0.

What is being obsolete:

1. ILoggerProvider extension methods for adding loggers
2. ILogger concrete implementations and classes that are part of implementation details
3. LoggerSettings classes that have Option class alternative.

/cc @muratg @Eilon 
